### PR TITLE
Mobile interface: URL routing, tag filter fix, auth cookie fix

### DIFF
--- a/backend/internal/auth/handler.go
+++ b/backend/internal/auth/handler.go
@@ -16,6 +16,15 @@ func NewHandler(svc *Service) *Handler {
 	return &Handler{svc: svc}
 }
 
+// isHTTPS reports whether the request arrived over HTTPS — either directly
+// (r.TLS != nil) or via a reverse proxy that signals it with X-Forwarded-Proto.
+// This is used to set the Secure flag on cookies: hardcoding Secure:true breaks
+// plain-HTTP deployments because browsers silently discard secure cookies sent
+// over HTTP, making every session immediately invalid after login.
+func isHTTPS(r *http.Request) bool {
+	return r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https"
+}
+
 // Login handles POST /api/auth/login.
 // Body: {"username": "...", "password": "..."}
 // Sets an HttpOnly session cookie on success.
@@ -45,7 +54,7 @@ func (h *Handler) Login(w http.ResponseWriter, r *http.Request) {
 		Path:     "/",
 		Expires:  sess.ExpiresAt,
 		HttpOnly: true,
-		Secure:   true,
+		Secure:   isHTTPS(r),
 		SameSite: http.SameSiteStrictMode,
 	})
 
@@ -69,7 +78,7 @@ func (h *Handler) Logout(w http.ResponseWriter, r *http.Request) {
 		Path:     "/",
 		MaxAge:   -1,
 		HttpOnly: true,
-		Secure:   true,
+		Secure:   isHTTPS(r),
 		SameSite: http.SameSiteStrictMode,
 	})
 

--- a/backend/internal/auth/handler_test.go
+++ b/backend/internal/auth/handler_test.go
@@ -58,6 +58,71 @@ func TestHandler_Login_Success(t *testing.T) {
 	}
 }
 
+// Cookie Secure flag must follow the transport, not be hardcoded to true.
+// Hardcoding Secure:true breaks HTTP deployments because browsers silently
+// discard the cookie on every subsequent request, making the session useless.
+
+func TestHandler_Login_Cookie_NotSecure_OverHTTP(t *testing.T) {
+	h, svc := newTestHandler(t)
+	svc.SeedAdmin(t.Context(), "admin", "pass") //nolint:errcheck
+
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/login",
+		bytes.NewBufferString(`{"username":"admin","password":"pass"}`))
+	// Plain HTTP request: r.TLS is nil, no X-Forwarded-Proto header
+	w := httptest.NewRecorder()
+	h.Login(w, req)
+
+	cookie := findCookie(t, w.Result(), "session")
+	if cookie.Secure {
+		t.Fatal("session cookie must NOT be Secure over plain HTTP — browser will discard it")
+	}
+}
+
+func TestHandler_Login_Cookie_Secure_WhenForwardedProtoIsHTTPS(t *testing.T) {
+	h, svc := newTestHandler(t)
+	svc.SeedAdmin(t.Context(), "admin", "pass") //nolint:errcheck
+
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/login",
+		bytes.NewBufferString(`{"username":"admin","password":"pass"}`))
+	req.Header.Set("X-Forwarded-Proto", "https") // reverse proxy signals HTTPS
+	w := httptest.NewRecorder()
+	h.Login(w, req)
+
+	cookie := findCookie(t, w.Result(), "session")
+	if !cookie.Secure {
+		t.Fatal("session cookie must be Secure when behind an HTTPS reverse proxy")
+	}
+}
+
+func TestHandler_Logout_Cookie_MatchesTransport(t *testing.T) {
+	h, svc := newTestHandler(t)
+	svc.SeedAdmin(t.Context(), "admin", "pass") //nolint:errcheck
+	sess, _ := svc.Login(t.Context(), "admin", "pass")
+
+	// Over plain HTTP the cleared cookie should also not be Secure
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/logout", nil)
+	req.AddCookie(&http.Cookie{Name: "session", Value: sess.ID})
+	w := httptest.NewRecorder()
+	h.Logout(w, req)
+
+	cookie := findCookie(t, w.Result(), "session")
+	if cookie.Secure {
+		t.Fatal("logout cookie must NOT be Secure over plain HTTP")
+	}
+}
+
+// findCookie is a test helper that fails if the named cookie is absent.
+func findCookie(t *testing.T, resp *http.Response, name string) *http.Cookie {
+	t.Helper()
+	for _, c := range resp.Cookies() {
+		if c.Name == name {
+			return c
+		}
+	}
+	t.Fatalf("cookie %q not found in response", name)
+	return nil
+}
+
 func TestHandler_Login_BadCredentials(t *testing.T) {
 	h, svc := newTestHandler(t)
 	svc.SeedAdmin(t.Context(), "admin", "correct") //nolint:errcheck

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -23,7 +23,7 @@
 		Bold, Italic, Underline, Quote, Code, FileCode2,
 		List, ListOrdered, Minus, Undo2, Redo2,
 		Plus, Star, Pin, Archive, Trash2, Settings, LogOut,
-		ChevronLeft, ChevronRight, Search, Tag as TagIcon,
+		ChevronRight, Search, Tag as TagIcon,
 	} from 'lucide-svelte';
 
 	let notes = $state<Note[]>([]);
@@ -399,12 +399,6 @@
 		{#if selectedNote}
 			<!-- Toolbar (above title) -->
 			<div class="toolbar" role="toolbar" aria-label="Formatting">
-				<!-- Mobile back -->
-				<button class="tb-btn mobile-back" onclick={() => (mobileShowEditor = false)} title="Back to notes">
-					<ChevronLeft size={16} />
-				</button>
-				<span class="tb-sep mobile-sep"></span>
-
 				<button class="tb-btn" onclick={() => cmd(toggleStrongCommand.key)} title="Bold">
 					<Bold size={14} />
 				</button>
@@ -744,9 +738,6 @@
 
 	.save-status { font-size: 0.75rem; color: #9ca3af; white-space: nowrap; }
 
-	/* Mobile back button — hidden on desktop */
-	.mobile-back { display: none; }
-	.mobile-sep { display: none; }
 	.mobile-show-editor { display: none; }
 
 	/* ─── Editor header (tags + title) ─────────────────── */

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -146,9 +146,11 @@
 	let tagFilterScrollable = $state(false);
 
 	function onTagFilterMouseEnter() {
+		if (isMobile()) return; // touch devices fire mouseenter on tap — skip to avoid layout jump
 		tagFilterExpanded = true;
 	}
 	function onTagFilterMouseLeave() {
+		if (isMobile()) return;
 		tagFilterScrollable = false;
 		tagFilterExpanded = false;
 		if (tagFilterEl) tagFilterEl.scrollTop = 0;
@@ -990,6 +992,15 @@
 		.app {
 			flex-direction: column;
 			height: 100dvh;
+		}
+
+		/* Tag filter: on mobile the hover-expand is disabled (JS guard), so remove
+		   the max-height clip entirely — all tags always visible, no transition */
+		.filter-tags,
+		.filter-tags.expanded {
+			max-height: none;
+			overflow-y: visible;
+			transition: none;
 		}
 
 		/* On mobile the list is a full-screen page; tapping a note navigates to

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -32,8 +32,8 @@
 	let search = $state('');
 	let saving = $state(false);
 	let saveTimer: ReturnType<typeof setTimeout> | null = null;
-	// Mobile: track which panel is visible
-	let mobileShowEditor = $state(false);
+	// Helpers for detecting mobile viewport
+	function isMobile() { return window.matchMedia('(max-width: 767px)').matches; }
 	// Editor command ref
 	let editorRef = $state<EditorRef | null>(null);
 
@@ -107,7 +107,9 @@
 	onMount(async () => {
 		await loadNotes();
 		allTags = await api.tags.list();
-		if (notes.length > 0 && selectedId === null) {
+		// On mobile the list is the home screen; we never auto-open the editor.
+		// On desktop, pre-select the first note so the editor pane isn't empty.
+		if (!isMobile() && notes.length > 0 && selectedId === null) {
 			const initId = notes[0].id;
 			selectedId = initId;
 			const tags = await api.tags.listForNote(initId);
@@ -129,12 +131,12 @@
 		}
 		selectedId = note.id;
 		noteTags = [];
-		mobileShowEditor = true;
+		if (isMobile()) { goto(`/notes/${note.id}`); return; }
 	}
 
 	async function selectNote(id: number) {
+		if (isMobile()) { goto(`/notes/${id}`); return; }
 		selectedId = id;
-		mobileShowEditor = true;
 		showTagPopover = false;
 		noteTags = await api.tags.listForNote(id);
 	}
@@ -165,7 +167,6 @@
 		} else if (notes.length === 0) {
 			selectedId = null;
 			noteTags = [];
-			mobileShowEditor = false;
 		}
 	}
 
@@ -238,7 +239,6 @@
 		notes = notes.filter((n) => n.id !== id);
 		if (selectedId === id) {
 			selectedId = notes.length > 0 ? notes[0].id : null;
-			if (!selectedId) mobileShowEditor = false;
 		}
 	}
 
@@ -247,7 +247,6 @@
 		notes = notes.filter((n) => n.id !== id);
 		if (selectedId === id) {
 			selectedId = notes.length > 0 ? notes[0].id : null;
-			if (!selectedId) mobileShowEditor = false;
 		}
 	}
 
@@ -274,13 +273,13 @@
 	<title>Crapnote</title>
 </svelte:head>
 
-<div class="app" class:mobile-editor={mobileShowEditor}>
+<div class="app">
 	<!-- ── Sidebar ── -->
 	<aside class="sidebar">
 		<header class="sidebar-header">
 			<span class="app-name">Crapnote</span>
 			{#if selectedId}
-				<button class="hdr-btn mobile-show-editor" onclick={() => (mobileShowEditor = true)} title="View note" aria-label="View note">
+				<button class="hdr-btn mobile-show-editor" onclick={() => goto(`/notes/${selectedId}`)} title="View note" aria-label="View note">
 					<ChevronRight size={18} />
 				</button>
 			{/if}
@@ -993,7 +992,8 @@
 			height: 100dvh;
 		}
 
-		/* On mobile, sidebar is full screen by default */
+		/* On mobile the list is a full-screen page; tapping a note navigates to
+		   /notes/[id] via SvelteKit routing — the editor pane is never shown here */
 		.sidebar {
 			width: 100%;
 			min-width: unset;
@@ -1002,22 +1002,9 @@
 			overflow: hidden;
 		}
 
-		/* Editor pane hidden unless we're in mobile-editor mode */
-		.editor-pane {
-			display: none;
-			position: fixed;
-			inset: 0;
-			z-index: 10;
-			background: #fff;
-		}
+		.editor-pane { display: none; }
 
-		/* When a note is selected on mobile, show editor full-screen */
-		.app.mobile-editor .sidebar { display: none; }
-		.app.mobile-editor .editor-pane { display: flex; }
-
-		/* Show mobile back button */
-		.mobile-back { display: flex; }
-		.mobile-sep { display: block; }
+		/* Show the chevron button to navigate to the currently-selected note */
 		.mobile-show-editor { display: flex; }
 
 		/* Tighter sidebar padding */

--- a/frontend/src/routes/notes/[id]/+page.svelte
+++ b/frontend/src/routes/notes/[id]/+page.svelte
@@ -1,0 +1,419 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+	import { page } from '$app/stores';
+	import {
+		toggleStrongCommand,
+		toggleEmphasisCommand,
+		toggleInlineCodeCommand,
+		wrapInBlockquoteCommand,
+		wrapInBulletListCommand,
+		wrapInOrderedListCommand,
+		insertHrCommand,
+		createCodeBlockCommand,
+	} from '@milkdown/kit/preset/commonmark';
+	import { undoCommand, redoCommand } from '@milkdown/kit/plugin/history';
+	import { toggleUnderlineCommand } from '$lib/milkdown/underline';
+	import type { CmdKey } from '@milkdown/kit/core';
+	import { api, type Note, type Tag } from '$lib/api';
+	import Editor, { type EditorRef } from '$lib/components/Editor.svelte';
+	import {
+		Bold, Italic, Underline, Quote, Code, FileCode2,
+		List, ListOrdered, Minus, Undo2, Redo2,
+		Plus, ChevronLeft, Tag as TagIcon,
+	} from 'lucide-svelte';
+
+	const noteId = $derived(Number($page.params.id));
+
+	let note = $state<Note | null>(null);
+	let noteTags = $state<Tag[]>([]);
+	let allTags = $state<Tag[]>([]);
+	let saving = $state(false);
+	let saveTimer: ReturnType<typeof setTimeout> | null = null;
+	let editorRef = $state<EditorRef | null>(null);
+	let showTagPopover = $state(false);
+	let newTagName = $state('');
+
+	// Same palette + hash as the main notes list so tag colours are consistent
+	const PALETTE = [
+		{ bg: '#fee2e2', text: '#991b1b' },
+		{ bg: '#fce7f3', text: '#831843' },
+		{ bg: '#ffe4e6', text: '#881337' },
+		{ bg: '#fecdd3', text: '#9f1239' },
+		{ bg: '#ffedd5', text: '#9a3412' },
+		{ bg: '#fef3c7', text: '#78350f' },
+		{ bg: '#fef9c3', text: '#854d0e' },
+		{ bg: '#ecfccb', text: '#365314' },
+		{ bg: '#dcfce7', text: '#166534' },
+		{ bg: '#d1fae5', text: '#064e3b' },
+		{ bg: '#ccfbf1', text: '#134e4a' },
+		{ bg: '#cffafe', text: '#164e63' },
+		{ bg: '#e0f2fe', text: '#0c4a6e' },
+		{ bg: '#dbeafe', text: '#1e3a8a' },
+		{ bg: '#e0e7ff', text: '#3730a3' },
+		{ bg: '#ede9fe', text: '#4c1d95' },
+		{ bg: '#f3e8ff', text: '#6b21a8' },
+		{ bg: '#fae8ff', text: '#86198f' },
+		{ bg: '#fecaca', text: '#7f1d1d' },
+		{ bg: '#fbcfe8', text: '#9d174d' },
+		{ bg: '#fda4af', text: '#881337' },
+		{ bg: '#fed7aa', text: '#7c2d12' },
+		{ bg: '#fde68a', text: '#78350f' },
+		{ bg: '#bbf7d0', text: '#14532d' },
+		{ bg: '#99f6e4', text: '#134e4a' },
+		{ bg: '#bae6fd', text: '#0c4a6e' },
+		{ bg: '#bfdbfe', text: '#1e40af' },
+		{ bg: '#c7d2fe', text: '#3730a3' },
+		{ bg: '#ddd6fe', text: '#5b21b6' },
+		{ bg: '#e9d5ff', text: '#6b21a8' },
+		{ bg: '#f5d0fe', text: '#86198f' },
+		{ bg: '#a7f3d0', text: '#064e3b' },
+	] as const;
+
+	function tagColor(tag: Tag) {
+		return PALETTE[Math.imul(tag.id, 0x9e3779b9) >>> 27];
+	}
+
+	onMount(async () => {
+		[note, noteTags, allTags] = await Promise.all([
+			api.notes.get(noteId),
+			api.tags.listForNote(noteId),
+			api.tags.list(),
+		]);
+	});
+
+	function scheduleAutoSave(field: 'title' | 'body', value: string) {
+		if (saveTimer) clearTimeout(saveTimer);
+		saveTimer = setTimeout(async () => {
+			saving = true;
+			try {
+				const updated = await api.notes.update(noteId, { [field]: value });
+				note = updated;
+			} finally {
+				saving = false;
+			}
+		}, 800);
+	}
+
+	function cmd(key: string | CmdKey<unknown>, payload?: unknown) {
+		editorRef?.call(key, payload);
+	}
+
+	async function toggleTag(tag: Tag) {
+		const has = noteTags.find(t => t.id === tag.id);
+		if (has) {
+			await api.tags.removeFromNote(noteId, tag.id);
+			noteTags = noteTags.filter(t => t.id !== tag.id);
+		} else {
+			await api.tags.addToNote(noteId, tag.id);
+			noteTags = [...noteTags, tag];
+		}
+		allTags = await api.tags.list();
+	}
+
+	async function createAndAddTag() {
+		if (!newTagName.trim()) return;
+		const name = newTagName.trim();
+		let tag = allTags.find(t => t.name.toLowerCase() === name.toLowerCase());
+		if (!tag) {
+			tag = await api.tags.create(name);
+		}
+		if (!noteTags.find(t => t.id === tag!.id)) {
+			await api.tags.addToNote(noteId, tag.id);
+			noteTags = [...noteTags, tag];
+		}
+		newTagName = '';
+		allTags = await api.tags.list();
+	}
+</script>
+
+<svelte:head>
+	<title>{note?.title || 'Note'} — Crapnote</title>
+</svelte:head>
+
+{#if note}
+<div class="note-page">
+	<div class="toolbar" role="toolbar" aria-label="Formatting">
+		<button class="tb-btn" onclick={() => goto('/')} title="Back to notes" aria-label="Back to notes">
+			<ChevronLeft size={16} />
+		</button>
+		<span class="tb-sep"></span>
+
+		<button class="tb-btn" onclick={() => cmd(toggleStrongCommand.key)} title="Bold"><Bold size={14} /></button>
+		<button class="tb-btn" onclick={() => cmd(toggleEmphasisCommand.key)} title="Italic"><Italic size={14} /></button>
+		<button class="tb-btn" onclick={() => cmd(toggleUnderlineCommand.key)} title="Underline"><Underline size={14} /></button>
+		<span class="tb-sep"></span>
+		<button class="tb-btn" onclick={() => cmd(wrapInBlockquoteCommand.key)} title="Quote"><Quote size={14} /></button>
+		<button class="tb-btn" onclick={() => cmd(toggleInlineCodeCommand.key)} title="Inline code"><Code size={14} /></button>
+		<button class="tb-btn" onclick={() => cmd(createCodeBlockCommand.key)} title="Code block"><FileCode2 size={14} /></button>
+		<span class="tb-sep"></span>
+		<button class="tb-btn" onclick={() => cmd(wrapInBulletListCommand.key)} title="Bullet list"><List size={14} /></button>
+		<button class="tb-btn" onclick={() => cmd(wrapInOrderedListCommand.key)} title="Numbered list"><ListOrdered size={14} /></button>
+		<button class="tb-btn" onclick={() => cmd(insertHrCommand.key)} title="Horizontal rule"><Minus size={14} /></button>
+		<span class="tb-sep"></span>
+		<button class="tb-btn" onclick={() => cmd(undoCommand.key)} title="Undo"><Undo2 size={14} /></button>
+		<button class="tb-btn" onclick={() => cmd(redoCommand.key)} title="Redo"><Redo2 size={14} /></button>
+		<span class="tb-spacer"></span>
+		<span class="save-status">{saving ? 'Saving…' : ''}</span>
+	</div>
+
+	<div class="editor-header">
+		{#if noteTags.length > 0}
+			<div class="note-tags-chips">
+				{#each noteTags as tag (tag.id)}
+					{@const c = tagColor(tag)}
+					<span class="note-tag-chip" style="--tag-bg:{c.bg};--tag-text:{c.text}">
+						<TagIcon size={9} />{tag.name}
+					</span>
+				{/each}
+			</div>
+		{/if}
+		<input
+			class="title-input"
+			type="text"
+			value={note.title}
+			oninput={(e) => scheduleAutoSave('title', (e.target as HTMLInputElement).value)}
+			placeholder="Note title"
+		/>
+		<div class="tag-popover-wrap">
+			<button
+				class="tag-chip-btn"
+				class:tag-chip-btn-active={noteTags.length > 0}
+				onclick={() => (showTagPopover = !showTagPopover)}
+				title="Tags"
+			>
+				<TagIcon size={11} />
+				{#if noteTags.length > 0}<span class="tb-tag-count">{noteTags.length}</span>{/if}
+			</button>
+			{#if showTagPopover}
+				<div class="tag-popover">
+					<p class="popover-label">Tags</p>
+					{#each allTags as tag (tag.id)}
+						{@const c = tagColor(tag)}
+						<label class="popover-item">
+							<input type="checkbox" checked={!!noteTags.find(t => t.id === tag.id)} onchange={() => toggleTag(tag)} />
+							<span class="popover-tag-dot" style="background:{c.text}"></span>
+							{tag.name}
+						</label>
+					{/each}
+					<div class="popover-new">
+						<input
+							class="popover-new-input"
+							type="text"
+							placeholder="New tag…"
+							bind:value={newTagName}
+							onkeydown={(e) => e.key === 'Enter' && createAndAddTag()}
+						/>
+						<button class="popover-add-btn" onclick={createAndAddTag}><Plus size={12} /></button>
+					</div>
+				</div>
+			{/if}
+		</div>
+	</div>
+
+	{#key noteId}
+		<Editor
+			value={note.body}
+			onchange={(md) => scheduleAutoSave('body', md)}
+			bind:ref={editorRef}
+		/>
+	{/key}
+</div>
+{:else}
+<div class="loading">Loading…</div>
+{/if}
+
+<style>
+	.note-page {
+		display: flex;
+		flex-direction: column;
+		height: 100dvh;
+		background: #fff;
+	}
+
+	.loading {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		height: 100dvh;
+		color: #9ca3af;
+		font-size: 0.875rem;
+	}
+
+	/* ─── Toolbar ──────────────────────────────── */
+	.toolbar {
+		display: flex;
+		align-items: center;
+		gap: 0.125rem;
+		padding: 0.375rem 0.75rem;
+		border-bottom: 1px solid #e5e7eb;
+		background: #fafafa;
+		flex-shrink: 0;
+		flex-wrap: wrap;
+	}
+
+	.tb-btn {
+		padding: 0.3rem 0.4rem;
+		background: none;
+		border: 1px solid transparent;
+		border-radius: 0.25rem;
+		cursor: pointer;
+		color: #374151;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+	.tb-btn:hover { background: #e5e7eb; border-color: #d1d5db; }
+	.tb-btn:active { background: #dbeafe; border-color: #93c5fd; }
+
+	.tb-sep {
+		width: 1px;
+		height: 1rem;
+		background: #e5e7eb;
+		margin: 0 0.2rem;
+		flex-shrink: 0;
+	}
+	.tb-spacer { flex: 1; }
+	.save-status { font-size: 0.75rem; color: #9ca3af; white-space: nowrap; }
+
+	/* ─── Editor header ────────────────────────── */
+	.editor-header {
+		position: relative;
+		padding: 0.45rem 5rem 0.45rem 1rem;
+		border-bottom: 1px solid #e5e7eb;
+		flex-shrink: 0;
+	}
+
+	.note-tags-chips {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.25rem;
+		margin-bottom: 0.3rem;
+	}
+
+	.note-tag-chip {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.2rem;
+		padding: 0.1rem 0.45rem;
+		background: var(--tag-bg, #e0e7ff);
+		color: var(--tag-text, #4338ca);
+		border-radius: 999px;
+		font-size: 0.7rem;
+		font-weight: 500;
+	}
+
+	.title-input {
+		width: 100%;
+		font-size: 1.25rem;
+		font-weight: 600;
+		border: none;
+		outline: none;
+		padding: 0;
+		background: transparent;
+		font-family: system-ui, -apple-system, sans-serif;
+		color: #111827;
+	}
+
+	/* ─── Tag popover ──────────────────────────── */
+	.tag-popover-wrap {
+		position: absolute;
+		top: 0.45rem;
+		right: 1rem;
+	}
+
+	.tag-chip-btn {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.2rem;
+		padding: 0.1rem 0.45rem;
+		background: transparent;
+		color: #9ca3af;
+		border-radius: 999px;
+		font-size: 0.7rem;
+		font-weight: 500;
+		border: 1px dashed #d1d5db;
+		cursor: pointer;
+		transition: all 0.1s;
+	}
+	.tag-chip-btn:hover { background: #f3f4f6; color: #374151; border-color: #9ca3af; }
+	.tag-chip-btn-active { color: #6366f1; border-color: #6366f1; }
+
+	.tb-tag-count {
+		background: #6366f1;
+		color: white;
+		border-radius: 999px;
+		padding: 0 0.3rem;
+		font-size: 0.6rem;
+	}
+
+	.tag-popover {
+		position: absolute;
+		right: 0;
+		top: calc(100% + 4px);
+		background: white;
+		border: 1px solid #e5e7eb;
+		border-radius: 0.5rem;
+		box-shadow: 0 4px 16px rgba(0,0,0,0.12);
+		padding: 0.5rem;
+		min-width: 11rem;
+		z-index: 30;
+	}
+
+	.popover-label {
+		font-size: 0.7rem;
+		font-weight: 600;
+		color: #9ca3af;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		margin: 0 0 0.25rem;
+		padding: 0 0.25rem;
+	}
+
+	.popover-item {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.3rem 0.25rem;
+		border-radius: 0.25rem;
+		cursor: pointer;
+		font-size: 0.85rem;
+	}
+	.popover-item:hover { background: #f3f4f6; }
+
+	.popover-tag-dot {
+		width: 0.5rem;
+		height: 0.5rem;
+		border-radius: 50%;
+		flex-shrink: 0;
+	}
+
+	.popover-new {
+		display: flex;
+		align-items: center;
+		gap: 0.25rem;
+		margin-top: 0.375rem;
+		padding-top: 0.375rem;
+		border-top: 1px solid #f3f4f6;
+	}
+
+	.popover-new-input {
+		flex: 1;
+		border: none;
+		border-bottom: 1px solid #d1d5db;
+		outline: none;
+		font-size: 0.8rem;
+		padding: 0.15rem 0.1rem;
+		background: transparent;
+	}
+	.popover-new-input:focus { border-color: #6366f1; }
+
+	.popover-add-btn {
+		background: none;
+		border: none;
+		cursor: pointer;
+		color: #6366f1;
+		padding: 0.1rem;
+		display: flex;
+	}
+</style>

--- a/frontend/src/routes/notes/[id]/page.test.ts
+++ b/frontend/src/routes/notes/[id]/page.test.ts
@@ -1,0 +1,166 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import NotePage from './+page.svelte';
+
+vi.mock('@milkdown/kit/preset/commonmark', () => ({
+	toggleStrongCommand: { key: 'ToggleStrong' },
+	toggleEmphasisCommand: { key: 'ToggleEmphasis' },
+	toggleInlineCodeCommand: { key: 'ToggleInlineCode' },
+	wrapInBlockquoteCommand: { key: 'WrapInBlockquote' },
+	wrapInBulletListCommand: { key: 'WrapInBulletList' },
+	wrapInOrderedListCommand: { key: 'WrapInOrderedList' },
+	insertHrCommand: { key: 'InsertHr' },
+	createCodeBlockCommand: { key: 'CreateCodeBlock' },
+}));
+vi.mock('@milkdown/kit/plugin/history', () => ({
+	undoCommand: { key: 'Undo' },
+	redoCommand: { key: 'Redo' },
+}));
+vi.mock('$lib/milkdown/underline', () => ({
+	underlinePlugin: [],
+	toggleUnderlineCommand: { key: 'ToggleUnderline' },
+}));
+vi.mock('$lib/components/Editor.svelte', async () => ({
+	default: (anchor: unknown, props: unknown) => { void anchor; void props; },
+}));
+
+// Override the page store to supply a real note id in params
+vi.mock('$app/stores', async () => {
+	const { readable } = await import('svelte/store');
+	return {
+		page: readable({
+			params: { id: '42' },
+			url: new URL('http://localhost/notes/42'),
+			route: { id: '/notes/[id]' },
+			status: 200,
+			error: null,
+			data: {},
+			form: undefined,
+			state: {},
+		}),
+		navigating: readable(null),
+		updated: readable(false),
+	};
+});
+
+vi.mock('$app/navigation', () => ({ goto: vi.fn() }));
+
+vi.mock('$lib/api', () => ({
+	api: {
+		notes: { get: vi.fn(), update: vi.fn() },
+		tags: {
+			list: vi.fn(),
+			listForNote: vi.fn(),
+			addToNote: vi.fn(),
+			removeFromNote: vi.fn(),
+			create: vi.fn(),
+		},
+	},
+}));
+
+import { api } from '$lib/api';
+import { goto } from '$app/navigation';
+
+const mockNote = (overrides = {}) => ({
+	id: 42, title: 'My Note', body: '# Hello',
+	starred: false, pinned: false, archived: false,
+	created_at: '2024-01-01T00:00:00Z', updated_at: '2024-01-01T00:00:00Z',
+	...overrides,
+});
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	vi.mocked(api.notes.get).mockResolvedValue(mockNote());
+	vi.mocked(api.tags.listForNote).mockResolvedValue([]);
+	vi.mocked(api.tags.list).mockResolvedValue([]);
+});
+
+describe('/notes/[id] page', () => {
+	it('shows the note title after loading', async () => {
+		render(NotePage);
+		await waitFor(() => expect(screen.getByDisplayValue('My Note')).toBeInTheDocument());
+	});
+
+	it('loads note with the id from the route params', async () => {
+		render(NotePage);
+		await waitFor(() => expect(api.notes.get).toHaveBeenCalledWith(42));
+	});
+
+	it('loads note tags on mount', async () => {
+		render(NotePage);
+		await waitFor(() => expect(api.tags.listForNote).toHaveBeenCalledWith(42));
+	});
+
+	it('back button navigates to /', async () => {
+		render(NotePage);
+		await waitFor(() => screen.getByDisplayValue('My Note'));
+
+		await fireEvent.click(screen.getByRole('button', { name: /back to notes/i }));
+		expect(goto).toHaveBeenCalledWith('/');
+	});
+
+	it('title input change schedules auto-save', async () => {
+		vi.useFakeTimers();
+		vi.mocked(api.notes.update).mockResolvedValue(mockNote({ title: 'New Title' }));
+
+		render(NotePage);
+		await waitFor(() => screen.getByDisplayValue('My Note'));
+
+		await fireEvent.input(screen.getByDisplayValue('My Note'), {
+			target: { value: 'New Title' },
+		});
+
+		// Auto-save fires after 800 ms debounce
+		vi.advanceTimersByTime(800);
+		await waitFor(() =>
+			expect(api.notes.update).toHaveBeenCalledWith(42, { title: 'New Title' })
+		);
+		vi.useRealTimers();
+	});
+
+	it('renders the formatting toolbar', async () => {
+		render(NotePage);
+		await waitFor(() =>
+			expect(screen.getByRole('toolbar', { name: /formatting/i })).toBeInTheDocument()
+		);
+	});
+
+	it('shows existing tags as checkboxes in the popover when opened', async () => {
+		vi.mocked(api.tags.list).mockResolvedValue([
+			{ id: 1, name: 'Work', note_count: 2 },
+		]);
+		vi.mocked(api.tags.listForNote).mockResolvedValue([
+			{ id: 1, name: 'Work', note_count: 2 },
+		]);
+
+		render(NotePage);
+		await waitFor(() => screen.getByDisplayValue('My Note'));
+
+		// Open tag popover — popover shows one checkbox per tag
+		await fireEvent.click(screen.getByTitle('Tags'));
+		await waitFor(() => expect(screen.getByRole('checkbox')).toBeInTheDocument());
+	});
+
+	it('removes a tag when its checkbox is unchecked', async () => {
+		vi.mocked(api.tags.list).mockResolvedValue([
+			{ id: 1, name: 'Work', note_count: 2 },
+		]);
+		vi.mocked(api.tags.listForNote).mockResolvedValue([
+			{ id: 1, name: 'Work', note_count: 2 },
+		]);
+		vi.mocked(api.tags.removeFromNote).mockResolvedValue(undefined);
+		vi.mocked(api.tags.list)
+			.mockResolvedValueOnce([{ id: 1, name: 'Work', note_count: 2 }]) // initial load
+			.mockResolvedValue([{ id: 1, name: 'Work', note_count: 1 }]);   // after remove
+
+		render(NotePage);
+		await waitFor(() => screen.getByDisplayValue('My Note'));
+
+		await fireEvent.click(screen.getByTitle('Tags'));
+		const checkbox = await waitFor(() => screen.getByRole('checkbox'));
+		await fireEvent.change(checkbox);
+		await waitFor(() =>
+			expect(api.tags.removeFromNote).toHaveBeenCalledWith(42, 1)
+		);
+	});
+});

--- a/frontend/src/routes/page.test.ts
+++ b/frontend/src/routes/page.test.ts
@@ -52,6 +52,20 @@ vi.mock('$lib/milkdown/underline', () => ({
 
 import { api } from '$lib/api';
 
+// Helper: override matchMedia to simulate a mobile or desktop viewport for one test.
+function mockViewport(mobile: boolean) {
+	vi.stubGlobal('matchMedia', vi.fn().mockImplementation((query: string) => ({
+		matches: mobile && query === '(max-width: 767px)',
+		media: query,
+		onchange: null,
+		addListener: vi.fn(),
+		removeListener: vi.fn(),
+		addEventListener: vi.fn(),
+		removeEventListener: vi.fn(),
+		dispatchEvent: vi.fn(),
+	})));
+}
+
 const mockNote = (overrides = {}) => ({
 	id: 1, title: 'Test Note', body: '# Hello',
 	starred: false, pinned: false, archived: false,
@@ -124,5 +138,105 @@ describe('Notes page', () => {
 	it('renders formatting toolbar', async () => {
 		render(Page);
 		await waitFor(() => expect(screen.getByRole('toolbar', { name: /formatting/i })).toBeInTheDocument());
+	});
+});
+
+describe('Mobile navigation', () => {
+	beforeEach(() => {
+		mockViewport(true); // mobile for every test in this block
+	});
+
+	it('clicking a note navigates to /notes/[id] on mobile', async () => {
+		const { goto } = await import('$app/navigation');
+		render(Page);
+		await waitFor(() => screen.getByText('Test Note'));
+
+		// Click the note button
+		const noteBtn = screen.getAllByRole('button').find(
+			(b) => b.classList.contains('note-btn')
+		);
+		await fireEvent.click(noteBtn!);
+
+		await waitFor(() => expect(goto).toHaveBeenCalledWith('/notes/1'));
+	});
+
+	it('new note navigates to /notes/[id] on mobile', async () => {
+		const { goto } = await import('$app/navigation');
+		vi.mocked(api.notes.create).mockResolvedValueOnce(
+			{ id: 99, title: '', body: '', starred: false, pinned: false, archived: false,
+			  created_at: '', updated_at: '' }
+		);
+
+		render(Page);
+		await waitFor(() => screen.getByText('Test Note'));
+
+		// Grab the sidebar header button specifically (title attr distinguishes it from
+		// the empty-state button which is CSS-hidden on mobile but still in the DOM)
+		const newBtn = screen.getByTitle('New note');
+		await fireEvent.click(newBtn);
+
+		await waitFor(() => expect(goto).toHaveBeenCalledWith('/notes/99'));
+	});
+
+	it('clicking a note on desktop does NOT navigate — shows editor in-pane', async () => {
+		mockViewport(false); // override to desktop
+		const { goto } = await import('$app/navigation');
+		vi.mocked(api.tags.listForNote).mockResolvedValue([]);
+
+		render(Page);
+		await waitFor(() => screen.getByText('Test Note'));
+
+		const noteBtn = screen.getAllByRole('button').find(
+			(b) => b.classList.contains('note-btn')
+		);
+		await fireEvent.click(noteBtn!);
+
+		// No navigation on desktop
+		expect(goto).not.toHaveBeenCalledWith(expect.stringMatching(/\/notes\//));
+	});
+});
+
+describe('Tag filter hover', () => {
+	const mockTags = [
+		{ id: 1, name: 'Alpha', note_count: 1 },
+		{ id: 2, name: 'Beta',  note_count: 1 },
+	];
+
+	beforeEach(() => {
+		vi.mocked(api.tags.list).mockResolvedValue(mockTags);
+	});
+
+	it('adds expanded class on mouseenter on desktop', async () => {
+		mockViewport(false); // desktop
+		render(Page);
+		await waitFor(() => screen.getByText('Alpha'));
+
+		const filterTags = screen.getByRole('group', { name: /tag filters/i });
+		await fireEvent.mouseEnter(filterTags);
+
+		expect(filterTags).toHaveClass('expanded');
+	});
+
+	it('does NOT add expanded class on mouseenter on mobile', async () => {
+		mockViewport(true); // mobile
+		render(Page);
+		await waitFor(() => screen.getByText('Alpha'));
+
+		const filterTags = screen.getByRole('group', { name: /tag filters/i });
+		await fireEvent.mouseEnter(filterTags);
+
+		expect(filterTags).not.toHaveClass('expanded');
+	});
+
+	it('removes expanded class on mouseleave on desktop', async () => {
+		mockViewport(false); // desktop
+		render(Page);
+		await waitFor(() => screen.getByText('Alpha'));
+
+		const filterTags = screen.getByRole('group', { name: /tag filters/i });
+		await fireEvent.mouseEnter(filterTags);
+		await fireEvent.mouseLeave(filterTags);
+
+		expect(filterTags).not.toHaveClass('expanded');
 	});
 });

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -1,1 +1,19 @@
 import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+
+// jsdom doesn't implement window.matchMedia.  Default to desktop (matches: false)
+// so tests that don't care about breakpoints behave like a desktop browser.
+// Individual tests can override with vi.stubGlobal('matchMedia', ...).
+Object.defineProperty(window, 'matchMedia', {
+	writable: true,
+	value: vi.fn().mockImplementation((query: string) => ({
+		matches: false,
+		media: query,
+		onchange: null,
+		addListener: vi.fn(),
+		removeListener: vi.fn(),
+		addEventListener: vi.fn(),
+		removeEventListener: vi.fn(),
+		dispatchEvent: vi.fn(),
+	})),
+});


### PR DESCRIPTION
## Summary

- **Mobile navigation**: on mobile, tapping a note navigates to \`/notes/[id]\` (a new dedicated route) rather than toggling a CSS panel. Back button works natively. Desktop two-panel layout is unchanged.
- **Tag filter hover glitch**: touch events were firing \`mouseenter\` on the filter bar, causing a 1–3 px layout jump. Fixed with a JS guard (\`isMobile()\` early return) and a CSS \`max-height: none\` override on mobile.
- **Session cookie \`Secure\` flag**: was hardcoded \`true\`, silently breaking HTTP deployments — the browser discards secure cookies over HTTP, so every API call after login was unauthenticated (no notes, no writes). Now derived from actual transport (\`r.TLS != nil\` or \`X-Forwarded-Proto: https\`).

## Test plan

- [ ] Log in on a phone over HTTP — notes load, new notes can be created
- [ ] Tapping a note opens the editor; back button returns to list
- [ ] Hovering the tag filter on mobile no longer causes a layout jump
- [ ] Behind an HTTPS reverse proxy — session cookie still has \`Secure: true\`
- [ ] 56 frontend tests pass (\`npm test\`)
- [ ] All backend tests pass (\`go test -tags sqlite_fts5 ./...\`)

https://claude.ai/code/session_01Ly6pFPM7nwfDGmaPJRPryy