### PR TITLE
Improve e2e test reliability and server startup detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,12 @@ jobs:
         run: npm ci
         working-directory: e2e
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ hashFiles('e2e/package-lock.json') }}
+
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
         working-directory: e2e
@@ -124,3 +130,11 @@ jobs:
         working-directory: e2e
         env:
           SERVER_BIN: /tmp/crapnote-server
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: e2e/playwright-report/
+          retention-days: 30

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -23,17 +23,22 @@ export async function startServer() {
     stdio: 'pipe',
   });
 
-  // Wait for the server to be ready
+  // Poll the server's HTTP port rather than watching stderr logs, so that the
+  // readiness check is independent of Go's log format and tests actual TCP
+  // connectivity rather than just process startup.
   await new Promise<void>((resolve, reject) => {
-    const timeout = setTimeout(() => reject(new Error('Server failed to start')), 10_000);
-    // Go's log package writes to stderr by default
-    server.stderr?.on('data', (data: Buffer) => {
-      if (data.toString().includes('listening on')) {
-        clearTimeout(timeout);
-        resolve();
-      }
-    });
-    server.on('error', reject);
+    const deadline = setTimeout(
+      () => reject(new Error('Server failed to start within 10s')),
+      10_000,
+    );
+    server.on('error', (err) => { clearTimeout(deadline); reject(err); });
+
+    const poll = () =>
+      fetch('http://localhost:4173')
+        .then(() => { clearTimeout(deadline); resolve(); })
+        .catch(() => setTimeout(poll, 100));
+
+    setTimeout(poll, 100);
   });
 }
 

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -6,6 +6,9 @@ export default defineConfig({
   timeout: 30_000,
   retries: process.env.CI ? 1 : 0,
   reporter: process.env.CI ? 'github' : 'list',
+  // SQLite test DB is shared across tests; increase only after adding
+  // per-worker DB isolation (separate server instance per worker).
+  workers: 1,
 
   use: {
     baseURL: 'http://localhost:4173',

--- a/e2e/tests/notes.spec.ts
+++ b/e2e/tests/notes.spec.ts
@@ -12,13 +12,15 @@ async function login(page: Page) {
 async function createNote(page: Page, title: string) {
   await page.getByLabel('New note').click();
   const titleInput = page.getByPlaceholder(/note title/i);
-  // triple-click selects all existing text, then type replaces it atomically
-  await titleInput.click({ clickCount: 3 });
-  // Wait a tick so Svelte's one-way binding doesn't re-set the value mid-type
-  await page.waitForTimeout(50);
-  await titleInput.pressSequentially(title, { delay: 20 });
-  // Wait for the 800ms autosave debounce + network round-trip
-  await page.waitForResponse((r) => r.url().includes('/api/notes') && r.request().method() === 'PUT');
+  // Register the response listener BEFORE fill() so a fast autosave can't
+  // arrive before the listener is attached (race condition).
+  // fill() replaces any existing text atomically and fires Svelte's input
+  // binding without needing keystroke delays or an explicit waitForTimeout.
+  const saved = page.waitForResponse(
+    (r) => r.url().includes('/api/notes') && r.request().method() === 'PUT',
+  );
+  await titleInput.fill(title);
+  await saved;
 }
 
 test.describe('Notes', () => {
@@ -34,19 +36,23 @@ test.describe('Notes', () => {
   test('title change does not erase body', async ({ page }) => {
     await createNote(page, 'My Note');
 
-    // Type in editor
+    // Type in editor (ProseMirror is a contenteditable — pressSequentially is
+    // correct here; fill() does not work on rich-text editors).
     const editor = page.locator('.ProseMirror');
     await editor.click();
+    const bodySaved = page.waitForResponse(
+      (r) => r.url().includes('/api/notes') && r.request().method() === 'PUT',
+    );
     await editor.pressSequentially('Hello world');
-
-    // Wait for body autosave
-    await page.waitForResponse((r) => r.url().includes('/api/notes') && r.request().method() === 'PUT');
+    await bodySaved;
 
     // Rename the note
     const titleInput = page.getByPlaceholder(/note title/i);
-    await titleInput.clear();
-    await titleInput.pressSequentially('Renamed Note', { delay: 20 });
-    await page.waitForResponse((r) => r.url().includes('/api/notes') && r.request().method() === 'PUT');
+    const titleSaved = page.waitForResponse(
+      (r) => r.url().includes('/api/notes') && r.request().method() === 'PUT',
+    );
+    await titleInput.fill('Renamed Note');
+    await titleSaved;
 
     // Reload to confirm both title and body persisted
     await page.reload();
@@ -88,11 +94,12 @@ test.describe('Notes', () => {
     await createNote(page, 'Apple note');
     await createNote(page, 'Banana note');
 
-    // Type into the search box and wait for the API response
     const searchBox = page.getByPlaceholder(/search/i);
-    await searchBox.click();
-    await page.keyboard.type('Apple');
-    await page.waitForResponse((r) => r.url().includes('/api/notes') && r.url().includes('search=Apple'));
+    const searchDone = page.waitForResponse(
+      (r) => r.url().includes('/api/notes') && r.url().includes('search=Apple'),
+    );
+    await searchBox.fill('Apple');
+    await searchDone;
 
     await expect(page.locator('.note-item').filter({ hasText: 'Apple note' })).toBeVisible();
     await expect(page.locator('.note-item').filter({ hasText: 'Banana note' })).not.toBeVisible();


### PR DESCRIPTION
## Summary
This PR improves the reliability and robustness of end-to-end tests by refactoring test helpers to use more stable APIs and fixing the server startup detection mechanism.

## Key Changes

### Test Helper Improvements (notes.spec.ts)
- **Replaced keystroke simulation with `fill()`**: Changed from `pressSequentially()` with artificial delays to `fill()` for text input fields, which is more reliable and doesn't require timing workarounds
- **Fixed race condition in response listeners**: Moved `waitForResponse()` calls to execute *before* triggering the action, preventing fast autosaves from arriving before the listener is attached
- **Simplified test code**: Removed unnecessary `click({ clickCount: 3 })`, `waitForTimeout()`, and keystroke delays that were workarounds for timing issues
- **Improved comments**: Added clarifications about when to use `pressSequentially()` (rich-text editors like ProseMirror) vs `fill()` (regular inputs)

### Server Startup Detection (global-setup.ts)
- **Replaced stderr log parsing with HTTP polling**: Changed from watching Go's stderr logs for "listening on" message to actively polling the server's HTTP port
- **Improved reliability**: The new approach is independent of Go's log format and verifies actual TCP connectivity rather than just process startup
- **Better error handling**: Added explicit error handler for server process errors

### CI/CD Improvements (.github/workflows/ci.yml)
- **Added Playwright browser caching**: Caches Chromium browser between runs to speed up CI
- **Added test report upload**: Uploads Playwright HTML report as artifact for failed test investigation

### Test Configuration (playwright.config.ts)
- **Enforced single worker mode**: Set `workers: 1` with explanation that SQLite test DB is shared across tests and needs per-worker isolation before parallelization is safe

https://claude.ai/code/session_01PZDBjy67jBJFKc18L9CLQj