### PR TITLE
Add image upload, storage, and export support

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/danpicton/crapnote/internal/auth"
 	"github.com/danpicton/crapnote/internal/db"
 	"github.com/danpicton/crapnote/internal/export"
+	"github.com/danpicton/crapnote/internal/images"
 	"github.com/danpicton/crapnote/internal/notes"
 	"github.com/danpicton/crapnote/internal/tags"
 	"github.com/danpicton/crapnote/internal/trash"
@@ -71,8 +72,10 @@ func main() {
 		}
 	}()
 
+	imagesHandler := images.NewHandler(database)
+
 	port := envOrDefault("PORT", "8080")
-	mux := newMux(authHandler, adminHandler, notesHandler, tagsHandler, trashHandler, exportHandler)
+	mux := newMux(authHandler, adminHandler, notesHandler, tagsHandler, trashHandler, exportHandler, imagesHandler)
 
 	addr := fmt.Sprintf(":%s", port)
 	log.Printf("listening on %s", addr)

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -45,7 +45,7 @@ func main() {
 
 	notesSvc := notes.NewService(notes.NewRepo(database))
 	notesHandler := notes.NewHandler(notesSvc)
-	exportHandler := export.NewHandler(notesSvc)
+	exportHandler := export.NewHandler(notesSvc, database)
 	tagsHandler := tags.NewHandler(tags.NewService(tags.NewRepo(database)))
 
 	trashRepo := trash.NewRepo(database)

--- a/backend/cmd/server/server.go
+++ b/backend/cmd/server/server.go
@@ -6,18 +6,20 @@ import (
 
 	"github.com/danpicton/crapnote/internal/auth"
 	"github.com/danpicton/crapnote/internal/export"
+	"github.com/danpicton/crapnote/internal/images"
 	"github.com/danpicton/crapnote/internal/notes"
 	"github.com/danpicton/crapnote/internal/tags"
 	"github.com/danpicton/crapnote/internal/trash"
 )
 
 func newMux(
-	authHandler   *auth.Handler,
-	adminHandler  *auth.AdminHandler,
-	notesHandler  *notes.Handler,
-	tagsHandler   *tags.Handler,
-	trashHandler  *trash.Handler,
-	exportHandler *export.Handler,
+	authHandler    *auth.Handler,
+	adminHandler   *auth.AdminHandler,
+	notesHandler   *notes.Handler,
+	tagsHandler    *tags.Handler,
+	trashHandler   *trash.Handler,
+	exportHandler  *export.Handler,
+	imagesHandler  *images.Handler,
 ) *http.ServeMux {
 	mux := http.NewServeMux()
 
@@ -68,6 +70,10 @@ func newMux(
 
 	// Export
 	protected("GET", "/api/export", exportHandler.Export)
+
+	// Images
+	protected("POST", "/api/images", imagesHandler.Upload)
+	protected("GET", "/api/images/{id}", imagesHandler.Serve)
 
 	// Trash
 	protected("GET", "/api/trash", trashHandler.List)

--- a/backend/cmd/server/server_test.go
+++ b/backend/cmd/server/server_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/danpicton/crapnote/internal/auth"
 	"github.com/danpicton/crapnote/internal/db"
 	"github.com/danpicton/crapnote/internal/export"
+	"github.com/danpicton/crapnote/internal/images"
 	"github.com/danpicton/crapnote/internal/notes"
 	"github.com/danpicton/crapnote/internal/tags"
 	"github.com/danpicton/crapnote/internal/trash"
@@ -36,7 +37,8 @@ func newTestMux(t *testing.T) *http.ServeMux {
 		notes.NewHandler(notesSvc),
 		tags.NewHandler(tags.NewService(tags.NewRepo(database))),
 		trash.NewHandler(trash.NewService(trash.NewRepo(database))),
-		export.NewHandler(notesSvc),
+		export.NewHandler(notesSvc, database),
+		images.NewHandler(database),
 	)
 }
 

--- a/backend/internal/db/migrations/000007_images.down.sql
+++ b/backend/internal/db/migrations/000007_images.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_images_user_id;
+DROP TABLE IF EXISTS images;

--- a/backend/internal/db/migrations/000007_images.up.sql
+++ b/backend/internal/db/migrations/000007_images.up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS images (
+    id         TEXT     PRIMARY KEY,
+    user_id    INTEGER  NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    mime_type  TEXT     NOT NULL,
+    data       BLOB     NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_images_user_id ON images(user_id);

--- a/backend/internal/export/export.go
+++ b/backend/internal/export/export.go
@@ -11,6 +11,7 @@ import (
 
 	yzip "github.com/yeka/zip"
 
+	"github.com/danpicton/crapnote/internal/images"
 	"github.com/danpicton/crapnote/internal/notes"
 )
 
@@ -19,6 +20,8 @@ var (
 	unsafeChars = regexp.MustCompile(`[/\\:*?"<>|]+`)
 	// collapseSpaces replaces runs of whitespace/hyphens with a single hyphen.
 	collapseSpaces = regexp.MustCompile(`[\s\-]+`)
+	// imageAPIPath matches /api/images/<id> inside src="…" attributes.
+	imageAPIPath = regexp.MustCompile(`/api/images/([a-f0-9\-]+)`)
 )
 
 // sanitiseFilename turns an arbitrary title into a safe .md filename.
@@ -47,11 +50,101 @@ func sanitiseFilename(title string) string {
 	return s + ".md"
 }
 
+// mimeToExt returns a file extension (without dot) for common image MIME types.
+func mimeToExt(mimeType string) string {
+	switch strings.ToLower(strings.TrimSpace(mimeType)) {
+	case "image/png":
+		return "png"
+	case "image/jpeg", "image/jpg":
+		return "jpg"
+	case "image/gif":
+		return "gif"
+	case "image/webp":
+		return "webp"
+	case "image/svg+xml":
+		return "svg"
+	case "image/avif":
+		return "avif"
+	default:
+		// Fall back to the subtype part, e.g. "image/tiff" → "tiff".
+		if idx := strings.Index(mimeType, "/"); idx >= 0 {
+			return mimeType[idx+1:]
+		}
+		return "bin"
+	}
+}
+
+// extractImageIDs returns the unique image IDs referenced in a note body.
+func extractImageIDs(body string) []string {
+	matches := imageAPIPath.FindAllStringSubmatch(body, -1)
+	seen := make(map[string]struct{})
+	var ids []string
+	for _, m := range matches {
+		id := m[1]
+		if _, ok := seen[id]; !ok {
+			seen[id] = struct{}{}
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+// rewriteImageSrcs replaces /api/images/<id> with images/<id>.<ext> in body.
+func rewriteImageSrcs(body string, imgFiles map[string]string) string {
+	return imageAPIPath.ReplaceAllStringFunc(body, func(match string) string {
+		// match is the full "/api/images/<id>"
+		sub := imageAPIPath.FindStringSubmatch(match)
+		if len(sub) < 2 {
+			return match
+		}
+		id := sub[1]
+		if filename, ok := imgFiles[id]; ok {
+			return "images/" + filename
+		}
+		return match
+	})
+}
+
 // Build creates a ZIP archive of all non-trashed notes for userID.
+// imageData maps image ID → image bytes+mime; if nil no images are bundled.
 // If password is non-empty each entry is AES-256 encrypted.
-func Build(w io.Writer, noteList []*notes.Note, password string) error {
+func Build(w io.Writer, noteList []*notes.Note, imageData map[string]images.Data, password string) error {
 	zw := yzip.NewWriter(w)
 
+	// Collect all image IDs referenced across all notes, build id→filename map.
+	imgFiles := make(map[string]string) // id → "images/<id>.<ext>" basename
+	for _, n := range noteList {
+		for _, id := range extractImageIDs(n.Body) {
+			if _, ok := imgFiles[id]; ok {
+				continue
+			}
+			if d, found := imageData[id]; found {
+				imgFiles[id] = id + "." + mimeToExt(d.MimeType)
+			}
+		}
+	}
+
+	// Write image files first (images/ prefix inside the ZIP).
+	for id, filename := range imgFiles {
+		d := imageData[id]
+		zipName := "images/" + filename
+
+		var fw io.Writer
+		var err error
+		if password != "" {
+			fw, err = zw.Encrypt(zipName, password, yzip.StandardEncryption)
+		} else {
+			fw, err = zw.Create(zipName)
+		}
+		if err != nil {
+			return fmt.Errorf("zip entry %q: %w", zipName, err)
+		}
+		if _, err := io.Copy(fw, bytes.NewReader(d.Bytes)); err != nil {
+			return fmt.Errorf("write entry %q: %w", zipName, err)
+		}
+	}
+
+	// Write notes, rewriting image src paths to relative ones.
 	seen := make(map[string]int)
 	for _, n := range noteList {
 		name := sanitiseFilename(n.Title)
@@ -63,7 +156,8 @@ func Build(w io.Writer, noteList []*notes.Note, password string) error {
 		}
 		seen[name]++
 
-		content := fmt.Sprintf("# %s\n\n%s\n", n.Title, n.Body)
+		body := rewriteImageSrcs(n.Body, imgFiles)
+		content := fmt.Sprintf("# %s\n\n%s\n", n.Title, body)
 
 		var fw io.Writer
 		var err error
@@ -79,6 +173,7 @@ func Build(w io.Writer, noteList []*notes.Note, password string) error {
 			return fmt.Errorf("write entry %q: %w", name, err)
 		}
 	}
+
 	// Close must be called to flush the zip central directory.
 	if err := zw.Close(); err != nil {
 		return fmt.Errorf("finalise zip: %w", err)

--- a/backend/internal/export/handler.go
+++ b/backend/internal/export/handler.go
@@ -1,26 +1,30 @@
 package export
 
 import (
+	"database/sql"
 	"fmt"
 	"net/http"
 	"time"
 
 	"github.com/danpicton/crapnote/internal/auth"
+	"github.com/danpicton/crapnote/internal/images"
 	"github.com/danpicton/crapnote/internal/notes"
 )
 
 // Handler handles the export endpoint.
 type Handler struct {
 	notes *notes.Service
+	db    *sql.DB
 }
 
 // NewHandler creates a new export Handler.
-func NewHandler(notesSvc *notes.Service) *Handler {
-	return &Handler{notes: notesSvc}
+func NewHandler(notesSvc *notes.Service, db *sql.DB) *Handler {
+	return &Handler{notes: notesSvc, db: db}
 }
 
 // Export handles GET /api/export?password=<optional>
-// Streams a ZIP file containing all non-trashed notes as .md files.
+// Streams a ZIP file containing all non-trashed notes as .md files,
+// with any referenced images bundled under images/ and src paths rewritten.
 func (h *Handler) Export(w http.ResponseWriter, r *http.Request) {
 	u := auth.UserFromContext(r.Context())
 	if u == nil {
@@ -36,6 +40,24 @@ func (h *Handler) Export(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Collect every image ID referenced across all notes.
+	var allIDs []string
+	seen := make(map[string]struct{})
+	for _, n := range noteList {
+		for _, id := range extractImageIDs(n.Body) {
+			if _, ok := seen[id]; !ok {
+				seen[id] = struct{}{}
+				allIDs = append(allIDs, id)
+			}
+		}
+	}
+
+	imageData, err := images.FetchByIDs(r.Context(), h.db, u.ID, allIDs)
+	if err != nil {
+		http.Error(w, `{"error":"internal error"}`, http.StatusInternalServerError)
+		return
+	}
+
 	filename := fmt.Sprintf("crapnote-export-%s.zip",
 		time.Now().UTC().Format("2006-01-02"))
 
@@ -43,8 +65,8 @@ func (h *Handler) Export(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Disposition",
 		fmt.Sprintf(`attachment; filename="%s"`, filename))
 
-	if err := Build(w, noteList, password); err != nil {
-		// Headers already sent; log but can't return a clean error.
+	if err := Build(w, noteList, imageData, password); err != nil {
+		// Headers already sent; can't return a clean HTTP error.
 		_ = err
 	}
 }

--- a/backend/internal/export/handler_test.go
+++ b/backend/internal/export/handler_test.go
@@ -35,7 +35,7 @@ func setup(t *testing.T) (*export.Handler, *auth.User) {
 	notesSvc.Create(context.Background(), user.ID, "First Note", "body one")   //nolint:errcheck
 	notesSvc.Create(context.Background(), user.ID, "Second Note", "body two")  //nolint:errcheck
 
-	h := export.NewHandler(notesSvc)
+	h := export.NewHandler(notesSvc, database)
 	return h, user
 }
 
@@ -123,7 +123,7 @@ func TestExport_FilenamesSanitised(t *testing.T) {
 	notesSvc := notes.NewService(notes.NewRepo(database))
 	notesSvc.Create(context.Background(), user.ID, "Hello/World & More!", "body") //nolint:errcheck
 
-	h := export.NewHandler(notesSvc)
+	h := export.NewHandler(notesSvc, database)
 	req := httptest.NewRequest(http.MethodGet, "/api/export", nil)
 	req = withUser(req, user)
 	w := httptest.NewRecorder()
@@ -145,7 +145,7 @@ func TestExport_EmptyNotes(t *testing.T) {
 	t.Cleanup(func() { database.Close() })
 	userRepo := auth.NewUserRepo(database)
 	user, _ := userRepo.Create(context.Background(), "empty", "$2a$12$x", false)
-	h := export.NewHandler(notes.NewService(notes.NewRepo(database)))
+	h := export.NewHandler(notes.NewService(notes.NewRepo(database)), database)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/export", nil)
 	req = withUser(req, user)

--- a/backend/internal/images/handler.go
+++ b/backend/internal/images/handler.go
@@ -1,0 +1,128 @@
+package images
+
+import (
+	"crypto/rand"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/danpicton/crapnote/internal/auth"
+)
+
+const maxImageSize = 10 << 20 // 10 MB
+
+// Handler holds HTTP handlers for image upload and serving.
+type Handler struct {
+	db *sql.DB
+}
+
+// NewHandler creates a new images Handler.
+func NewHandler(db *sql.DB) *Handler {
+	return &Handler{db: db}
+}
+
+// Upload handles POST /api/images (multipart form with field "image").
+func (h *Handler) Upload(w http.ResponseWriter, r *http.Request) {
+	u := auth.UserFromContext(r.Context())
+	if u == nil {
+		writeError(w, http.StatusUnauthorized, "not authenticated")
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxImageSize+512)
+	if err := r.ParseMultipartForm(maxImageSize); err != nil {
+		writeError(w, http.StatusBadRequest, "image too large or bad request")
+		return
+	}
+
+	file, header, err := r.FormFile("image")
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "missing image field")
+		return
+	}
+	defer file.Close()
+
+	data, err := io.ReadAll(io.LimitReader(file, maxImageSize))
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	mimeType := header.Header.Get("Content-Type")
+	if mimeType == "" {
+		mimeType = http.DetectContentType(data)
+	}
+
+	id := newID()
+
+	_, err = h.db.ExecContext(r.Context(),
+		`INSERT INTO images (id, user_id, mime_type, data) VALUES (?, ?, ?, ?)`,
+		id, u.ID, mimeType, data,
+	)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(map[string]string{"url": "/api/images/" + id}) //nolint:errcheck
+}
+
+// Serve handles GET /api/images/{id}.
+func (h *Handler) Serve(w http.ResponseWriter, r *http.Request) {
+	u := auth.UserFromContext(r.Context())
+	if u == nil {
+		writeError(w, http.StatusUnauthorized, "not authenticated")
+		return
+	}
+
+	id := r.PathValue("id")
+
+	var userID int64
+	var mimeType string
+	var data []byte
+
+	err := h.db.QueryRowContext(r.Context(),
+		`SELECT user_id, mime_type, data FROM images WHERE id = ?`, id,
+	).Scan(&userID, &mimeType, &data)
+
+	if err == sql.ErrNoRows {
+		http.NotFound(w, r)
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	// Users can only access their own images.
+	if userID != u.ID {
+		http.NotFound(w, r)
+		return
+	}
+
+	w.Header().Set("Content-Type", mimeType)
+	w.Header().Set("Cache-Control", "private, max-age=31536000, immutable")
+	w.Write(data) //nolint:errcheck
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+func newID() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		panic(fmt.Sprintf("images: rand.Read: %v", err))
+	}
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // variant 10
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
+}
+
+func writeError(w http.ResponseWriter, code int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	json.NewEncoder(w).Encode(map[string]string{"error": msg}) //nolint:errcheck
+}

--- a/backend/internal/images/handler.go
+++ b/backend/internal/images/handler.go
@@ -1,6 +1,7 @@
 package images
 
 import (
+	"context"
 	"crypto/rand"
 	"database/sql"
 	"encoding/json"
@@ -12,6 +13,37 @@ import (
 )
 
 const maxImageSize = 10 << 20 // 10 MB
+
+// Data holds the raw bytes and MIME type of a stored image.
+type Data struct {
+	MimeType string
+	Bytes    []byte
+}
+
+// FetchByIDs returns the image data for the given IDs that belong to userID.
+// IDs not found or belonging to another user are silently omitted.
+func FetchByIDs(ctx context.Context, db *sql.DB, userID int64, ids []string) (map[string]Data, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]Data, len(ids))
+	for _, id := range ids {
+		var uid int64
+		var mime string
+		var data []byte
+		err := db.QueryRowContext(ctx,
+			`SELECT user_id, mime_type, data FROM images WHERE id = ?`, id,
+		).Scan(&uid, &mime, &data)
+		if err == sql.ErrNoRows || uid != userID {
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("fetch image %s: %w", id, err)
+		}
+		out[id] = Data{MimeType: mime, Bytes: data}
+	}
+	return out, nil
+}
 
 // Handler holds HTTP handlers for image upload and serving.
 type Handler struct {

--- a/frontend/src/__mocks__/lucide-svelte.ts
+++ b/frontend/src/__mocks__/lucide-svelte.ts
@@ -19,6 +19,7 @@ export {
 	noop as EyeOff,
 	noop as FileCode2,
 	noop as Home,
+	noop as Image,
 	noop as Info,
 	noop as Italic,
 	noop as Key,

--- a/frontend/src/lib/components/Editor.svelte
+++ b/frontend/src/lib/components/Editor.svelte
@@ -33,9 +33,9 @@
 					onchange?.(markdown);
 				});
 			})
-			.use(imagePlugin as Parameters<typeof Editor.prototype.use>[0])
 			.use(commonmark)
 			.use(underlinePlugin as Parameters<typeof Editor.prototype.use>[0])
+			.use(imagePlugin as Parameters<typeof Editor.prototype.use>[0])
 			.use(history)
 			.use(listener)
 			.create();
@@ -134,7 +134,7 @@
 	}
 
 	/* ── Image blocks ── */
-	.editor-container :global(figure.crapnote-img-view) {
+	.editor-container :global(span.crapnote-img-view) {
 		position: relative;
 		display: inline-block;
 		margin: 0.5em 0;
@@ -143,7 +143,7 @@
 		user-select: none;
 	}
 
-	.editor-container :global(figure.crapnote-img-view img) {
+	.editor-container :global(span.crapnote-img-view img) {
 		display: block;
 		max-width: 100%;
 		height: auto;
@@ -164,7 +164,7 @@
 		transition: opacity 0.15s;
 	}
 
-	.editor-container :global(figure.crapnote-img-view:hover .crapnote-img-handle) {
+	.editor-container :global(span.crapnote-img-view:hover .crapnote-img-handle) {
 		opacity: 1;
 	}
 </style>

--- a/frontend/src/lib/components/Editor.svelte
+++ b/frontend/src/lib/components/Editor.svelte
@@ -33,9 +33,9 @@
 					onchange?.(markdown);
 				});
 			})
+			.use(imagePlugin as Parameters<typeof Editor.prototype.use>[0])
 			.use(commonmark)
 			.use(underlinePlugin as Parameters<typeof Editor.prototype.use>[0])
-			.use(imagePlugin as Parameters<typeof Editor.prototype.use>[0])
 			.use(history)
 			.use(listener)
 			.create();

--- a/frontend/src/lib/components/Editor.svelte
+++ b/frontend/src/lib/components/Editor.svelte
@@ -7,6 +7,7 @@
 	import { history } from '@milkdown/kit/plugin/history';
 	import { listener, listenerCtx } from '@milkdown/kit/plugin/listener';
 	import { underlinePlugin } from '$lib/milkdown/underline';
+	import { imagePlugin } from '$lib/milkdown/image';
 
 	export interface EditorRef {
 		call: (key: string | CmdKey<unknown>, payload?: unknown) => void;
@@ -34,6 +35,7 @@
 			})
 			.use(commonmark)
 			.use(underlinePlugin as Parameters<typeof Editor.prototype.use>[0])
+			.use(imagePlugin as Parameters<typeof Editor.prototype.use>[0])
 			.use(history)
 			.use(listener)
 			.create();
@@ -129,5 +131,40 @@
 
 	.editor-container :global(u) {
 		text-decoration: underline;
+	}
+
+	/* ── Image blocks ── */
+	.editor-container :global(figure.crapnote-img-view) {
+		position: relative;
+		display: inline-block;
+		margin: 0.5em 0;
+		line-height: 0;
+		max-width: 100%;
+		user-select: none;
+	}
+
+	.editor-container :global(figure.crapnote-img-view img) {
+		display: block;
+		max-width: 100%;
+		height: auto;
+		border-radius: 0.25em;
+	}
+
+	.editor-container :global(.crapnote-img-handle) {
+		position: absolute;
+		right: -5px;
+		top: 50%;
+		transform: translateY(-50%);
+		width: 10px;
+		height: 36px;
+		background: #6366f1;
+		border-radius: 4px;
+		cursor: ew-resize;
+		opacity: 0;
+		transition: opacity 0.15s;
+	}
+
+	.editor-container :global(figure.crapnote-img-view:hover .crapnote-img-handle) {
+		opacity: 1;
 	}
 </style>

--- a/frontend/src/lib/milkdown/image.ts
+++ b/frontend/src/lib/milkdown/image.ts
@@ -1,0 +1,231 @@
+/**
+ * Milkdown plugin for resizable images.
+ *
+ * Images are stored in markdown as a <figure> HTML block (CommonMark type-6,
+ * so definitely parsed as a block-level HTML node by remark):
+ *
+ *   <figure><img src="URL" alt="ALT" width="400"></figure>
+ *
+ * Images without an explicit width omit the width attribute.
+ * A drag handle on the right edge of each image lets the user resize it
+ * by clicking and dragging; the new width is written back to the document.
+ */
+
+import { $node, $view, $prose, $command } from '@milkdown/kit/utils';
+import { Plugin, PluginKey } from '@milkdown/kit/prose/state';
+import type { Node as ProseMirrorNode } from '@milkdown/kit/prose/model';
+import type { EditorView } from '@milkdown/kit/prose/view';
+import type { MarkdownNode, ParserState } from '@milkdown/transformer';
+
+// ─── Markdown helpers ─────────────────────────────────────────────────────────
+
+function parseImgAttrs(html: string): { src: string; alt: string; width: number | null } | null {
+	const srcMatch = html.match(/src="([^"]*)"/);
+	if (!srcMatch) return null;
+	const altMatch = html.match(/alt="([^"]*)"/);
+	const widthMatch = html.match(/width="(\d+)"/);
+	return {
+		src: srcMatch[1],
+		alt: altMatch?.[1] ?? '',
+		width: widthMatch ? parseInt(widthMatch[1], 10) : null,
+	};
+}
+
+function buildFigureHtml(src: string, alt: string, width: number | null): string {
+	const esc = (s: string) => s.replace(/"/g, '&quot;');
+	const widthAttr = width ? ` width="${width}"` : '';
+	return `<figure><img src="${esc(src)}" alt="${esc(alt)}"${widthAttr}></figure>`;
+}
+
+// ─── Shared upload helper ─────────────────────────────────────────────────────
+
+async function uploadImage(blob: Blob): Promise<string> {
+	const form = new FormData();
+	form.append('image', blob);
+	const res = await fetch('/api/images', { method: 'POST', body: form, credentials: 'include' });
+	if (!res.ok) throw new Error(`Image upload failed: ${res.status}`);
+	const data = (await res.json()) as { url: string };
+	return data.url;
+}
+
+function insertImageAt(view: EditorView, src: string): void {
+	const { state } = view;
+	const nodeType = state.schema.nodes['crapnote_image'];
+	if (!nodeType) return;
+	const node = nodeType.create({ src, alt: '', width: null });
+	view.dispatch(state.tr.replaceSelectionWith(node));
+}
+
+// ─── ProseMirror node ─────────────────────────────────────────────────────────
+
+export const imageNode = $node('crapnote_image', () => ({
+	group: 'block',
+	atom: true,
+	attrs: {
+		src: { default: '' },
+		alt: { default: '' },
+		width: { default: null },
+	},
+	// toDOM is used as a fallback (the NodeView below takes over in the editor).
+	toDOM(node: ProseMirrorNode) {
+		const { src, alt, width } = node.attrs as { src: string; alt: string; width: number | null };
+		return [
+			'figure',
+			{ class: 'crapnote-img-block' },
+			['img', { src, alt, ...(width ? { width: String(width) } : {}) }],
+		] as unknown as ReturnType<NonNullable<import('@milkdown/kit/prose/model').NodeSpec['toDOM']>>;
+	},
+	parseDOM: [
+		{
+			tag: 'figure.crapnote-img-block',
+			getAttrs(dom) {
+				const el = dom as HTMLElement;
+				const img = el.querySelector('img');
+				return {
+					src: img?.getAttribute('src') ?? '',
+					alt: img?.getAttribute('alt') ?? '',
+					width: img?.getAttribute('width') ? parseInt(img.getAttribute('width')!, 10) : null,
+				};
+			},
+		},
+	],
+	parseMarkdown: {
+		match: (node) =>
+			node.type === 'html' &&
+			typeof node.value === 'string' &&
+			(node.value as string).includes('<figure>') &&
+			(node.value as string).includes('<img'),
+		runner: (state: ParserState, node: MarkdownNode, nodeType) => {
+			const attrs = parseImgAttrs(node.value as string);
+			if (attrs) {
+				(state as unknown as { addNode: (t: unknown, a: unknown) => void }).addNode(nodeType, attrs);
+			}
+		},
+	},
+	toMarkdown: {
+		match: (node: ProseMirrorNode) => node.type.name === 'crapnote_image',
+		runner: (state: { addNode: (type: string, children: undefined, value: string) => void }, node: ProseMirrorNode) => {
+			const { src, alt, width } = node.attrs as { src: string; alt: string; width: number | null };
+			state.addNode('html', undefined, buildFigureHtml(src, alt, width));
+		},
+	},
+}));
+
+// ─── NodeView — interactive resize handle ─────────────────────────────────────
+
+export const imageView = $view(imageNode, () => (initialNode, view, getPos) => {
+	let currentNode = initialNode;
+
+	const wrapper = document.createElement('figure');
+	wrapper.className = 'crapnote-img-view';
+	wrapper.contentEditable = 'false';
+
+	const img = document.createElement('img');
+	img.src = currentNode.attrs.src as string;
+	img.alt = currentNode.attrs.alt as string;
+	img.draggable = false;
+	if (currentNode.attrs.width) img.style.width = `${currentNode.attrs.width}px`;
+
+	const handle = document.createElement('div');
+	handle.className = 'crapnote-img-handle';
+	handle.setAttribute('aria-label', 'Drag to resize image');
+
+	wrapper.appendChild(img);
+	wrapper.appendChild(handle);
+
+	// Drag-to-resize
+	handle.addEventListener('mousedown', (e: MouseEvent) => {
+		e.preventDefault();
+		e.stopPropagation();
+		const startX = e.clientX;
+		const startWidth = img.offsetWidth;
+
+		const onMove = (e: MouseEvent) => {
+			const w = Math.max(48, startWidth + e.clientX - startX);
+			img.style.width = `${w}px`;
+		};
+
+		const onUp = (e: MouseEvent) => {
+			document.removeEventListener('mousemove', onMove);
+			document.removeEventListener('mouseup', onUp);
+
+			const newWidth = Math.max(48, Math.round(startWidth + e.clientX - startX));
+			const pos = typeof getPos === 'function' ? getPos() : undefined;
+			if (pos !== undefined) {
+				view.dispatch(
+					view.state.tr.setNodeMarkup(pos, undefined, { ...currentNode.attrs, width: newWidth })
+				);
+			}
+		};
+
+		document.addEventListener('mousemove', onMove);
+		document.addEventListener('mouseup', onUp);
+	});
+
+	return {
+		dom: wrapper as unknown as HTMLElement,
+		update(updatedNode: ProseMirrorNode) {
+			if (updatedNode.type.name !== 'crapnote_image') return false;
+			currentNode = updatedNode;
+			img.src = updatedNode.attrs.src as string;
+			img.alt = updatedNode.attrs.alt as string;
+			img.style.width = updatedNode.attrs.width ? `${updatedNode.attrs.width}px` : '';
+			return true;
+		},
+		destroy() {},
+	};
+});
+
+// ─── Paste plugin ─────────────────────────────────────────────────────────────
+
+export const imagePastePlugin = $prose(() =>
+	new Plugin({
+		key: new PluginKey('crapnote-image-paste'),
+		props: {
+			handlePaste(view: EditorView, event: ClipboardEvent) {
+				const items = Array.from(event.clipboardData?.items ?? []);
+				const imageItem = items.find((item) => item.type.startsWith('image/'));
+				if (!imageItem) return false;
+
+				event.preventDefault();
+				const blob = imageItem.getAsFile();
+				if (!blob) return false;
+
+				uploadImage(blob)
+					.then((url) => insertImageAt(view, url))
+					.catch((err) => console.error('[crapnote] image paste failed:', err));
+
+				return true;
+			},
+		},
+	})
+);
+
+// ─── Insert-image command (opens file picker) ─────────────────────────────────
+
+export const insertImageCommand = $command(
+	'InsertImage',
+	() => () => (_state, _dispatch, view) => {
+		if (!view) return false;
+
+		const input = document.createElement('input');
+		input.type = 'file';
+		input.accept = 'image/*';
+		input.onchange = async () => {
+			const file = input.files?.[0];
+			if (!file) return;
+			try {
+				const url = await uploadImage(file);
+				insertImageAt(view, url);
+			} catch (err) {
+				console.error('[crapnote] image insert failed:', err);
+			}
+		};
+		input.click();
+		return true;
+	}
+);
+
+// ─── Composed export ──────────────────────────────────────────────────────────
+
+export const imagePlugin = [imageNode, imageView, imagePastePlugin, insertImageCommand].flat();

--- a/frontend/src/lib/milkdown/image.ts
+++ b/frontend/src/lib/milkdown/image.ts
@@ -1,43 +1,48 @@
 /**
- * Milkdown plugin for resizable images.
+ * Image plugin for crapnote.
  *
- * Images are stored in markdown as a <figure> HTML block (CommonMark type-6,
- * so definitely parsed as a block-level HTML node by remark):
+ * Rather than a custom ProseMirror node, we piggyback on the existing
+ * commonmark `image` node (which already parses/serialises `![alt](url)`
+ * correctly) and attach a custom NodeView that:
  *
- *   <figure><img src="URL" alt="ALT" width="400"></figure>
+ *   • Renders images from /api/images/… with a drag-to-resize handle.
+ *   • Encodes the chosen width in the URL as a ?w=NNN query parameter,
+ *     so it survives round-trips through the markdown: ![alt](/api/images/UUID?w=333)
+ *   • Falls back to plain <img> rendering for all other image URLs.
  *
- * Images without an explicit width omit the width attribute.
- * A drag handle on the right edge of each image lets the user resize it
- * by clicking and dragging; the new width is written back to the document.
+ * Paste from clipboard and the Insert Image toolbar button both upload the
+ * blob to /api/images, receive back the URL, and insert a standard image node.
  */
 
-import { $node, $view, $prose, $command } from '@milkdown/kit/utils';
+import { $view, $prose, $command } from '@milkdown/kit/utils';
+import { imageSchema } from '@milkdown/preset-commonmark';
 import { Plugin, PluginKey } from '@milkdown/kit/prose/state';
 import type { Node as ProseMirrorNode } from '@milkdown/kit/prose/model';
 import type { EditorView } from '@milkdown/kit/prose/view';
-import type { MarkdownNode, ParserState } from '@milkdown/transformer';
 
-// ─── Markdown helpers ─────────────────────────────────────────────────────────
+// ─── URL helpers ──────────────────────────────────────────────────────────────
 
-function parseImgAttrs(html: string): { src: string; alt: string; width: number | null } | null {
-	const srcMatch = html.match(/src="([^"]*)"/);
-	if (!srcMatch) return null;
-	const altMatch = html.match(/alt="([^"]*)"/);
-	const widthMatch = html.match(/width="(\d+)"/);
-	return {
-		src: srcMatch[1],
-		alt: altMatch?.[1] ?? '',
-		width: widthMatch ? parseInt(widthMatch[1], 10) : null,
-	};
+function isApiImage(src: string): boolean {
+	return typeof src === 'string' && src.startsWith('/api/images/');
 }
 
-function buildFigureHtml(src: string, alt: string, width: number | null): string {
-	const esc = (s: string) => s.replace(/"/g, '&quot;');
-	const widthAttr = width ? ` width="${width}"` : '';
-	return `<figure><img src="${esc(src)}" alt="${esc(alt)}"${widthAttr}></figure>`;
+function extractWidth(src: string): number | null {
+	const m = src.match(/[?&]w=(\d+)/);
+	return m ? parseInt(m[1], 10) : null;
 }
 
-// ─── Shared upload helper ─────────────────────────────────────────────────────
+function baseSrc(src: string): string {
+	// Strip any existing ?w= param, leaving other query params intact.
+	return src.replace(/([?&])w=\d+(&?)/, (_, p, trail) => (trail ? p : '')).replace(/[?&]$/, '');
+}
+
+function withWidth(src: string, width: number): string {
+	const base = baseSrc(src);
+	const sep = base.includes('?') ? '&' : '?';
+	return `${base}${sep}w=${width}`;
+}
+
+// ─── Upload helper ────────────────────────────────────────────────────────────
 
 async function uploadImage(blob: Blob): Promise<string> {
 	const form = new FormData();
@@ -50,131 +55,86 @@ async function uploadImage(blob: Blob): Promise<string> {
 
 function insertImageAt(view: EditorView, src: string): void {
 	const { state } = view;
-	const nodeType = state.schema.nodes['crapnote_image'];
-	if (!nodeType) return;
-	const node = nodeType.create({ src, alt: '', width: null });
+	const imageType = state.schema.nodes['image'];
+	if (!imageType) return;
+	const node = imageType.create({ src, alt: '', title: '' });
 	view.dispatch(state.tr.replaceSelectionWith(node));
 }
 
-// ─── ProseMirror node ─────────────────────────────────────────────────────────
+// ─── NodeView ─────────────────────────────────────────────────────────────────
 
-export const imageNode = $node('crapnote_image', () => ({
-	group: 'block',
-	atom: true,
-	attrs: {
-		src: { default: '' },
-		alt: { default: '' },
-		width: { default: null },
-	},
-	// toDOM is used as a fallback (the NodeView below takes over in the editor).
-	toDOM(node: ProseMirrorNode) {
-		const { src, alt, width } = node.attrs as { src: string; alt: string; width: number | null };
-		return [
-			'figure',
-			{ class: 'crapnote-img-block' },
-			['img', { src, alt, ...(width ? { width: String(width) } : {}) }],
-		] as unknown as ReturnType<NonNullable<import('@milkdown/kit/prose/model').NodeSpec['toDOM']>>;
-	},
-	parseDOM: [
-		{
-			tag: 'figure.crapnote-img-block',
-			getAttrs(dom) {
-				const el = dom as HTMLElement;
-				const img = el.querySelector('img');
-				return {
-					src: img?.getAttribute('src') ?? '',
-					alt: img?.getAttribute('alt') ?? '',
-					width: img?.getAttribute('width') ? parseInt(img.getAttribute('width')!, 10) : null,
-				};
-			},
-		},
-	],
-	parseMarkdown: {
-		match: (node) =>
-			node.type === 'html' &&
-			typeof node.value === 'string' &&
-			(node.value as string).includes('<figure>') &&
-			(node.value as string).includes('<img'),
-		runner: (state: ParserState, node: MarkdownNode, nodeType) => {
-			const attrs = parseImgAttrs(node.value as string);
-			if (attrs) {
-				(state as unknown as { addNode: (t: unknown, a: unknown) => void }).addNode(nodeType, attrs);
+export const imageView = $view(
+	imageSchema.node,
+	() =>
+		(initialNode: ProseMirrorNode, view: EditorView, getPos: (() => number | undefined) | boolean) => {
+			let currentNode = initialNode;
+
+			const wrapper = document.createElement('span');
+			wrapper.className = 'crapnote-img-view';
+			wrapper.contentEditable = 'false';
+
+			const img = document.createElement('img');
+			img.draggable = false;
+
+			function syncImg(node: ProseMirrorNode) {
+				const src = node.attrs.src as string;
+				img.src = baseSrc(src);
+				img.alt = (node.attrs.alt as string) ?? '';
+				const w = extractWidth(src);
+				img.style.width = w ? `${w}px` : '';
 			}
-		},
-	},
-	toMarkdown: {
-		match: (node: ProseMirrorNode) => node.type.name === 'crapnote_image',
-		runner: (state: { addNode: (type: string, children: undefined, value: string) => void }, node: ProseMirrorNode) => {
-			const { src, alt, width } = node.attrs as { src: string; alt: string; width: number | null };
-			state.addNode('html', undefined, buildFigureHtml(src, alt, width));
-		},
-	},
-}));
 
-// ─── NodeView — interactive resize handle ─────────────────────────────────────
+			syncImg(initialNode);
+			wrapper.appendChild(img);
 
-export const imageView = $view(imageNode, () => (initialNode, view, getPos) => {
-	let currentNode = initialNode;
+			// Only add the resize handle for images we serve.
+			if (isApiImage(initialNode.attrs.src as string)) {
+				const handle = document.createElement('div');
+				handle.className = 'crapnote-img-handle';
+				handle.setAttribute('aria-label', 'Drag to resize');
+				wrapper.appendChild(handle);
 
-	const wrapper = document.createElement('figure');
-	wrapper.className = 'crapnote-img-view';
-	wrapper.contentEditable = 'false';
+				handle.addEventListener('mousedown', (e: MouseEvent) => {
+					e.preventDefault();
+					e.stopPropagation();
+					const startX = e.clientX;
+					const startWidth = img.offsetWidth;
 
-	const img = document.createElement('img');
-	img.src = currentNode.attrs.src as string;
-	img.alt = currentNode.attrs.alt as string;
-	img.draggable = false;
-	if (currentNode.attrs.width) img.style.width = `${currentNode.attrs.width}px`;
-
-	const handle = document.createElement('div');
-	handle.className = 'crapnote-img-handle';
-	handle.setAttribute('aria-label', 'Drag to resize image');
-
-	wrapper.appendChild(img);
-	wrapper.appendChild(handle);
-
-	// Drag-to-resize
-	handle.addEventListener('mousedown', (e: MouseEvent) => {
-		e.preventDefault();
-		e.stopPropagation();
-		const startX = e.clientX;
-		const startWidth = img.offsetWidth;
-
-		const onMove = (e: MouseEvent) => {
-			const w = Math.max(48, startWidth + e.clientX - startX);
-			img.style.width = `${w}px`;
-		};
-
-		const onUp = (e: MouseEvent) => {
-			document.removeEventListener('mousemove', onMove);
-			document.removeEventListener('mouseup', onUp);
-
-			const newWidth = Math.max(48, Math.round(startWidth + e.clientX - startX));
-			const pos = typeof getPos === 'function' ? getPos() : undefined;
-			if (pos !== undefined) {
-				view.dispatch(
-					view.state.tr.setNodeMarkup(pos, undefined, { ...currentNode.attrs, width: newWidth })
-				);
+					const onMove = (ev: MouseEvent) => {
+						img.style.width = `${Math.max(48, startWidth + ev.clientX - startX)}px`;
+					};
+					const onUp = (ev: MouseEvent) => {
+						document.removeEventListener('mousemove', onMove);
+						document.removeEventListener('mouseup', onUp);
+						const newWidth = Math.max(48, Math.round(startWidth + ev.clientX - startX));
+						const pos = typeof getPos === 'function' ? getPos() : undefined;
+						if (pos !== undefined) {
+							const newSrc = withWidth(baseSrc(currentNode.attrs.src as string), newWidth);
+							view.dispatch(
+								view.state.tr.setNodeMarkup(pos, undefined, {
+									...currentNode.attrs,
+									src: newSrc,
+								})
+							);
+						}
+					};
+					document.addEventListener('mousemove', onMove);
+					document.addEventListener('mouseup', onUp);
+				});
 			}
-		};
 
-		document.addEventListener('mousemove', onMove);
-		document.addEventListener('mouseup', onUp);
-	});
-
-	return {
-		dom: wrapper as unknown as HTMLElement,
-		update(updatedNode: ProseMirrorNode) {
-			if (updatedNode.type.name !== 'crapnote_image') return false;
-			currentNode = updatedNode;
-			img.src = updatedNode.attrs.src as string;
-			img.alt = updatedNode.attrs.alt as string;
-			img.style.width = updatedNode.attrs.width ? `${updatedNode.attrs.width}px` : '';
-			return true;
-		},
-		destroy() {},
-	};
-});
+			return {
+				dom: wrapper as unknown as HTMLElement,
+				update(updatedNode: ProseMirrorNode) {
+					if (updatedNode.type !== currentNode.type) return false;
+					currentNode = updatedNode;
+					syncImg(updatedNode);
+					return true;
+				},
+				destroy() {},
+			};
+		}
+);
 
 // ─── Paste plugin ─────────────────────────────────────────────────────────────
 
@@ -186,28 +146,24 @@ export const imagePastePlugin = $prose(() =>
 				const items = Array.from(event.clipboardData?.items ?? []);
 				const imageItem = items.find((item) => item.type.startsWith('image/'));
 				if (!imageItem) return false;
-
 				event.preventDefault();
 				const blob = imageItem.getAsFile();
 				if (!blob) return false;
-
 				uploadImage(blob)
 					.then((url) => insertImageAt(view, url))
 					.catch((err) => console.error('[crapnote] image paste failed:', err));
-
 				return true;
 			},
 		},
 	})
 );
 
-// ─── Insert-image command (opens file picker) ─────────────────────────────────
+// ─── Insert-image command (file picker) ───────────────────────────────────────
 
 export const insertImageCommand = $command(
-	'InsertImage',
+	'CrapnoteInsertImage',
 	() => () => (_state, _dispatch, view) => {
 		if (!view) return false;
-
 		const input = document.createElement('input');
 		input.type = 'file';
 		input.accept = 'image/*';
@@ -228,4 +184,4 @@ export const insertImageCommand = $command(
 
 // ─── Composed export ──────────────────────────────────────────────────────────
 
-export const imagePlugin = [imageNode, imageView, imagePastePlugin, insertImageCommand].flat();
+export const imagePlugin = [imageView, imagePastePlugin, insertImageCommand].flat();

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -13,6 +13,7 @@
 	} from '@milkdown/kit/preset/commonmark';
 	import { undoCommand, redoCommand } from '@milkdown/kit/plugin/history';
 	import { toggleUnderlineCommand } from '$lib/milkdown/underline';
+	import { insertImageCommand } from '$lib/milkdown/image';
 	import type { CmdKey } from '@milkdown/kit/core';
 	import { api, type Note, type Tag } from '$lib/api';
 	import { auth } from '$lib/stores/auth.svelte';
@@ -21,7 +22,7 @@
 	// Lucide icons
 	import {
 		Bold, Italic, Underline, Quote, Code, FileCode2,
-		List, ListOrdered, Minus, Undo2, Redo2,
+		List, ListOrdered, Minus, Undo2, Redo2, Image,
 		Plus, Star, Pin, Archive, Trash2, Settings, LogOut,
 		ChevronRight, Search, Tag as TagIcon,
 	} from 'lucide-svelte';
@@ -434,6 +435,10 @@
 				</button>
 				<button class="tb-btn" onclick={() => cmd(redoCommand.key)} title="Redo">
 					<Redo2 size={14} />
+				</button>
+				<span class="tb-sep"></span>
+				<button class="tb-btn" onclick={() => cmd(insertImageCommand.key)} title="Insert image">
+					<Image size={14} />
 				</button>
 				<span class="tb-spacer"></span>
 				<span class="save-status">{saving ? 'Saving…' : ''}</span>


### PR DESCRIPTION
## Summary
This PR adds comprehensive image support to crapnote, enabling users to upload images, embed them in notes with resizable rendering, and export notes with embedded images bundled in the ZIP archive.

## Key Changes

**Frontend:**
- New Milkdown image plugin (`frontend/src/lib/milkdown/image.ts`) that:
  - Leverages the existing commonmark `image` node for markdown compatibility
  - Renders images from `/api/images/…` with a drag-to-resize handle
  - Encodes chosen width in the URL as a `?w=NNN` query parameter for persistence
  - Supports image paste from clipboard and file picker via toolbar button
  - Falls back to plain `<img>` rendering for non-API image URLs
- Updated Editor component to integrate the image plugin and add styling for image blocks and resize handles
- Added "Insert Image" toolbar button in the main page

**Backend:**
- New `internal/images` package with:
  - `Handler` for POST `/api/images` (upload) and GET `/api/images/{id}` (serve) endpoints
  - `FetchByIDs` function to retrieve image data for export
  - Image size limit (10 MB) and MIME type detection
  - User-scoped access control (users can only access their own images)
  - UUID v4 ID generation for uploaded images
- Database migration (`000007_images.up.sql`) creating `images` table with user_id foreign key and index
- Enhanced export functionality:
  - Extracts image IDs from note markdown using regex
  - Bundles referenced images in `images/` directory within ZIP
  - Rewrites image src paths from `/api/images/<id>` to relative `images/<id>.<ext>`
  - Converts MIME types to appropriate file extensions
- Updated export handler to accept database connection and fetch image data during export
- Integrated images handler into server mux with protected routes

## Notable Implementation Details

- Images are stored as BLOBs in the database with their MIME type, enabling format-agnostic storage
- Width parameter in image URLs survives markdown round-trips, allowing persistent user-chosen dimensions
- Export process deduplicates image references across multiple notes before bundling
- Image access is strictly user-scoped; attempting to access another user's image returns 404
- Resize handle only appears for images served from `/api/images/`, not external URLs
- Cache-Control header set to `private, max-age=31536000, immutable` for served images

https://claude.ai/code/session_01QbqeetNYna6wUuj35D4fyb