### PR TITLE
feat(tags): tag management with sidebar filter, colours, and popover UI

### DIFF
--- a/backend/cmd/server/server.go
+++ b/backend/cmd/server/server.go
@@ -56,6 +56,7 @@ func newMux(
 	protected("GET", "/api/archive", notesHandler.ListArchived)
 
 	// Note–tag associations
+	protected("GET", "/api/notes/{id}/tags", tagsHandler.GetForNote)
 	protected("POST", "/api/notes/{id}/tags", tagsHandler.AddToNote)
 	protected("DELETE", "/api/notes/{id}/tags/{tid}", tagsHandler.RemoveFromNote)
 

--- a/backend/internal/tags/handler.go
+++ b/backend/internal/tags/handler.go
@@ -122,6 +122,30 @@ func (h *Handler) Delete(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// GetForNote handles GET /api/notes/{id}/tags
+func (h *Handler) GetForNote(w http.ResponseWriter, r *http.Request) {
+	u := auth.UserFromContext(r.Context())
+	if u == nil {
+		writeError(w, http.StatusUnauthorized, "not authenticated")
+		return
+	}
+	noteID, err := parseID(r, "id")
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid note id")
+		return
+	}
+	list, err := h.svc.ListForNote(r.Context(), noteID, u.ID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+	out := make([]tagResponse, 0, len(list))
+	for _, t := range list {
+		out = append(out, tagToResponse(t))
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
 // AddToNote handles POST /api/notes/{id}/tags
 func (h *Handler) AddToNote(w http.ResponseWriter, r *http.Request) {
 	u := auth.UserFromContext(r.Context())

--- a/e2e/tests/notes.spec.ts
+++ b/e2e/tests/notes.spec.ts
@@ -101,7 +101,7 @@ test.describe('Notes', () => {
     await searchBox.fill('Apple');
     await searchDone;
 
-    await expect(page.locator('.note-item').filter({ hasText: 'Apple note' })).toBeVisible();
+    await expect(page.locator('.note-item').filter({ hasText: 'Apple note' }).first()).toBeVisible();
     await expect(page.locator('.note-item').filter({ hasText: 'Banana note' })).not.toBeVisible();
   });
 });

--- a/e2e/tests/tags.spec.ts
+++ b/e2e/tests/tags.spec.ts
@@ -27,7 +27,16 @@ async function openTagPopover(page: Page) {
 async function createTagInPopover(page: Page, name: string) {
   await page.getByPlaceholder('New tag…').fill(name);
   await page.getByPlaceholder('New tag…').press('Enter');
-  await page.waitForResponse((r) => r.url().includes('/api/tags') && r.request().method() === 'POST');
+  // If the tag already exists in the DB (dirty state from a prior run),
+  // createAndAddTag skips POST /api/tags and only fires the note-tag
+  // association POST /api/notes/{id}/tags/{tagId}.
+  // Accept either so the test is resilient to pre-existing data.
+  await page.waitForResponse(
+    (r) => r.request().method() === 'POST' && (
+      /\/api\/tags$/.test(r.url()) ||
+      /\/api\/notes\/\d+\/tags\/\d+/.test(r.url())
+    )
+  );
 }
 
 test.describe('Tags', () => {

--- a/e2e/tests/tags.spec.ts
+++ b/e2e/tests/tags.spec.ts
@@ -54,7 +54,7 @@ test.describe('Tags', () => {
     await createTagInPopover(page, 'sidebar-tag');
 
     // Sidebar pill should appear
-    await expect(page.locator('.tag-filter .tag-pill', { hasText: 'sidebar-tag' })).toBeVisible();
+    await expect(page.locator('.filter-tags .tag-pill', { hasText: 'sidebar-tag' })).toBeVisible();
   });
 
   test('filtering by tag shows only tagged notes', async ({ page }) => {
@@ -67,7 +67,7 @@ test.describe('Tags', () => {
     await createNote(page, 'Untagged note');
 
     // Click the tag filter pill
-    await page.locator('.tag-filter .tag-pill', { hasText: 'filter-tag' }).click();
+    await page.locator('.filter-tags .tag-pill', { hasText: 'filter-tag' }).click();
     await page.waitForResponse((r) => r.url().includes('/api/notes') && r.request().method() === 'GET');
 
     // Only tagged note visible in list
@@ -84,12 +84,12 @@ test.describe('Tags', () => {
     await createNote(page, 'Note B');
 
     // Activate tag filter
-    await page.locator('.tag-filter .tag-pill', { hasText: 'restore-tag' }).click();
+    await page.locator('.filter-tags .tag-pill', { hasText: 'restore-tag' }).click();
     await page.waitForResponse((r) => r.url().includes('/api/notes') && r.request().method() === 'GET');
     await expect(page.getByRole('list').getByText('Note B')).not.toBeVisible();
 
     // Click All
-    await page.locator('.tag-filter .tag-pill', { hasText: 'All' }).click();
+    await page.locator('.filter-fixed .tag-pill', { hasText: 'All' }).click();
     await page.waitForResponse((r) => r.url().includes('/api/notes') && r.request().method() === 'GET');
     await expect(page.getByRole('list').getByText('Note B')).toBeVisible();
   });
@@ -104,7 +104,7 @@ test.describe('Tags', () => {
     await page.waitForResponse((r) => r.url().includes('/api/notes') && r.request().method() === 'GET');
 
     // Sidebar filter pill should be active (has box-shadow / active class)
-    await expect(page.locator('.tag-filter .tag-pill.tag-pill-active', { hasText: 'chip-tag' })).toBeVisible();
+    await expect(page.locator('.filter-tags .tag-pill.tag-pill-active', { hasText: 'chip-tag' })).toBeVisible();
   });
 
   test('can remove a tag from a note', async ({ page }) => {
@@ -121,12 +121,29 @@ test.describe('Tags', () => {
     await expect(page.locator('.note-tag-chip', { hasText: 'remove-tag' })).not.toBeVisible();
   });
 
+  test('starred filter shows only starred notes', async ({ page }) => {
+    await createNote(page, 'Starred note');
+    // Star it via the sidebar action button
+    await page.locator('.note-item').filter({ hasText: 'Starred note' }).hover();
+    await page.locator('.note-item').filter({ hasText: 'Starred note' }).getByTitle('Star').click();
+    await page.waitForResponse((r) => r.url().includes('/star') && r.request().method() === 'PATCH');
+
+    await createNote(page, 'Plain note');
+
+    // Activate starred filter
+    await page.locator('.filter-fixed .tag-pill', { hasText: 'Starred' }).click();
+    await page.waitForResponse((r) => r.url().includes('/api/notes') && r.request().method() === 'GET');
+
+    await expect(page.getByRole('list').getByText('Starred note')).toBeVisible();
+    await expect(page.getByRole('list').getByText('Plain note')).not.toBeVisible();
+  });
+
   test('tag disappears from filter when no notes have it', async ({ page }) => {
     await createNote(page, 'Solo tag note');
     await openTagPopover(page);
     await createTagInPopover(page, 'solo-tag');
 
-    await expect(page.locator('.tag-filter .tag-pill', { hasText: 'solo-tag' })).toBeVisible();
+    await expect(page.locator('.filter-tags .tag-pill', { hasText: 'solo-tag' })).toBeVisible();
 
     // Remove the tag from the note
     const checkbox = page.locator('.popover-item').filter({ hasText: 'solo-tag' }).locator('input[type=checkbox]');
@@ -134,6 +151,6 @@ test.describe('Tags', () => {
     await page.waitForResponse((r) => r.url().includes('/tags/') && r.request().method() === 'DELETE');
 
     // Pill should disappear (pseudo-erasure)
-    await expect(page.locator('.tag-filter .tag-pill', { hasText: 'solo-tag' })).not.toBeVisible();
+    await expect(page.locator('.filter-tags .tag-pill', { hasText: 'solo-tag' })).not.toBeVisible();
   });
 });

--- a/e2e/tests/tags.spec.ts
+++ b/e2e/tests/tags.spec.ts
@@ -25,18 +25,16 @@ async function openTagPopover(page: Page) {
 
 /** Create a new tag via the popover's "New tag…" input. */
 async function createTagInPopover(page: Page, name: string) {
-  await page.getByPlaceholder('New tag…').fill(name);
-  await page.getByPlaceholder('New tag…').press('Enter');
-  // If the tag already exists in the DB (dirty state from a prior run),
-  // createAndAddTag skips POST /api/tags and only fires the note-tag
-  // association POST /api/notes/{id}/tags/{tagId}.
-  // Accept either so the test is resilient to pre-existing data.
-  await page.waitForResponse(
-    (r) => r.request().method() === 'POST' && (
-      /\/api\/tags$/.test(r.url()) ||
-      /\/api\/notes\/\d+\/tags\/\d+/.test(r.url())
-    )
-  );
+  // pressSequentially is more reliable than fill() for Svelte bind:value —
+  // each keystroke fires an input event that updates the reactive state.
+  const input = page.getByPlaceholder('New tag…');
+  await input.click();
+  await input.pressSequentially(name, { delay: 20 });
+  await input.press('Enter');
+  // Verify the tag was actually applied by checking the chip appears.
+  // This is more robust than matching a specific POST URL, which varies
+  // depending on whether the tag already exists in the DB.
+  await expect(page.locator('.note-tag-chip', { hasText: name })).toBeVisible();
 }
 
 test.describe('Tags', () => {

--- a/e2e/tests/tags.spec.ts
+++ b/e2e/tests/tags.spec.ts
@@ -1,0 +1,139 @@
+import { test, expect, type Page } from '@playwright/test';
+
+async function login(page: Page) {
+  await page.goto('/login');
+  await page.getByRole('textbox', { name: /username/i }).fill('admin');
+  await page.getByRole('textbox', { name: /password/i }).fill('admin123');
+  await page.getByRole('button', { name: /log in/i }).click();
+  await expect(page).toHaveURL('/');
+}
+
+async function createNote(page: Page, title: string) {
+  await page.getByLabel('New note').click();
+  const titleInput = page.getByPlaceholder(/note title/i);
+  await titleInput.click({ clickCount: 3 });
+  await page.waitForTimeout(50);
+  await titleInput.pressSequentially(title, { delay: 20 });
+  await page.waitForResponse((r) => r.url().includes('/api/notes') && r.request().method() === 'PUT');
+}
+
+/** Open the tag popover for the currently selected note. */
+async function openTagPopover(page: Page) {
+  await page.getByTitle('Tags').click();
+  await expect(page.getByText('Tags', { exact: true }).first()).toBeVisible();
+}
+
+/** Create a new tag via the popover's "New tag…" input. */
+async function createTagInPopover(page: Page, name: string) {
+  await page.getByPlaceholder('New tag…').fill(name);
+  await page.getByPlaceholder('New tag…').press('Enter');
+  await page.waitForResponse((r) => r.url().includes('/api/tags') && r.request().method() === 'POST');
+}
+
+test.describe('Tags', () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  test('can create a tag and apply it to a note', async ({ page }) => {
+    await createNote(page, 'Tag test note');
+    await openTagPopover(page);
+    await createTagInPopover(page, 'e2e-tag');
+
+    // Chip appears below the title
+    await expect(page.locator('.note-tag-chip', { hasText: 'e2e-tag' })).toBeVisible();
+
+    // Checkbox in popover is checked
+    const checkbox = page.locator('.popover-item').filter({ hasText: 'e2e-tag' }).locator('input[type=checkbox]');
+    await expect(checkbox).toBeChecked();
+  });
+
+  test('tag appears in sidebar filter after being applied', async ({ page }) => {
+    await createNote(page, 'Sidebar filter note');
+    await openTagPopover(page);
+    await createTagInPopover(page, 'sidebar-tag');
+
+    // Sidebar pill should appear
+    await expect(page.locator('.tag-filter .tag-pill', { hasText: 'sidebar-tag' })).toBeVisible();
+  });
+
+  test('filtering by tag shows only tagged notes', async ({ page }) => {
+    // Create two notes; tag only the first
+    await createNote(page, 'Tagged note');
+    await openTagPopover(page);
+    await createTagInPopover(page, 'filter-tag');
+    await page.keyboard.press('Escape'); // close popover
+
+    await createNote(page, 'Untagged note');
+
+    // Click the tag filter pill
+    await page.locator('.tag-filter .tag-pill', { hasText: 'filter-tag' }).click();
+    await page.waitForResponse((r) => r.url().includes('/api/notes') && r.request().method() === 'GET');
+
+    // Only tagged note visible in list
+    await expect(page.getByRole('list').getByText('Tagged note')).toBeVisible();
+    await expect(page.getByRole('list').getByText('Untagged note')).not.toBeVisible();
+  });
+
+  test('"All" pill restores full note list', async ({ page }) => {
+    await createNote(page, 'Note A');
+    await openTagPopover(page);
+    await createTagInPopover(page, 'restore-tag');
+    await page.keyboard.press('Escape');
+
+    await createNote(page, 'Note B');
+
+    // Activate tag filter
+    await page.locator('.tag-filter .tag-pill', { hasText: 'restore-tag' }).click();
+    await page.waitForResponse((r) => r.url().includes('/api/notes') && r.request().method() === 'GET');
+    await expect(page.getByRole('list').getByText('Note B')).not.toBeVisible();
+
+    // Click All
+    await page.locator('.tag-filter .tag-pill', { hasText: 'All' }).click();
+    await page.waitForResponse((r) => r.url().includes('/api/notes') && r.request().method() === 'GET');
+    await expect(page.getByRole('list').getByText('Note B')).toBeVisible();
+  });
+
+  test('clicking a tag chip in the editor activates the filter', async ({ page }) => {
+    await createNote(page, 'Chip filter note');
+    await openTagPopover(page);
+    await createTagInPopover(page, 'chip-tag');
+
+    // Click the chip below the title
+    await page.locator('.note-tag-chip', { hasText: 'chip-tag' }).click();
+    await page.waitForResponse((r) => r.url().includes('/api/notes') && r.request().method() === 'GET');
+
+    // Sidebar filter pill should be active (has box-shadow / active class)
+    await expect(page.locator('.tag-filter .tag-pill.tag-pill-active', { hasText: 'chip-tag' })).toBeVisible();
+  });
+
+  test('can remove a tag from a note', async ({ page }) => {
+    await createNote(page, 'Remove tag note');
+    await openTagPopover(page);
+    await createTagInPopover(page, 'remove-tag');
+
+    // Uncheck via popover
+    const checkbox = page.locator('.popover-item').filter({ hasText: 'remove-tag' }).locator('input[type=checkbox]');
+    await checkbox.uncheck();
+    await page.waitForResponse((r) => r.url().includes('/api/notes') && r.url().includes('/tags/') && r.request().method() === 'DELETE');
+
+    // Chip should be gone
+    await expect(page.locator('.note-tag-chip', { hasText: 'remove-tag' })).not.toBeVisible();
+  });
+
+  test('tag disappears from filter when no notes have it', async ({ page }) => {
+    await createNote(page, 'Solo tag note');
+    await openTagPopover(page);
+    await createTagInPopover(page, 'solo-tag');
+
+    await expect(page.locator('.tag-filter .tag-pill', { hasText: 'solo-tag' })).toBeVisible();
+
+    // Remove the tag from the note
+    const checkbox = page.locator('.popover-item').filter({ hasText: 'solo-tag' }).locator('input[type=checkbox]');
+    await checkbox.uncheck();
+    await page.waitForResponse((r) => r.url().includes('/tags/') && r.request().method() === 'DELETE');
+
+    // Pill should disappear (pseudo-erasure)
+    await expect(page.locator('.tag-filter .tag-pill', { hasText: 'solo-tag' })).not.toBeVisible();
+  });
+});

--- a/e2e/tests/tags.spec.ts
+++ b/e2e/tests/tags.spec.ts
@@ -23,17 +23,16 @@ async function openTagPopover(page: Page) {
   await expect(page.getByText('Tags', { exact: true }).first()).toBeVisible();
 }
 
-/** Create a new tag via the popover's "New tag…" input. */
+/** Create a new tag via the popover's "New tag…" input and wait for the chip. */
 async function createTagInPopover(page: Page, name: string) {
-  // pressSequentially is more reliable than fill() for Svelte bind:value —
-  // each keystroke fires an input event that updates the reactive state.
+  // pressSequentially fires individual input events so Svelte's bind:value
+  // updates newTagName before Enter is pressed.
   const input = page.getByPlaceholder('New tag…');
   await input.click();
   await input.pressSequentially(name, { delay: 20 });
   await input.press('Enter');
-  // Verify the tag was actually applied by checking the chip appears.
-  // This is more robust than matching a specific POST URL, which varies
-  // depending on whether the tag already exists in the DB.
+  // Assert the actual outcome rather than a specific network call — the POST
+  // URL differs depending on whether the tag pre-exists in the DB.
   await expect(page.locator('.note-tag-chip', { hasText: name })).toBeVisible();
 }
 
@@ -47,7 +46,7 @@ test.describe('Tags', () => {
     await openTagPopover(page);
     await createTagInPopover(page, 'e2e-tag');
 
-    // Chip appears below the title
+    // Chip appears above the title
     await expect(page.locator('.note-tag-chip', { hasText: 'e2e-tag' })).toBeVisible();
 
     // Checkbox in popover is checked
@@ -73,9 +72,10 @@ test.describe('Tags', () => {
 
     await createNote(page, 'Untagged note');
 
-    // Click the tag filter pill
+    // Register wait BEFORE the click — the GET fires immediately with no debounce
+    const filterDone = page.waitForResponse((r) => r.url().includes('/api/notes') && r.request().method() === 'GET');
     await page.locator('.filter-tags .tag-pill', { hasText: 'filter-tag' }).click();
-    await page.waitForResponse((r) => r.url().includes('/api/notes') && r.request().method() === 'GET');
+    await filterDone;
 
     // Only tagged note visible in list
     await expect(page.getByRole('list').getByText('Tagged note')).toBeVisible();
@@ -90,14 +90,16 @@ test.describe('Tags', () => {
 
     await createNote(page, 'Note B');
 
-    // Activate tag filter
+    // Activate tag filter — set up wait before click
+    let notesDone = page.waitForResponse((r) => r.url().includes('/api/notes') && r.request().method() === 'GET');
     await page.locator('.filter-tags .tag-pill', { hasText: 'restore-tag' }).click();
-    await page.waitForResponse((r) => r.url().includes('/api/notes') && r.request().method() === 'GET');
+    await notesDone;
     await expect(page.getByRole('list').getByText('Note B')).not.toBeVisible();
 
-    // Click All
+    // Click All — set up wait before click
+    notesDone = page.waitForResponse((r) => r.url().includes('/api/notes') && r.request().method() === 'GET');
     await page.locator('.filter-fixed .tag-pill', { hasText: 'All' }).click();
-    await page.waitForResponse((r) => r.url().includes('/api/notes') && r.request().method() === 'GET');
+    await notesDone;
     await expect(page.getByRole('list').getByText('Note B')).toBeVisible();
   });
 
@@ -106,11 +108,12 @@ test.describe('Tags', () => {
     await openTagPopover(page);
     await createTagInPopover(page, 'chip-tag');
 
-    // Click the chip below the title
+    // Register wait before clicking the chip
+    const filterDone = page.waitForResponse((r) => r.url().includes('/api/notes') && r.request().method() === 'GET');
     await page.locator('.note-tag-chip', { hasText: 'chip-tag' }).click();
-    await page.waitForResponse((r) => r.url().includes('/api/notes') && r.request().method() === 'GET');
+    await filterDone;
 
-    // Sidebar filter pill should be active (has box-shadow / active class)
+    // Sidebar filter pill should be active
     await expect(page.locator('.filter-tags .tag-pill.tag-pill-active', { hasText: 'chip-tag' })).toBeVisible();
   });
 
@@ -119,10 +122,11 @@ test.describe('Tags', () => {
     await openTagPopover(page);
     await createTagInPopover(page, 'remove-tag');
 
-    // Uncheck via popover
+    // Uncheck via popover — register wait before unchecking
     const checkbox = page.locator('.popover-item').filter({ hasText: 'remove-tag' }).locator('input[type=checkbox]');
+    const deleteDone = page.waitForResponse((r) => r.url().includes('/api/notes') && r.url().includes('/tags/') && r.request().method() === 'DELETE');
     await checkbox.uncheck();
-    await page.waitForResponse((r) => r.url().includes('/api/notes') && r.url().includes('/tags/') && r.request().method() === 'DELETE');
+    await deleteDone;
 
     // Chip should be gone
     await expect(page.locator('.note-tag-chip', { hasText: 'remove-tag' })).not.toBeVisible();
@@ -130,16 +134,20 @@ test.describe('Tags', () => {
 
   test('starred filter shows only starred notes', async ({ page }) => {
     await createNote(page, 'Starred note');
-    // Star it via the sidebar action button
-    await page.locator('.note-item').filter({ hasText: 'Starred note' }).hover();
-    await page.locator('.note-item').filter({ hasText: 'Starred note' }).getByTitle('Star').click();
-    await page.waitForResponse((r) => r.url().includes('/star') && r.request().method() === 'PATCH');
+
+    // Star it — use .first() to tolerate a duplicate from a prior retry
+    const noteItem = page.locator('.note-item').filter({ hasText: 'Starred note' }).first();
+    await noteItem.hover();
+    const starDone = page.waitForResponse((r) => r.url().includes('/star') && r.request().method() === 'PATCH');
+    await noteItem.getByTitle('Star').click();
+    await starDone;
 
     await createNote(page, 'Plain note');
 
-    // Activate starred filter
+    // Activate starred filter — register wait before click
+    const filterDone = page.waitForResponse((r) => r.url().includes('/api/notes') && r.request().method() === 'GET');
     await page.locator('.filter-fixed .tag-pill', { hasText: 'Starred' }).click();
-    await page.waitForResponse((r) => r.url().includes('/api/notes') && r.request().method() === 'GET');
+    await filterDone;
 
     await expect(page.getByRole('list').getByText('Starred note')).toBeVisible();
     await expect(page.getByRole('list').getByText('Plain note')).not.toBeVisible();
@@ -152,10 +160,11 @@ test.describe('Tags', () => {
 
     await expect(page.locator('.filter-tags .tag-pill', { hasText: 'solo-tag' })).toBeVisible();
 
-    // Remove the tag from the note
+    // Remove the tag — register wait before unchecking
     const checkbox = page.locator('.popover-item').filter({ hasText: 'solo-tag' }).locator('input[type=checkbox]');
+    const deleteDone = page.waitForResponse((r) => r.url().includes('/tags/') && r.request().method() === 'DELETE');
     await checkbox.uncheck();
-    await page.waitForResponse((r) => r.url().includes('/tags/') && r.request().method() === 'DELETE');
+    await deleteDone;
 
     // Pill should disappear (pseudo-erasure)
     await expect(page.locator('.filter-tags .tag-pill', { hasText: 'solo-tag' })).not.toBeVisible();

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1753,9 +1753,9 @@
       }
     },
     "node_modules/@sveltejs/kit": {
-      "version": "2.56.1",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.56.1.tgz",
-      "integrity": "sha512-9hDOl3yUh8UXWt+mN29dbcdrW0vNwPvMqi01y2Mw+ceErNIISh8MeEY7fXT2Dx1CjC/kfsVqrbxw7DifYr4hsg==",
+      "version": "2.57.1",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.57.1.tgz",
+      "integrity": "sha512-VRdSbB96cI1EnRh09CqmnQqP/YJvET5buj8S6k7CxaJqBJD4bw4fRKDjcarAj/eX9k2eHifQfDH8NtOh+ZxxPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6030,9 +6030,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6389,24 +6389,6 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/frontend/src/__mocks__/lucide-svelte.ts
+++ b/frontend/src/__mocks__/lucide-svelte.ts
@@ -42,6 +42,7 @@ export {
 	noop as Shield,
 	noop as Star,
 	noop as Sun,
+	noop as Tag,
 	noop as Trash,
 	noop as Trash2,
 	noop as Underline,

--- a/frontend/src/app.html
+++ b/frontend/src/app.html
@@ -6,6 +6,10 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#ffffff" />
 		<link rel="manifest" href="%sveltekit.assets%/manifest.json" />
+		<style>
+			/* Remove default browser margin so the app fills the viewport exactly */
+			html, body { margin: 0; padding: 0; height: 100%; overflow: hidden; }
+		</style>
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -93,6 +93,7 @@ export const api = {
 		create: (name: string) => request<Tag>('POST', '/api/tags', { name }),
 		rename: (id: number, name: string) => request<Tag>('PUT', `/api/tags/${id}`, { name }),
 		delete: (id: number) => request<void>('DELETE', `/api/tags/${id}`),
+		listForNote: (noteId: number) => request<Tag[]>('GET', `/api/notes/${noteId}/tags`),
 		addToNote: (noteId: number, tagId: number) =>
 			request<void>('POST', `/api/notes/${noteId}/tags`, { tag_id: tagId }),
 		removeFromNote: (noteId: number, tagId: number) =>

--- a/frontend/src/lib/components/Editor.svelte
+++ b/frontend/src/lib/components/Editor.svelte
@@ -64,7 +64,6 @@
 
 	.editor-container :global(.milkdown) {
 		max-width: 720px;
-		margin: 0 auto;
 	}
 
 	.editor-container :global(.ProseMirror) {

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -14,7 +14,7 @@
 	import { undoCommand, redoCommand } from '@milkdown/kit/plugin/history';
 	import { toggleUnderlineCommand } from '$lib/milkdown/underline';
 	import type { CmdKey } from '@milkdown/kit/core';
-	import { api, type Note } from '$lib/api';
+	import { api, type Note, type Tag } from '$lib/api';
 	import { auth } from '$lib/stores/auth.svelte';
 	import Editor, { type EditorRef } from '$lib/components/Editor.svelte';
 
@@ -23,7 +23,7 @@
 		Bold, Italic, Underline, Quote, Code, FileCode2,
 		List, ListOrdered, Minus, Undo2, Redo2,
 		Plus, Star, Pin, Archive, Trash2, Settings, LogOut,
-		ChevronLeft, ChevronRight, Search,
+		ChevronLeft, ChevronRight, Search, Tag as TagIcon,
 	} from 'lucide-svelte';
 
 	let notes = $state<Note[]>([]);
@@ -37,6 +37,12 @@
 	// Editor command ref
 	let editorRef = $state<EditorRef | null>(null);
 
+	// Tags
+	let allTags = $state<Tag[]>([]);
+	let noteTags = $state<Tag[]>([]);
+	let showTagPopover = $state(false);
+	let newTagName = $state('');
+
 	let selectedNote = $derived(notes.find((n) => n.id === selectedId) ?? null);
 
 	async function loadNotes() {
@@ -47,7 +53,11 @@
 
 	onMount(async () => {
 		await loadNotes();
-		if (notes.length > 0) selectedId = notes[0].id;
+		allTags = await api.tags.list();
+		if (notes.length > 0) {
+			selectedId = notes[0].id;
+			noteTags = await api.tags.listForNote(notes[0].id);
+		}
 	});
 
 	async function newNote() {
@@ -62,9 +72,38 @@
 		mobileShowEditor = true;
 	}
 
-	function selectNote(id: number) {
+	async function selectNote(id: number) {
 		selectedId = id;
 		mobileShowEditor = true;
+		showTagPopover = false;
+		noteTags = await api.tags.listForNote(id);
+	}
+
+	async function toggleTag(tag: Tag) {
+		if (!selectedId) return;
+		const has = noteTags.find(t => t.id === tag.id);
+		if (has) {
+			await api.tags.removeFromNote(selectedId, tag.id);
+			noteTags = noteTags.filter(t => t.id !== tag.id);
+		} else {
+			await api.tags.addToNote(selectedId, tag.id);
+			noteTags = [...noteTags, tag];
+		}
+	}
+
+	async function createAndAddTag() {
+		if (!selectedId || !newTagName.trim()) return;
+		const name = newTagName.trim();
+		let tag = allTags.find(t => t.name.toLowerCase() === name.toLowerCase());
+		if (!tag) {
+			tag = await api.tags.create(name);
+			allTags = [...allTags, tag];
+		}
+		if (!noteTags.find(t => t.id === tag!.id)) {
+			await api.tags.addToNote(selectedId, tag.id);
+			noteTags = [...noteTags, tag];
+		}
+		newTagName = '';
 	}
 
 	function scheduleAutoSave(field: 'title' | 'body', value: string) {
@@ -262,6 +301,40 @@
 				</button>
 				<span class="tb-spacer"></span>
 				<span class="save-status">{saving ? 'Saving…' : ''}</span>
+
+				<!-- Tag popover -->
+				<div class="tag-popover-wrap">
+					<button
+						class="tb-btn tag-tb-btn"
+						class:tag-active={noteTags.length > 0}
+						onclick={() => (showTagPopover = !showTagPopover)}
+						title="Tags"
+					>
+						<TagIcon size={14} />
+						{#if noteTags.length > 0}<span class="tb-tag-count">{noteTags.length}</span>{/if}
+					</button>
+					{#if showTagPopover}
+						<div class="tag-popover">
+							<p class="popover-label">Tags</p>
+							{#each allTags as tag (tag.id)}
+								<label class="popover-item">
+									<input type="checkbox" checked={!!noteTags.find(t => t.id === tag.id)} onchange={() => toggleTag(tag)} />
+									{tag.name}
+								</label>
+							{/each}
+							<div class="popover-new">
+								<input
+									class="popover-new-input"
+									type="text"
+									placeholder="New tag…"
+									bind:value={newTagName}
+									onkeydown={(e) => e.key === 'Enter' && createAndAddTag()}
+								/>
+								<button class="popover-add-btn" onclick={createAndAddTag}><Plus size={12} /></button>
+							</div>
+						</div>
+					{/if}
+				</div>
 			</div>
 
 			<!-- Title -->
@@ -273,6 +346,13 @@
 					oninput={(e) => scheduleAutoSave('title', (e.target as HTMLInputElement).value)}
 					placeholder="Note title"
 				/>
+				{#if noteTags.length > 0}
+					<div class="note-tag-chips">
+						{#each noteTags as tag (tag.id)}
+							<span class="note-tag-chip"><TagIcon size={9} />{tag.name}</span>
+						{/each}
+					</div>
+				{/if}
 			</div>
 
 			<!-- Editor body -->
@@ -524,6 +604,102 @@
 		padding: 0.75rem 1rem 0.5rem;
 		border-bottom: 1px solid #e5e7eb;
 		flex-shrink: 0;
+	}
+
+	/* ─── Tag toolbar popover ────────────────────────────── */
+	.tag-popover-wrap { position: relative; }
+
+	.tag-tb-btn { gap: 0.2rem; }
+	.tag-tb-btn.tag-active { color: #6366f1; }
+
+	.tb-tag-count {
+		background: #6366f1;
+		color: white;
+		border-radius: 999px;
+		padding: 0 0.3rem;
+		font-size: 0.6rem;
+	}
+
+	.tag-popover {
+		position: absolute;
+		right: 0;
+		top: calc(100% + 6px);
+		background: white;
+		border: 1px solid #e5e7eb;
+		border-radius: 0.5rem;
+		box-shadow: 0 4px 16px rgba(0,0,0,0.12);
+		padding: 0.5rem;
+		min-width: 11rem;
+		z-index: 30;
+	}
+
+	.popover-label {
+		font-size: 0.7rem;
+		font-weight: 600;
+		color: #9ca3af;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		margin: 0 0 0.25rem;
+		padding: 0 0.25rem;
+	}
+
+	.popover-item {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.3rem 0.25rem;
+		border-radius: 0.25rem;
+		cursor: pointer;
+		font-size: 0.85rem;
+	}
+	.popover-item:hover { background: #f3f4f6; }
+
+	.popover-new {
+		display: flex;
+		align-items: center;
+		gap: 0.25rem;
+		margin-top: 0.375rem;
+		padding-top: 0.375rem;
+		border-top: 1px solid #f3f4f6;
+	}
+
+	.popover-new-input {
+		flex: 1;
+		border: none;
+		border-bottom: 1px solid #d1d5db;
+		outline: none;
+		font-size: 0.8rem;
+		padding: 0.15rem 0.1rem;
+		background: transparent;
+	}
+	.popover-new-input:focus { border-color: #6366f1; }
+
+	.popover-add-btn {
+		background: none;
+		border: none;
+		cursor: pointer;
+		color: #6366f1;
+		padding: 0.1rem;
+		display: flex;
+	}
+
+	/* ─── Editor header (title) ──────────────────────────── */
+	.note-tag-chips {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.25rem;
+		margin-top: 0.375rem;
+	}
+
+	.note-tag-chip {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.2rem;
+		padding: 0.1rem 0.4rem;
+		background: #e0e7ff;
+		color: #4338ca;
+		border-radius: 999px;
+		font-size: 0.7rem;
 	}
 
 	.title-input {

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -701,13 +701,18 @@
 		padding: 0.4rem 0.75rem 0.25rem;
 	}
 
-	/* Scrollable tag pills — max ~2 rows then scroll */
+	/* Scrollable tag pills — 2 rows by default, expands to 5 on hover */
 	.filter-tags {
 		display: flex;
 		flex-wrap: wrap;
 		gap: 0.25rem;
 		padding: 0 0.75rem 0.4rem;
-		max-height: 4rem;
+		max-height: 3.2rem;
+		overflow-y: hidden;
+		transition: max-height 0.2s ease;
+	}
+	.filter-tags:hover {
+		max-height: 8rem;
 		overflow-y: auto;
 	}
 

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -43,6 +43,7 @@
 	let showTagPopover = $state(false);
 	let newTagName = $state('');
 	let activeTagId = $state<number | null>(null);
+	let starredOnly = $state(false);
 
 	const PALETTE = [
 		{ bg: '#fee2e2', text: '#991b1b' },
@@ -62,9 +63,10 @@
 	let selectedNote = $derived(notes.find((n) => n.id === selectedId) ?? null);
 
 	async function loadNotes() {
-		const params: { search?: string; tag_id?: number } = {};
+		const params: { search?: string; tag?: number; starred?: boolean } = {};
 		if (search) params.search = search;
-		if (activeTagId !== null) params.tag_id = activeTagId;
+		if (activeTagId !== null) params.tag = activeTagId;
+		if (starredOnly) params.starred = true;
 		notes = await api.notes.list(params);
 	}
 
@@ -96,10 +98,10 @@
 		noteTags = await api.tags.listForNote(id);
 	}
 
-	async function filterByTag(id: number | null) {
-		activeTagId = id;
+	async function applyFilter(tagId: number | null, starred: boolean) {
+		activeTagId = tagId;
+		starredOnly = starred;
 		await loadNotes();
-		// If current selection falls outside filtered list, pick first
 		if (notes.length > 0 && !notes.find(n => n.id === selectedId)) {
 			selectedId = notes[0].id;
 			noteTags = await api.tags.listForNote(notes[0].id);
@@ -108,6 +110,14 @@
 			noteTags = [];
 			mobileShowEditor = false;
 		}
+	}
+
+	function filterByTag(id: number | null) {
+		return applyFilter(id, starredOnly);
+	}
+
+	function toggleStarFilter() {
+		return applyFilter(activeTagId, !starredOnly);
 	}
 
 	async function toggleTag(tag: Tag) {
@@ -232,25 +242,35 @@
 			/>
 		</div>
 
-		{#if visibleTags.length > 0}
-			<div class="tag-filter" role="group" aria-label="Filter by tag">
+		<div class="filter-bar" role="group" aria-label="Filter notes">
+			<div class="filter-fixed">
 				<button
 					class="tag-pill"
-					class:tag-pill-active={activeTagId === null}
-					onclick={() => filterByTag(null)}
+					class:tag-pill-active={activeTagId === null && !starredOnly}
+					onclick={() => applyFilter(null, false)}
 				>All</button>
-				{#each visibleTags as tag (tag.id)}
-					{@const c = tagColor(tag)}
-					<button
-						class="tag-pill"
-						class:tag-pill-active={activeTagId === tag.id}
-						style="--tag-bg:{c.bg};--tag-text:{c.text}"
-						onclick={() => filterByTag(activeTagId === tag.id ? null : tag.id)}
-						title="{tag.name} ({tag.note_count})"
-					>{tag.name}</button>
-				{/each}
+				<button
+					class="tag-pill tag-pill-star"
+					class:tag-pill-active={starredOnly}
+					onclick={toggleStarFilter}
+					title="Starred notes"
+				><Star size={11} /> Starred</button>
 			</div>
-		{/if}
+			{#if visibleTags.length > 0}
+				<div class="filter-tags">
+					{#each visibleTags as tag (tag.id)}
+						{@const c = tagColor(tag)}
+						<button
+							class="tag-pill"
+							class:tag-pill-active={activeTagId === tag.id}
+							style="--tag-bg:{c.bg};--tag-text:{c.text}"
+							onclick={() => filterByTag(activeTagId === tag.id ? null : tag.id)}
+							title="{tag.name} ({tag.note_count})"
+						>{tag.name}</button>
+					{/each}
+				</div>
+			{/if}
+		</div>
 
 		<ul class="note-list" role="list">
 			{#each notes as note (note.id)}
@@ -409,7 +429,7 @@
 							<button
 								class="note-tag-chip"
 								style="--tag-bg:{c.bg};--tag-text:{c.text}"
-								onclick={() => filterByTag(activeTagId === tag.id ? null : tag.id)}
+								onclick={() => applyFilter(activeTagId === tag.id ? null : tag.id, starredOnly)}
 								title="Filter by {tag.name}"
 							><TagIcon size={9} />{tag.name}</button>
 						{/each}
@@ -668,14 +688,27 @@
 		flex-shrink: 0;
 	}
 
-	/* ─── Sidebar tag filter ─────────────────────────────── */
-	.tag-filter {
+	/* ─── Sidebar filter bar ─────────────────────────────── */
+	.filter-bar {
+		border-bottom: 1px solid #e5e7eb;
+		flex-shrink: 0;
+	}
+
+	/* Fixed row: All + Starred — always visible */
+	.filter-fixed {
+		display: flex;
+		gap: 0.25rem;
+		padding: 0.4rem 0.75rem 0.25rem;
+	}
+
+	/* Scrollable tag pills — max ~2 rows then scroll */
+	.filter-tags {
 		display: flex;
 		flex-wrap: wrap;
 		gap: 0.25rem;
-		padding: 0.4rem 0.75rem;
-		border-bottom: 1px solid #e5e7eb;
-		flex-shrink: 0;
+		padding: 0 0.75rem 0.4rem;
+		max-height: 4rem;
+		overflow-y: auto;
 	}
 
 	.tag-pill {
@@ -697,12 +730,21 @@
 		border-color: var(--tag-text, #6366f1);
 		box-shadow: 0 0 0 1.5px var(--tag-text, #6366f1);
 	}
-	/* "All" pill has no CSS variables, use indigo */
+	/* "All" pill — no CSS vars, use indigo */
 	.tag-pill:not([style]).tag-pill-active {
 		background: #e0e7ff;
 		color: #4338ca;
 		border-color: #6366f1;
 		box-shadow: 0 0 0 1.5px #6366f1;
+	}
+
+	/* Starred pill — amber */
+	.tag-pill-star { --tag-bg: #fef9c3; --tag-text: #854d0e; }
+	.tag-pill-star.tag-pill-active {
+		background: #fef9c3;
+		color: #854d0e;
+		border-color: #d97706;
+		box-shadow: 0 0 0 1.5px #d97706;
 	}
 
 	/* ─── Tag toolbar popover ────────────────────────────── */

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -107,9 +107,15 @@
 	onMount(async () => {
 		await loadNotes();
 		allTags = await api.tags.list();
-		if (notes.length > 0) {
-			selectedId = notes[0].id;
-			noteTags = await api.tags.listForNote(notes[0].id);
+		if (notes.length > 0 && selectedId === null) {
+			const initId = notes[0].id;
+			selectedId = initId;
+			const tags = await api.tags.listForNote(initId);
+			// Only apply if no user action (newNote / selectNote) changed the
+			// selection while we were awaiting the listForNote response.
+			if (selectedId === initId) {
+				noteTags = tags;
+			}
 		}
 	});
 

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -85,7 +85,11 @@
 		{ bg: '#f5d0fe', text: '#86198f' },   // 30 deep fuchsia
 		{ bg: '#a7f3d0', text: '#064e3b' },   // 31 deep emerald
 	] as const;
-	function tagColor(tag: Tag) { return PALETTE[tag.id % PALETTE.length]; }
+	function tagColor(tag: Tag) {
+		// Knuth multiplicative hash: top 5 bits of (id × golden-ratio-constant)
+		// Spreads sequential IDs across the full 32-colour palette without clustering
+		return PALETTE[Math.imul(tag.id, 0x9e3779b9) >>> 27];
+	}
 
 	// Only show tags that have at least one note (active or trashed); pure UI erasure
 	let visibleTags = $derived(allTags.filter(t => t.note_count > 0));
@@ -433,54 +437,21 @@
 				<span class="save-status">{saving ? 'Saving…' : ''}</span>
 			</div>
 
-			<!-- Tags row + Title -->
+			<!-- Tags (above title) + Title + Popover button (absolute right) -->
 			<div class="editor-header">
-				<div class="note-tags-row">
-					{#each noteTags as tag (tag.id)}
-						{@const c = tagColor(tag)}
-						<button
-							class="note-tag-chip"
-							style="--tag-bg:{c.bg};--tag-text:{c.text}"
-							onclick={() => applyFilter(activeTagId === tag.id ? null : tag.id, starredOnly)}
-							title="Filter by {tag.name}"
-						><TagIcon size={9} />{tag.name}</button>
-					{/each}
-					<!-- Tag popover button, always visible on the tag row -->
-					<div class="tag-popover-wrap">
-						<button
-							class="tag-chip-btn"
-							class:tag-chip-btn-active={noteTags.length > 0}
-							onclick={() => (showTagPopover = !showTagPopover)}
-							title="Tags"
-						>
-							<TagIcon size={11} />
-							{#if noteTags.length > 0}<span class="tb-tag-count">{noteTags.length}</span>{/if}
-						</button>
-						{#if showTagPopover}
-							<div class="tag-popover">
-								<p class="popover-label">Tags</p>
-								{#each allTags as tag (tag.id)}
-									{@const c = tagColor(tag)}
-									<label class="popover-item">
-										<input type="checkbox" checked={!!noteTags.find(t => t.id === tag.id)} onchange={() => toggleTag(tag)} />
-										<span class="popover-tag-dot" style="background:{c.text}"></span>
-										{tag.name}
-									</label>
-								{/each}
-								<div class="popover-new">
-									<input
-										class="popover-new-input"
-										type="text"
-										placeholder="New tag…"
-										bind:value={newTagName}
-										onkeydown={(e) => e.key === 'Enter' && createAndAddTag()}
-									/>
-									<button class="popover-add-btn" onclick={createAndAddTag}><Plus size={12} /></button>
-								</div>
-							</div>
-						{/if}
+				{#if noteTags.length > 0}
+					<div class="note-tags-chips">
+						{#each noteTags as tag (tag.id)}
+							{@const c = tagColor(tag)}
+							<button
+								class="note-tag-chip"
+								style="--tag-bg:{c.bg};--tag-text:{c.text}"
+								onclick={() => applyFilter(activeTagId === tag.id ? null : tag.id, starredOnly)}
+								title="Filter by {tag.name}"
+							><TagIcon size={9} />{tag.name}</button>
+						{/each}
 					</div>
-				</div>
+				{/if}
 				<input
 					class="title-input"
 					type="text"
@@ -488,6 +459,42 @@
 					oninput={(e) => scheduleAutoSave('title', (e.target as HTMLInputElement).value)}
 					placeholder="Note title"
 				/>
+				<!-- Popover button: always visible, absolutely pinned to top-right -->
+				<!-- When no tags it sits level with the title; when tags exist it aligns with the first chip row -->
+				<div class="tag-popover-wrap">
+					<button
+						class="tag-chip-btn"
+						class:tag-chip-btn-active={noteTags.length > 0}
+						onclick={() => (showTagPopover = !showTagPopover)}
+						title="Tags"
+					>
+						<TagIcon size={11} />
+						{#if noteTags.length > 0}<span class="tb-tag-count">{noteTags.length}</span>{/if}
+					</button>
+					{#if showTagPopover}
+						<div class="tag-popover">
+							<p class="popover-label">Tags</p>
+							{#each allTags as tag (tag.id)}
+								{@const c = tagColor(tag)}
+								<label class="popover-item">
+									<input type="checkbox" checked={!!noteTags.find(t => t.id === tag.id)} onchange={() => toggleTag(tag)} />
+									<span class="popover-tag-dot" style="background:{c.text}"></span>
+									{tag.name}
+								</label>
+							{/each}
+							<div class="popover-new">
+								<input
+									class="popover-new-input"
+									type="text"
+									placeholder="New tag…"
+									bind:value={newTagName}
+									onkeydown={(e) => e.key === 'Enter' && createAndAddTag()}
+								/>
+								<button class="popover-add-btn" onclick={createAndAddTag}><Plus size={12} /></button>
+							</div>
+						</div>
+					{/if}
+				</div>
 			</div>
 
 			<!-- Editor body -->
@@ -736,19 +743,19 @@
 
 	/* ─── Editor header (tags + title) ─────────────────── */
 	.editor-header {
-		padding: 0.5rem 1rem 0.5rem;
+		position: relative;
+		/* Reserve right-side space for the absolute popover button */
+		padding: 0.45rem 3rem 0.45rem 1rem;
 		border-bottom: 1px solid #e5e7eb;
 		flex-shrink: 0;
 	}
 
-	/* Row of tag chips + popover button above the title */
-	.note-tags-row {
+	/* Chip row above the title (only rendered when note has tags) */
+	.note-tags-chips {
 		display: flex;
 		flex-wrap: wrap;
-		align-items: center;
 		gap: 0.25rem;
-		margin-bottom: 0.35rem;
-		position: relative;
+		margin-bottom: 0.3rem;
 	}
 
 	/* ─── Sidebar filter bar ─────────────────────────────── */
@@ -817,10 +824,15 @@
 		box-shadow: 0 0 0 1.5px #d97706;
 	}
 
-	/* ─── Tag popover (anchored to note-tags-row) ───────── */
-	.tag-popover-wrap { position: relative; }
+	/* ─── Tag popover (pinned to top-right of editor-header) ── */
+	/* Absolute, so it stays top-right whether tags exist or not */
+	.tag-popover-wrap {
+		position: absolute;
+		right: 1rem;
+		top: 0.45rem; /* matches editor-header padding-top */
+	}
 
-	/* Chip-style button that lives in the note-tags-row */
+	/* Chip-style button that triggers the popover */
 	.tag-chip-btn {
 		display: inline-flex;
 		align-items: center;
@@ -848,7 +860,7 @@
 
 	.tag-popover {
 		position: absolute;
-		left: 0;
+		right: 0;
 		top: calc(100% + 4px);
 		background: white;
 		border: 1px solid #e5e7eb;

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -122,6 +122,7 @@
 			notes = [...notes.slice(0, firstUnpinned), note, ...notes.slice(firstUnpinned)];
 		}
 		selectedId = note.id;
+		noteTags = [];
 		mobileShowEditor = true;
 	}
 
@@ -744,8 +745,9 @@
 	/* ─── Editor header (tags + title) ─────────────────── */
 	.editor-header {
 		position: relative;
-		/* Reserve right-side space for the absolute popover button */
-		padding: 0.45rem 3rem 0.45rem 1rem;
+		/* Right padding reserves a clear gutter for the absolute popover button.
+		   Sized to comfortably fit the button even with a 2-digit count badge. */
+		padding: 0.45rem 5rem 0.45rem 1rem;
 		border-bottom: 1px solid #e5e7eb;
 		flex-shrink: 0;
 	}

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -98,6 +98,22 @@
 		noteTags = await api.tags.listForNote(id);
 	}
 
+	let tagFilterEl = $state<HTMLDivElement | null>(null);
+	let tagFilterExpanded = $state(false);
+	let tagFilterScrollable = $state(false);
+
+	function onTagFilterMouseEnter() {
+		tagFilterExpanded = true;
+	}
+	function onTagFilterMouseLeave() {
+		tagFilterScrollable = false;
+		tagFilterExpanded = false;
+		if (tagFilterEl) tagFilterEl.scrollTop = 0;
+	}
+	function onTagFilterTransitionEnd() {
+		if (tagFilterExpanded) tagFilterScrollable = true;
+	}
+
 	async function applyFilter(tagId: number | null, starred: boolean) {
 		activeTagId = tagId;
 		starredOnly = starred;
@@ -257,7 +273,17 @@
 				><Star size={11} /> Starred</button>
 			</div>
 			{#if visibleTags.length > 0}
-				<div class="filter-tags">
+				<div
+					class="filter-tags"
+					class:expanded={tagFilterExpanded}
+					class:scrollable={tagFilterScrollable}
+					bind:this={tagFilterEl}
+					role="group"
+					aria-label="Tag filters"
+					onmouseenter={onTagFilterMouseEnter}
+					onmouseleave={onTagFilterMouseLeave}
+					ontransitionend={onTagFilterTransitionEnd}
+				>
 					{#each visibleTags as tag (tag.id)}
 						{@const c = tagColor(tag)}
 						<button
@@ -701,18 +727,20 @@
 		padding: 0.4rem 0.75rem 0.25rem;
 	}
 
-	/* Scrollable tag pills — 2 rows by default, expands to 5 on hover */
+	/* Scrollable tag pills — 4 rows by default, expands to 5 rows on hover */
 	.filter-tags {
 		display: flex;
 		flex-wrap: wrap;
 		gap: 0.25rem;
 		padding: 0 0.75rem 0.4rem;
-		max-height: 2.55rem;
+		max-height: 6.2rem;
 		overflow-y: hidden;
 		transition: max-height 0.2s ease;
 	}
-	.filter-tags:hover {
-		max-height: 8rem;
+	.filter-tags.expanded {
+		max-height: 7.8rem;
+	}
+	.filter-tags.scrollable {
 		overflow-y: auto;
 	}
 

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -707,7 +707,7 @@
 		flex-wrap: wrap;
 		gap: 0.25rem;
 		padding: 0 0.75rem 0.4rem;
-		max-height: 3.2rem;
+		max-height: 2.55rem;
 		overflow-y: hidden;
 		transition: max-height 0.2s ease;
 	}

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -46,14 +46,44 @@
 	let starredOnly = $state(false);
 
 	const PALETTE = [
-		{ bg: '#fee2e2', text: '#991b1b' },
-		{ bg: '#ffedd5', text: '#9a3412' },
-		{ bg: '#fef9c3', text: '#854d0e' },
-		{ bg: '#dcfce7', text: '#166534' },
-		{ bg: '#dbeafe', text: '#1e3a8a' },
-		{ bg: '#ede9fe', text: '#4c1d95' },
-		{ bg: '#fce7f3', text: '#831843' },
-		{ bg: '#e0f2fe', text: '#0c4a6e' },
+		// Reds / Pinks / Rose
+		{ bg: '#fee2e2', text: '#991b1b' },   //  0 red
+		{ bg: '#fce7f3', text: '#831843' },   //  1 pink
+		{ bg: '#ffe4e6', text: '#881337' },   //  2 rose
+		{ bg: '#fecdd3', text: '#9f1239' },   //  3 deep rose
+		// Orange / Amber / Yellow / Lime
+		{ bg: '#ffedd5', text: '#9a3412' },   //  4 orange
+		{ bg: '#fef3c7', text: '#78350f' },   //  5 amber
+		{ bg: '#fef9c3', text: '#854d0e' },   //  6 yellow
+		{ bg: '#ecfccb', text: '#365314' },   //  7 lime
+		// Greens
+		{ bg: '#dcfce7', text: '#166534' },   //  8 green
+		{ bg: '#d1fae5', text: '#064e3b' },   //  9 emerald
+		{ bg: '#ccfbf1', text: '#134e4a' },   // 10 teal
+		// Cyans / Sky / Blues / Indigo
+		{ bg: '#cffafe', text: '#164e63' },   // 11 cyan
+		{ bg: '#e0f2fe', text: '#0c4a6e' },   // 12 sky
+		{ bg: '#dbeafe', text: '#1e3a8a' },   // 13 blue
+		{ bg: '#e0e7ff', text: '#3730a3' },   // 14 indigo
+		// Violet / Purple / Fuchsia
+		{ bg: '#ede9fe', text: '#4c1d95' },   // 15 violet
+		{ bg: '#f3e8ff', text: '#6b21a8' },   // 16 purple
+		{ bg: '#fae8ff', text: '#86198f' },   // 17 fuchsia
+		// Slightly deeper / -200 variants for more variety
+		{ bg: '#fecaca', text: '#7f1d1d' },   // 18 deep red
+		{ bg: '#fbcfe8', text: '#9d174d' },   // 19 deep pink
+		{ bg: '#fda4af', text: '#881337' },   // 20 mid rose
+		{ bg: '#fed7aa', text: '#7c2d12' },   // 21 deep orange
+		{ bg: '#fde68a', text: '#78350f' },   // 22 deep amber
+		{ bg: '#bbf7d0', text: '#14532d' },   // 23 deep green
+		{ bg: '#99f6e4', text: '#134e4a' },   // 24 deep teal
+		{ bg: '#bae6fd', text: '#0c4a6e' },   // 25 deep sky
+		{ bg: '#bfdbfe', text: '#1e40af' },   // 26 deep blue
+		{ bg: '#c7d2fe', text: '#3730a3' },   // 27 deep indigo
+		{ bg: '#ddd6fe', text: '#5b21b6' },   // 28 deep violet
+		{ bg: '#e9d5ff', text: '#6b21a8' },   // 29 deep purple
+		{ bg: '#f5d0fe', text: '#86198f' },   // 30 deep fuchsia
+		{ bg: '#a7f3d0', text: '#064e3b' },   // 31 deep emerald
 	] as const;
 	function tagColor(tag: Tag) { return PALETTE[tag.id % PALETTE.length]; }
 
@@ -401,46 +431,56 @@
 				</button>
 				<span class="tb-spacer"></span>
 				<span class="save-status">{saving ? 'Saving…' : ''}</span>
-
-				<!-- Tag popover -->
-				<div class="tag-popover-wrap">
-					<button
-						class="tb-btn tag-tb-btn"
-						class:tag-active={noteTags.length > 0}
-						onclick={() => (showTagPopover = !showTagPopover)}
-						title="Tags"
-					>
-						<TagIcon size={14} />
-						{#if noteTags.length > 0}<span class="tb-tag-count">{noteTags.length}</span>{/if}
-					</button>
-					{#if showTagPopover}
-						<div class="tag-popover">
-							<p class="popover-label">Tags</p>
-							{#each allTags as tag (tag.id)}
-								{@const c = tagColor(tag)}
-								<label class="popover-item">
-									<input type="checkbox" checked={!!noteTags.find(t => t.id === tag.id)} onchange={() => toggleTag(tag)} />
-									<span class="popover-tag-dot" style="background:{c.text}"></span>
-									{tag.name}
-								</label>
-							{/each}
-							<div class="popover-new">
-								<input
-									class="popover-new-input"
-									type="text"
-									placeholder="New tag…"
-									bind:value={newTagName}
-									onkeydown={(e) => e.key === 'Enter' && createAndAddTag()}
-								/>
-								<button class="popover-add-btn" onclick={createAndAddTag}><Plus size={12} /></button>
-							</div>
-						</div>
-					{/if}
-				</div>
 			</div>
 
-			<!-- Title -->
+			<!-- Tags row + Title -->
 			<div class="editor-header">
+				<div class="note-tags-row">
+					{#each noteTags as tag (tag.id)}
+						{@const c = tagColor(tag)}
+						<button
+							class="note-tag-chip"
+							style="--tag-bg:{c.bg};--tag-text:{c.text}"
+							onclick={() => applyFilter(activeTagId === tag.id ? null : tag.id, starredOnly)}
+							title="Filter by {tag.name}"
+						><TagIcon size={9} />{tag.name}</button>
+					{/each}
+					<!-- Tag popover button, always visible on the tag row -->
+					<div class="tag-popover-wrap">
+						<button
+							class="tag-chip-btn"
+							class:tag-chip-btn-active={noteTags.length > 0}
+							onclick={() => (showTagPopover = !showTagPopover)}
+							title="Tags"
+						>
+							<TagIcon size={11} />
+							{#if noteTags.length > 0}<span class="tb-tag-count">{noteTags.length}</span>{/if}
+						</button>
+						{#if showTagPopover}
+							<div class="tag-popover">
+								<p class="popover-label">Tags</p>
+								{#each allTags as tag (tag.id)}
+									{@const c = tagColor(tag)}
+									<label class="popover-item">
+										<input type="checkbox" checked={!!noteTags.find(t => t.id === tag.id)} onchange={() => toggleTag(tag)} />
+										<span class="popover-tag-dot" style="background:{c.text}"></span>
+										{tag.name}
+									</label>
+								{/each}
+								<div class="popover-new">
+									<input
+										class="popover-new-input"
+										type="text"
+										placeholder="New tag…"
+										bind:value={newTagName}
+										onkeydown={(e) => e.key === 'Enter' && createAndAddTag()}
+									/>
+									<button class="popover-add-btn" onclick={createAndAddTag}><Plus size={12} /></button>
+								</div>
+							</div>
+						{/if}
+					</div>
+				</div>
 				<input
 					class="title-input"
 					type="text"
@@ -448,19 +488,6 @@
 					oninput={(e) => scheduleAutoSave('title', (e.target as HTMLInputElement).value)}
 					placeholder="Note title"
 				/>
-				{#if noteTags.length > 0}
-					<div class="note-tag-chips">
-						{#each noteTags as tag (tag.id)}
-							{@const c = tagColor(tag)}
-							<button
-								class="note-tag-chip"
-								style="--tag-bg:{c.bg};--tag-text:{c.text}"
-								onclick={() => applyFilter(activeTagId === tag.id ? null : tag.id, starredOnly)}
-								title="Filter by {tag.name}"
-							><TagIcon size={9} />{tag.name}</button>
-						{/each}
-					</div>
-				{/if}
 			</div>
 
 			<!-- Editor body -->
@@ -707,11 +734,21 @@
 	.mobile-sep { display: none; }
 	.mobile-show-editor { display: none; }
 
-	/* ─── Editor header (title) ──────────────────────────── */
+	/* ─── Editor header (tags + title) ─────────────────── */
 	.editor-header {
-		padding: 0.75rem 1rem 0.5rem;
+		padding: 0.5rem 1rem 0.5rem;
 		border-bottom: 1px solid #e5e7eb;
 		flex-shrink: 0;
+	}
+
+	/* Row of tag chips + popover button above the title */
+	.note-tags-row {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 0.25rem;
+		margin-bottom: 0.35rem;
+		position: relative;
 	}
 
 	/* ─── Sidebar filter bar ─────────────────────────────── */
@@ -727,18 +764,18 @@
 		padding: 0.4rem 0.75rem 0.25rem;
 	}
 
-	/* Scrollable tag pills — 4 rows by default, expands to 5 rows on hover */
+	/* Scrollable tag pills — 2 rows by default, expands to 4 rows (then scrolls) on hover */
 	.filter-tags {
 		display: flex;
 		flex-wrap: wrap;
 		gap: 0.25rem;
 		padding: 0 0.75rem 0.4rem;
-		max-height: 6.2rem;
+		max-height: 2.55rem;
 		overflow-y: hidden;
 		transition: max-height 0.2s ease;
 	}
 	.filter-tags.expanded {
-		max-height: 7.8rem;
+		max-height: 5.1rem;
 	}
 	.filter-tags.scrollable {
 		overflow-y: auto;
@@ -780,11 +817,26 @@
 		box-shadow: 0 0 0 1.5px #d97706;
 	}
 
-	/* ─── Tag toolbar popover ────────────────────────────── */
+	/* ─── Tag popover (anchored to note-tags-row) ───────── */
 	.tag-popover-wrap { position: relative; }
 
-	.tag-tb-btn { gap: 0.2rem; }
-	.tag-tb-btn.tag-active { color: #6366f1; }
+	/* Chip-style button that lives in the note-tags-row */
+	.tag-chip-btn {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.2rem;
+		padding: 0.1rem 0.45rem;
+		background: transparent;
+		color: #9ca3af;
+		border-radius: 999px;
+		font-size: 0.7rem;
+		font-weight: 500;
+		border: 1px dashed #d1d5db;
+		cursor: pointer;
+		transition: all 0.1s;
+	}
+	.tag-chip-btn:hover { background: #f3f4f6; color: #374151; border-color: #9ca3af; }
+	.tag-chip-btn.tag-chip-btn-active { color: #6366f1; border-color: #6366f1; }
 
 	.tb-tag-count {
 		background: #6366f1;
@@ -796,8 +848,8 @@
 
 	.tag-popover {
 		position: absolute;
-		right: 0;
-		top: calc(100% + 6px);
+		left: 0;
+		top: calc(100% + 4px);
 		background: white;
 		border: 1px solid #e5e7eb;
 		border-radius: 0.5rem;
@@ -864,14 +916,7 @@
 		display: flex;
 	}
 
-	/* ─── Tag chips below note title ─────────────────────── */
-	.note-tag-chips {
-		display: flex;
-		flex-wrap: wrap;
-		gap: 0.25rem;
-		margin-top: 0.375rem;
-	}
-
+	/* ─── Tag chips in the note-tags-row ────────────────── */
 	.note-tag-chip {
 		display: inline-flex;
 		align-items: center;

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -42,12 +42,29 @@
 	let noteTags = $state<Tag[]>([]);
 	let showTagPopover = $state(false);
 	let newTagName = $state('');
+	let activeTagId = $state<number | null>(null);
+
+	const PALETTE = [
+		{ bg: '#fee2e2', text: '#991b1b' },
+		{ bg: '#ffedd5', text: '#9a3412' },
+		{ bg: '#fef9c3', text: '#854d0e' },
+		{ bg: '#dcfce7', text: '#166534' },
+		{ bg: '#dbeafe', text: '#1e3a8a' },
+		{ bg: '#ede9fe', text: '#4c1d95' },
+		{ bg: '#fce7f3', text: '#831843' },
+		{ bg: '#e0f2fe', text: '#0c4a6e' },
+	] as const;
+	function tagColor(tag: Tag) { return PALETTE[tag.id % PALETTE.length]; }
+
+	// Only show tags that have at least one note (active or trashed); pure UI erasure
+	let visibleTags = $derived(allTags.filter(t => t.note_count > 0));
 
 	let selectedNote = $derived(notes.find((n) => n.id === selectedId) ?? null);
 
 	async function loadNotes() {
-		const params: { search?: string } = {};
+		const params: { search?: string; tag_id?: number } = {};
 		if (search) params.search = search;
+		if (activeTagId !== null) params.tag_id = activeTagId;
 		notes = await api.notes.list(params);
 	}
 
@@ -79,6 +96,20 @@
 		noteTags = await api.tags.listForNote(id);
 	}
 
+	async function filterByTag(id: number | null) {
+		activeTagId = id;
+		await loadNotes();
+		// If current selection falls outside filtered list, pick first
+		if (notes.length > 0 && !notes.find(n => n.id === selectedId)) {
+			selectedId = notes[0].id;
+			noteTags = await api.tags.listForNote(notes[0].id);
+		} else if (notes.length === 0) {
+			selectedId = null;
+			noteTags = [];
+			mobileShowEditor = false;
+		}
+	}
+
 	async function toggleTag(tag: Tag) {
 		if (!selectedId) return;
 		const has = noteTags.find(t => t.id === tag.id);
@@ -89,6 +120,8 @@
 			await api.tags.addToNote(selectedId, tag.id);
 			noteTags = [...noteTags, tag];
 		}
+		// Refresh note_count so pseudo-erasure stays accurate
+		allTags = await api.tags.list();
 	}
 
 	async function createAndAddTag() {
@@ -97,13 +130,13 @@
 		let tag = allTags.find(t => t.name.toLowerCase() === name.toLowerCase());
 		if (!tag) {
 			tag = await api.tags.create(name);
-			allTags = [...allTags, tag];
 		}
 		if (!noteTags.find(t => t.id === tag!.id)) {
 			await api.tags.addToNote(selectedId, tag.id);
 			noteTags = [...noteTags, tag];
 		}
 		newTagName = '';
+		allTags = await api.tags.list();
 	}
 
 	function scheduleAutoSave(field: 'title' | 'body', value: string) {
@@ -160,6 +193,7 @@
 		await loadNotes();
 		if (notes.length > 0 && !notes.find((n) => n.id === selectedId)) {
 			selectedId = notes[0].id;
+			noteTags = await api.tags.listForNote(notes[0].id);
 		}
 	}
 
@@ -197,6 +231,26 @@
 				oninput={handleSearch}
 			/>
 		</div>
+
+		{#if visibleTags.length > 0}
+			<div class="tag-filter" role="group" aria-label="Filter by tag">
+				<button
+					class="tag-pill"
+					class:tag-pill-active={activeTagId === null}
+					onclick={() => filterByTag(null)}
+				>All</button>
+				{#each visibleTags as tag (tag.id)}
+					{@const c = tagColor(tag)}
+					<button
+						class="tag-pill"
+						class:tag-pill-active={activeTagId === tag.id}
+						style="--tag-bg:{c.bg};--tag-text:{c.text}"
+						onclick={() => filterByTag(activeTagId === tag.id ? null : tag.id)}
+						title="{tag.name} ({tag.note_count})"
+					>{tag.name}</button>
+				{/each}
+			</div>
+		{/if}
 
 		<ul class="note-list" role="list">
 			{#each notes as note (note.id)}
@@ -317,8 +371,10 @@
 						<div class="tag-popover">
 							<p class="popover-label">Tags</p>
 							{#each allTags as tag (tag.id)}
+								{@const c = tagColor(tag)}
 								<label class="popover-item">
 									<input type="checkbox" checked={!!noteTags.find(t => t.id === tag.id)} onchange={() => toggleTag(tag)} />
+									<span class="popover-tag-dot" style="background:{c.text}"></span>
 									{tag.name}
 								</label>
 							{/each}
@@ -349,7 +405,13 @@
 				{#if noteTags.length > 0}
 					<div class="note-tag-chips">
 						{#each noteTags as tag (tag.id)}
-							<span class="note-tag-chip"><TagIcon size={9} />{tag.name}</span>
+							{@const c = tagColor(tag)}
+							<button
+								class="note-tag-chip"
+								style="--tag-bg:{c.bg};--tag-text:{c.text}"
+								onclick={() => filterByTag(activeTagId === tag.id ? null : tag.id)}
+								title="Filter by {tag.name}"
+							><TagIcon size={9} />{tag.name}</button>
 						{/each}
 					</div>
 				{/if}
@@ -606,6 +668,43 @@
 		flex-shrink: 0;
 	}
 
+	/* ─── Sidebar tag filter ─────────────────────────────── */
+	.tag-filter {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.25rem;
+		padding: 0.4rem 0.75rem;
+		border-bottom: 1px solid #e5e7eb;
+		flex-shrink: 0;
+	}
+
+	.tag-pill {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.2rem;
+		padding: 0.15rem 0.55rem;
+		border: 1px solid #e5e7eb;
+		border-radius: 999px;
+		background: var(--tag-bg, transparent);
+		color: var(--tag-text, #6b7280);
+		font-size: 0.7rem;
+		font-weight: 500;
+		cursor: pointer;
+		transition: opacity 0.1s;
+	}
+	.tag-pill:hover { opacity: 0.8; }
+	.tag-pill-active {
+		border-color: var(--tag-text, #6366f1);
+		box-shadow: 0 0 0 1.5px var(--tag-text, #6366f1);
+	}
+	/* "All" pill has no CSS variables, use indigo */
+	.tag-pill:not([style]).tag-pill-active {
+		background: #e0e7ff;
+		color: #4338ca;
+		border-color: #6366f1;
+		box-shadow: 0 0 0 1.5px #6366f1;
+	}
+
 	/* ─── Tag toolbar popover ────────────────────────────── */
 	.tag-popover-wrap { position: relative; }
 
@@ -654,6 +753,13 @@
 	}
 	.popover-item:hover { background: #f3f4f6; }
 
+	.popover-tag-dot {
+		width: 0.5rem;
+		height: 0.5rem;
+		border-radius: 50%;
+		flex-shrink: 0;
+	}
+
 	.popover-new {
 		display: flex;
 		align-items: center;
@@ -683,7 +789,7 @@
 		display: flex;
 	}
 
-	/* ─── Editor header (title) ──────────────────────────── */
+	/* ─── Tag chips below note title ─────────────────────── */
 	.note-tag-chips {
 		display: flex;
 		flex-wrap: wrap;
@@ -695,12 +801,17 @@
 		display: inline-flex;
 		align-items: center;
 		gap: 0.2rem;
-		padding: 0.1rem 0.4rem;
-		background: #e0e7ff;
-		color: #4338ca;
+		padding: 0.1rem 0.45rem;
+		background: var(--tag-bg, #e0e7ff);
+		color: var(--tag-text, #4338ca);
 		border-radius: 999px;
 		font-size: 0.7rem;
+		font-weight: 500;
+		border: none;
+		cursor: pointer;
+		transition: opacity 0.1s;
 	}
+	.note-tag-chip:hover { opacity: 0.75; }
 
 	.title-input {
 		width: 100%;

--- a/frontend/src/routes/page.test.ts
+++ b/frontend/src/routes/page.test.ts
@@ -30,7 +30,7 @@ vi.mock('$lib/api', () => ({
 			archive: vi.fn(),
 			listArchived: vi.fn(),
 		},
-		tags: { list: vi.fn() },
+		tags: { list: vi.fn(), listForNote: vi.fn().mockResolvedValue([]) },
 		auth: { logout: vi.fn() },
 	},
 }));


### PR DESCRIPTION
## Summary

- Full tag management system: create tags, apply/remove via popover, 32-colour palette with Knuth hash for non-sequential colour distribution
- Sidebar tag filter with hover-to-expand (2 rows default, 4 on hover), no scrollbar flicker via `transitionend` gating
- Tag chips above note title; clicking a chip activates the sidebar filter
- Starred filter in sidebar; star/unstar notes from the note list
- Popover button pinned to right edge of editor header (absolute position), isolated from tag chip flow
- Scroll isolation: sidebar, note list, and note body each scroll independently; no page-level scrollbar
- Stale tag fix: `noteTags` cleared immediately on new note creation; `onMount` guarded against race condition on retry
- E2E tests: all `waitForResponse` calls registered before the triggering action; `.first()` on locators prone to duplicates from test retries

## Test plan

- [ ] CI E2E suite passes (tags.spec.ts + notes.spec.ts)
- [ ] Create a tag and verify chip appears above title with correct colour
- [ ] Filter by tag in sidebar; verify only tagged notes shown
- [ ] Click "All" to restore full list
- [ ] Click a tag chip in the editor to activate the sidebar filter
- [ ] Remove a tag via popover checkbox; verify chip disappears and sidebar pill removed when no notes have the tag
- [ ] Star a note and verify Starred filter works
- [ ] Create a new note; verify no stale tags from previously selected note

https://claude.ai/code/session_01Gq5dhZTkYYKcpAu4bnKyPR