### PR TITLE
Add interactive link insertion with Ctrl+K and paste/input rules

### DIFF
--- a/frontend/src/__mocks__/lucide-svelte.ts
+++ b/frontend/src/__mocks__/lucide-svelte.ts
@@ -23,6 +23,7 @@ export {
 	noop as Info,
 	noop as Italic,
 	noop as Key,
+	noop as Link,
 	noop as List,
 	noop as ListOrdered,
 	noop as Lock,

--- a/frontend/src/lib/components/Editor.svelte
+++ b/frontend/src/lib/components/Editor.svelte
@@ -8,6 +8,7 @@
 	import { listener, listenerCtx } from '@milkdown/kit/plugin/listener';
 	import { underlinePlugin } from '$lib/milkdown/underline';
 	import { imagePlugin } from '$lib/milkdown/image';
+	import { linkPlugin } from '$lib/milkdown/link';
 
 	export interface EditorRef {
 		call: (key: string | CmdKey<unknown>, payload?: unknown) => void;
@@ -17,9 +18,10 @@
 		value?: string;
 		onchange?: (markdown: string) => void;
 		ref?: EditorRef | null;
+		oninsertlink?: () => void;
 	}
 
-	let { value = '', onchange, ref = $bindable<EditorRef | null>(null) }: Props = $props();
+	let { value = '', onchange, ref = $bindable<EditorRef | null>(null), oninsertlink }: Props = $props();
 
 	let container: HTMLDivElement;
 	let _editor: Editor | null = null;
@@ -36,9 +38,12 @@
 			.use(commonmark)
 			.use(underlinePlugin as Parameters<typeof Editor.prototype.use>[0])
 			.use(imagePlugin as Parameters<typeof Editor.prototype.use>[0])
+			.use(linkPlugin as Parameters<typeof Editor.prototype.use>[0])
 			.use(history)
 			.use(listener)
 			.create();
+
+		container.addEventListener('crapnote:insert-link', () => oninsertlink?.());
 
 		ref = {
 			call: (key, payload) => {
@@ -131,6 +136,16 @@
 
 	.editor-container :global(u) {
 		text-decoration: underline;
+	}
+
+	.editor-container :global(.ProseMirror a) {
+		color: #4f46e5;
+		text-decoration: underline;
+		cursor: text;
+	}
+
+	.editor-container :global(.ProseMirror a:hover) {
+		color: #3730a3;
 	}
 
 	/* ── Image blocks ── */

--- a/frontend/src/lib/components/Editor.svelte
+++ b/frontend/src/lib/components/Editor.svelte
@@ -141,7 +141,7 @@
 	.editor-container :global(.ProseMirror a) {
 		color: #4f46e5;
 		text-decoration: underline;
-		cursor: text;
+		cursor: pointer;
 	}
 
 	.editor-container :global(.ProseMirror a:hover) {

--- a/frontend/src/lib/milkdown/link.test.ts
+++ b/frontend/src/lib/milkdown/link.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock all Milkdown/ProseMirror imports so we can import link.ts in jsdom
+vi.mock('@milkdown/kit/utils', () => ({
+	$prose: vi.fn((fn: unknown) => fn),
+	$pasteRule: vi.fn((fn: unknown) => fn),
+	$inputRule: vi.fn((fn: unknown) => fn),
+}));
+vi.mock('@milkdown/kit/prose/inputrules', () => ({ InputRule: vi.fn() }));
+vi.mock('@milkdown/kit/prose/state', () => ({ Plugin: vi.fn(), PluginKey: vi.fn() }));
+vi.mock('@milkdown/kit/prose/model', () => ({ Fragment: { from: vi.fn() }, Slice: vi.fn() }));
+vi.mock('@milkdown/kit/prose/view', () => ({}));
+
+import { isUrl, normalizeUrl } from './link';
+
+describe('isUrl', () => {
+	it('accepts https URLs', () => {
+		expect(isUrl('https://example.com')).toBe(true);
+	});
+
+	it('accepts http URLs', () => {
+		expect(isUrl('http://example.com')).toBe(true);
+	});
+
+	it('accepts URLs with paths and query strings', () => {
+		expect(isUrl('https://example.com/path?q=1&r=2')).toBe(true);
+	});
+
+	it('accepts www. prefixed addresses', () => {
+		expect(isUrl('www.example.com')).toBe(true);
+	});
+
+	it('rejects plain words', () => {
+		expect(isUrl('notaurl')).toBe(false);
+	});
+
+	it('rejects ftp:// schemes', () => {
+		expect(isUrl('ftp://example.com')).toBe(false);
+	});
+
+	it('rejects empty string', () => {
+		expect(isUrl('')).toBe(false);
+	});
+
+	it('rejects bare domain without www or scheme', () => {
+		expect(isUrl('example.com')).toBe(false);
+	});
+
+	it('rejects https:// with nothing after the scheme', () => {
+		expect(isUrl('https://')).toBe(false);
+	});
+});
+
+describe('normalizeUrl', () => {
+	it('leaves https:// URLs unchanged', () => {
+		expect(normalizeUrl('https://example.com')).toBe('https://example.com');
+	});
+
+	it('leaves http:// URLs unchanged', () => {
+		expect(normalizeUrl('http://example.com')).toBe('http://example.com');
+	});
+
+	it('prepends https:// to URLs without a scheme', () => {
+		expect(normalizeUrl('example.com')).toBe('https://example.com');
+	});
+
+	it('prepends https:// to www. URLs', () => {
+		expect(normalizeUrl('www.example.com')).toBe('https://www.example.com');
+	});
+
+	it('trims leading and trailing whitespace', () => {
+		expect(normalizeUrl('  https://example.com  ')).toBe('https://example.com');
+	});
+
+	it('preserves paths and query strings', () => {
+		expect(normalizeUrl('https://example.com/a?b=c')).toBe('https://example.com/a?b=c');
+	});
+});

--- a/frontend/src/lib/milkdown/link.ts
+++ b/frontend/src/lib/milkdown/link.ts
@@ -40,6 +40,17 @@ export const linkKeymapPlugin = $prose(() =>
 	new Plugin({
 		key: new PluginKey('crapnote-link-keymap'),
 		props: {
+			// Open links on click.
+			handleDOMEvents: {
+				click(_view: EditorView, event: MouseEvent): boolean {
+					const anchor = (event.target as HTMLElement).closest('a');
+					if (!anchor?.href) return false;
+					event.preventDefault();
+					window.open(anchor.href, '_blank', 'noopener,noreferrer');
+					return true;
+				},
+			},
+
 			handleKeyDown(view: EditorView, event: KeyboardEvent): boolean {
 				if (!((event.ctrlKey || event.metaKey) && event.key === 'k')) return false;
 				event.preventDefault();

--- a/frontend/src/lib/milkdown/link.ts
+++ b/frontend/src/lib/milkdown/link.ts
@@ -1,20 +1,29 @@
 /**
  * Link plugin for crapnote.
  *
- * The commonmark preset already includes linkSchema and toggleLinkCommand, so
- * this plugin only needs to add two behaviours on top:
+ * The commonmark preset already includes linkSchema, toggleLinkCommand, etc.
+ * This plugin adds the interactive behaviours on top:
  *
- *  1. Ctrl/Cmd+K keymap — fires a 'crapnote:insert-link' CustomEvent that
- *     bubbles up to the editor container so Svelte can show the URL dialog.
+ *  1. linkKeymapPlugin (Ctrl/Cmd+K)
+ *       - If selected text is a bare URL → apply link mark directly.
+ *       - Otherwise → fire 'crapnote:insert-link' so Svelte shows the URL dialog.
  *
- *  2. Paste handler — when a bare URL is pasted:
- *       • With text selected  → wraps the selection in a link mark.
- *       • With an empty cursor → inserts the URL as linked text.
+ *  2. linkPasteRule ($pasteRule — runs inside Milkdown's paste pipeline)
+ *       - Bare URL pasted with text selected → wrap selection in link.
+ *       - Bare URL pasted at cursor        → insert as linked text.
+ *       - Markdown [text](url) pasted      → inline text with link mark.
+ *
+ *  3. linkInputRule ($inputRule)
+ *       - Typing [text](url) and pressing ) converts it to a link in place.
  */
 
-import { $prose } from '@milkdown/kit/utils';
+import { $prose, $pasteRule, $inputRule } from '@milkdown/kit/utils';
+import { InputRule } from '@milkdown/kit/prose/inputrules';
 import { Plugin, PluginKey } from '@milkdown/kit/prose/state';
+import { Fragment, Slice } from '@milkdown/kit/prose/model';
 import type { EditorView } from '@milkdown/kit/prose/view';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
 
 function isUrl(s: string): boolean {
 	return /^https?:\/\/\S+/.test(s) || /^www\.\S+\.\S+/.test(s);
@@ -25,54 +34,116 @@ function normalizeUrl(url: string): string {
 	return t.startsWith('http://') || t.startsWith('https://') ? t : `https://${t}`;
 }
 
+// ─── 1. Ctrl/Cmd+K keymap ────────────────────────────────────────────────────
+
 export const linkKeymapPlugin = $prose(() =>
 	new Plugin({
 		key: new PluginKey('crapnote-link-keymap'),
 		props: {
 			handleKeyDown(view: EditorView, event: KeyboardEvent): boolean {
-				if ((event.ctrlKey || event.metaKey) && event.key === 'k') {
-					event.preventDefault();
-					view.dom.dispatchEvent(
-						new CustomEvent('crapnote:insert-link', { bubbles: true })
-					);
-					return true;
-				}
-				return false;
-			},
-		},
-	})
-);
-
-export const linkPastePlugin = $prose(() =>
-	new Plugin({
-		key: new PluginKey('crapnote-link-paste'),
-		props: {
-			handlePaste(view: EditorView, event: ClipboardEvent): boolean {
-				const raw = event.clipboardData?.getData('text/plain')?.trim() ?? '';
-				if (!isUrl(raw)) return false;
-
-				const { state } = view;
-				const markType = state.schema.marks['link'];
-				if (!markType) return false;
-
-				const href = normalizeUrl(raw);
+				if (!((event.ctrlKey || event.metaKey) && event.key === 'k')) return false;
 				event.preventDefault();
 
-				if (!state.selection.empty) {
-					// Wrap selected text in a link mark.
-					const { from, to } = state.selection;
-					view.dispatch(
-						state.tr.addMark(from, to, markType.create({ href, title: null }))
-					);
-				} else {
-					// No selection: insert the URL as linked text.
-					const node = state.schema.text(href, [markType.create({ href, title: null })]);
-					view.dispatch(state.tr.replaceSelectionWith(node));
+				const { state } = view;
+				const { from, to } = state.selection;
+
+				// If the selection is a bare URL, apply the link immediately.
+				if (from !== to) {
+					const selectedText = state.doc.textBetween(from, to);
+					if (isUrl(selectedText)) {
+						const markType = state.schema.marks['link'];
+						if (markType) {
+							view.dispatch(
+								state.tr.addMark(
+									from,
+									to,
+									markType.create({ href: normalizeUrl(selectedText), title: null })
+								)
+							);
+							return true;
+						}
+					}
 				}
+
+				// Otherwise show the URL dialog.
+				view.dom.dispatchEvent(new CustomEvent('crapnote:insert-link', { bubbles: true }));
 				return true;
 			},
 		},
 	})
 );
 
-export const linkPlugin = [linkKeymapPlugin, linkPastePlugin].flat();
+// ─── 2. Paste rule ────────────────────────────────────────────────────────────
+
+export const linkPasteRule = $pasteRule(() => ({
+	run(slice: Slice, view: EditorView, isPlainText: boolean): Slice {
+		if (!isPlainText) return slice;
+
+		let text = '';
+		slice.content.forEach((node) => {
+			text += node.textContent;
+		});
+		text = text.trim();
+
+		const { state } = view;
+		const markType = state.schema.marks['link'];
+		if (!markType) return slice;
+
+		// ── Bare URL ──────────────────────────────────────────────────────────
+		if (isUrl(text)) {
+			const href = normalizeUrl(text);
+
+			if (!state.selection.empty) {
+				// Wrap the selected text in the link.
+				const { from, to } = state.selection;
+				const selectedText = state.doc.textBetween(from, to);
+				const node = state.schema.text(selectedText, [markType.create({ href, title: null })]);
+				return new Slice(Fragment.from(node), 0, 0);
+			}
+
+			// Insert the URL itself as linked text.
+			const node = state.schema.text(href, [markType.create({ href, title: null })]);
+			return new Slice(Fragment.from(node), 0, 0);
+		}
+
+		// ── Markdown [text](url) ──────────────────────────────────────────────
+		const mdLink = /\[([^\]\n]+)\]\(([^)\s]+)\)/g;
+		if (!mdLink.test(text)) return slice;
+
+		mdLink.lastIndex = 0;
+		const nodes: ReturnType<typeof state.schema.text>[] = [];
+		let last = 0;
+		let m: RegExpExecArray | null;
+
+		while ((m = mdLink.exec(text)) !== null) {
+			if (m.index > last) nodes.push(state.schema.text(text.slice(last, m.index)));
+			const [, linkText, href] = m;
+			nodes.push(
+				state.schema.text(linkText, [markType.create({ href: normalizeUrl(href), title: null })])
+			);
+			last = m.index + m[0].length;
+		}
+		if (last < text.length) nodes.push(state.schema.text(text.slice(last)));
+
+		return new Slice(Fragment.from(nodes), 0, 0);
+	},
+}));
+
+// ─── 3. Input rule ([text](url) → link as you type) ──────────────────────────
+
+export const linkInputRule = $inputRule(
+	(_ctx) =>
+		new InputRule(/\[([^\]\n]+)\]\(([^)\s]+)\)$/, (state, match, start, end) => {
+			const [, linkText, rawHref] = match;
+			const markType = state.schema.marks['link'];
+			if (!markType) return null;
+			const node = state.schema.text(linkText, [
+				markType.create({ href: normalizeUrl(rawHref), title: null }),
+			]);
+			return state.tr.replaceWith(start, end, node);
+		})
+);
+
+// ─── Composed export ──────────────────────────────────────────────────────────
+
+export const linkPlugin = [linkKeymapPlugin, linkPasteRule, linkInputRule].flat();

--- a/frontend/src/lib/milkdown/link.ts
+++ b/frontend/src/lib/milkdown/link.ts
@@ -143,7 +143,7 @@ export const linkPasteRule = $pasteRule(() => ({
 // ─── 3. Input rule ([text](url) → link as you type) ──────────────────────────
 
 export const linkInputRule = $inputRule(
-	(_ctx) =>
+	() =>
 		new InputRule(/\[([^\]\n]+)\]\(([^)\s]+)\)$/, (state, match, start, end) => {
 			const [, linkText, rawHref] = match;
 			const markType = state.schema.marks['link'];

--- a/frontend/src/lib/milkdown/link.ts
+++ b/frontend/src/lib/milkdown/link.ts
@@ -1,0 +1,78 @@
+/**
+ * Link plugin for crapnote.
+ *
+ * The commonmark preset already includes linkSchema and toggleLinkCommand, so
+ * this plugin only needs to add two behaviours on top:
+ *
+ *  1. Ctrl/Cmd+K keymap — fires a 'crapnote:insert-link' CustomEvent that
+ *     bubbles up to the editor container so Svelte can show the URL dialog.
+ *
+ *  2. Paste handler — when a bare URL is pasted:
+ *       • With text selected  → wraps the selection in a link mark.
+ *       • With an empty cursor → inserts the URL as linked text.
+ */
+
+import { $prose } from '@milkdown/kit/utils';
+import { Plugin, PluginKey } from '@milkdown/kit/prose/state';
+import type { EditorView } from '@milkdown/kit/prose/view';
+
+function isUrl(s: string): boolean {
+	return /^https?:\/\/\S+/.test(s) || /^www\.\S+\.\S+/.test(s);
+}
+
+function normalizeUrl(url: string): string {
+	const t = url.trim();
+	return t.startsWith('http://') || t.startsWith('https://') ? t : `https://${t}`;
+}
+
+export const linkKeymapPlugin = $prose(() =>
+	new Plugin({
+		key: new PluginKey('crapnote-link-keymap'),
+		props: {
+			handleKeyDown(view: EditorView, event: KeyboardEvent): boolean {
+				if ((event.ctrlKey || event.metaKey) && event.key === 'k') {
+					event.preventDefault();
+					view.dom.dispatchEvent(
+						new CustomEvent('crapnote:insert-link', { bubbles: true })
+					);
+					return true;
+				}
+				return false;
+			},
+		},
+	})
+);
+
+export const linkPastePlugin = $prose(() =>
+	new Plugin({
+		key: new PluginKey('crapnote-link-paste'),
+		props: {
+			handlePaste(view: EditorView, event: ClipboardEvent): boolean {
+				const raw = event.clipboardData?.getData('text/plain')?.trim() ?? '';
+				if (!isUrl(raw)) return false;
+
+				const { state } = view;
+				const markType = state.schema.marks['link'];
+				if (!markType) return false;
+
+				const href = normalizeUrl(raw);
+				event.preventDefault();
+
+				if (!state.selection.empty) {
+					// Wrap selected text in a link mark.
+					const { from, to } = state.selection;
+					view.dispatch(
+						state.tr.addMark(from, to, markType.create({ href, title: null }))
+					);
+				} else {
+					// No selection: insert the URL as linked text.
+					const node = state.schema.text(href, [markType.create({ href, title: null })]);
+					view.dispatch(state.tr.replaceSelectionWith(node));
+				}
+				return true;
+			},
+		},
+	})
+);
+
+export const linkPlugin = [linkKeymapPlugin, linkPastePlugin].flat();

--- a/frontend/src/lib/milkdown/link.ts
+++ b/frontend/src/lib/milkdown/link.ts
@@ -25,11 +25,11 @@ import type { EditorView } from '@milkdown/kit/prose/view';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-function isUrl(s: string): boolean {
+export function isUrl(s: string): boolean {
 	return /^https?:\/\/\S+/.test(s) || /^www\.\S+\.\S+/.test(s);
 }
 
-function normalizeUrl(url: string): string {
+export function normalizeUrl(url: string): string {
 	const t = url.trim();
 	return t.startsWith('http://') || t.startsWith('https://') ? t : `https://${t}`;
 }

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -14,6 +14,7 @@
 	import { undoCommand, redoCommand } from '@milkdown/kit/plugin/history';
 	import { toggleUnderlineCommand } from '$lib/milkdown/underline';
 	import { insertImageCommand } from '$lib/milkdown/image';
+	import { toggleLinkCommand } from '@milkdown/kit/preset/commonmark';
 	import type { CmdKey } from '@milkdown/kit/core';
 	import { api, type Note, type Tag } from '$lib/api';
 	import { auth } from '$lib/stores/auth.svelte';
@@ -22,7 +23,7 @@
 	// Lucide icons
 	import {
 		Bold, Italic, Underline, Quote, Code, FileCode2,
-		List, ListOrdered, Minus, Undo2, Redo2, Image,
+		List, ListOrdered, Minus, Undo2, Redo2, Image, Link,
 		Plus, Star, Pin, Archive, Trash2, Settings, LogOut,
 		ChevronRight, Search, Tag as TagIcon,
 	} from 'lucide-svelte';
@@ -270,6 +271,26 @@
 	function cmd(key: string | CmdKey<unknown>, payload?: unknown) {
 		editorRef?.call(key, payload);
 	}
+
+	// Link dialog
+	let showLinkDialog = $state(false);
+	let linkDialogHref = $state('');
+
+	function openLinkDialog() {
+		linkDialogHref = '';
+		showLinkDialog = true;
+	}
+
+	function applyLink() {
+		const href = linkDialogHref.trim();
+		if (href) cmd(toggleLinkCommand.key as CmdKey<unknown>, { href });
+		showLinkDialog = false;
+	}
+
+	function linkInputKeydown(e: KeyboardEvent) {
+		if (e.key === 'Enter') { e.preventDefault(); applyLink(); }
+		if (e.key === 'Escape') { showLinkDialog = false; }
+	}
 </script>
 
 <svelte:head>
@@ -409,6 +430,26 @@
 				<button class="tb-btn" onclick={() => cmd(toggleUnderlineCommand.key)} title="Underline">
 					<Underline size={14} />
 				</button>
+				<div class="link-btn-wrap">
+					<button class="tb-btn" onclick={openLinkDialog} title="Insert link (Ctrl+K)">
+						<Link size={14} />
+					</button>
+					{#if showLinkDialog}
+						<div class="link-dialog-backdrop" onclick={() => (showLinkDialog = false)} role="presentation"></div>
+						<div class="link-dialog" role="dialog" aria-label="Insert link">
+							<!-- svelte-ignore a11y_autofocus -->
+							<input
+								class="link-dialog-input"
+								type="url"
+								placeholder="https://…"
+								bind:value={linkDialogHref}
+								onkeydown={linkInputKeydown}
+								autofocus
+							/>
+							<button class="link-dialog-btn" onclick={applyLink}>Apply</button>
+						</div>
+					{/if}
+				</div>
 				<span class="tb-sep"></span>
 				<button class="tb-btn" onclick={() => cmd(wrapInBlockquoteCommand.key)} title="Quote">
 					<Quote size={14} />
@@ -510,6 +551,7 @@
 					value={selectedNote.body}
 					onchange={(md) => scheduleAutoSave('body', md)}
 					bind:ref={editorRef}
+					oninsertlink={openLinkDialog}
 				/>
 			{/key}
 		{:else}
@@ -742,6 +784,56 @@
 	.tb-spacer { flex: 1; }
 
 	.save-status { font-size: 0.75rem; color: #9ca3af; white-space: nowrap; }
+
+	.link-btn-wrap {
+		position: relative;
+		display: inline-flex;
+	}
+
+	.link-dialog-backdrop {
+		position: fixed;
+		inset: 0;
+		z-index: 49;
+	}
+
+	.link-dialog {
+		position: absolute;
+		top: calc(100% + 4px);
+		left: 0;
+		background: white;
+		border: 1px solid #e5e7eb;
+		border-radius: 0.5rem;
+		box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+		padding: 0.4rem;
+		display: flex;
+		gap: 0.25rem;
+		z-index: 50;
+		min-width: 14rem;
+	}
+
+	.link-dialog-input {
+		flex: 1;
+		border: 1px solid #d1d5db;
+		border-radius: 0.25rem;
+		padding: 0.25rem 0.4rem;
+		font-size: 0.8rem;
+		outline: none;
+		min-width: 0;
+	}
+	.link-dialog-input:focus { border-color: #6366f1; }
+
+	.link-dialog-btn {
+		background: #6366f1;
+		color: white;
+		border: none;
+		border-radius: 0.25rem;
+		padding: 0.25rem 0.6rem;
+		font-size: 0.8rem;
+		cursor: pointer;
+		white-space: nowrap;
+		flex-shrink: 0;
+	}
+	.link-dialog-btn:hover { background: #4f46e5; }
 
 	.mobile-show-editor { display: none; }
 

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -276,6 +276,10 @@
 	let showLinkDialog = $state(false);
 	let linkDialogHref = $state('');
 
+	function focusInput(node: HTMLInputElement) {
+		node.focus();
+	}
+
 	function openLinkDialog() {
 		linkDialogHref = '';
 		showLinkDialog = true;
@@ -437,14 +441,13 @@
 					{#if showLinkDialog}
 						<div class="link-dialog-backdrop" onclick={() => (showLinkDialog = false)} role="presentation"></div>
 						<div class="link-dialog" role="dialog" aria-label="Insert link">
-							<!-- svelte-ignore a11y_autofocus -->
 							<input
 								class="link-dialog-input"
 								type="url"
 								placeholder="https://…"
 								bind:value={linkDialogHref}
 								onkeydown={linkInputKeydown}
-								autofocus
+								use:focusInput
 							/>
 							<button class="link-dialog-btn" onclick={applyLink}>Apply</button>
 						</div>

--- a/frontend/src/routes/notes/[id]/+page.svelte
+++ b/frontend/src/routes/notes/[id]/+page.svelte
@@ -14,12 +14,13 @@
 	} from '@milkdown/kit/preset/commonmark';
 	import { undoCommand, redoCommand } from '@milkdown/kit/plugin/history';
 	import { toggleUnderlineCommand } from '$lib/milkdown/underline';
+	import { toggleLinkCommand } from '@milkdown/kit/preset/commonmark';
 	import type { CmdKey } from '@milkdown/kit/core';
 	import { api, type Note, type Tag } from '$lib/api';
 	import Editor, { type EditorRef } from '$lib/components/Editor.svelte';
 	import {
 		Bold, Italic, Underline, Quote, Code, FileCode2,
-		List, ListOrdered, Minus, Undo2, Redo2,
+		List, ListOrdered, Minus, Undo2, Redo2, Link,
 		Plus, ChevronLeft, Tag as TagIcon,
 	} from 'lucide-svelte';
 
@@ -99,6 +100,26 @@
 		editorRef?.call(key, payload);
 	}
 
+	// Link dialog
+	let showLinkDialog = $state(false);
+	let linkDialogHref = $state('');
+
+	function openLinkDialog() {
+		linkDialogHref = '';
+		showLinkDialog = true;
+	}
+
+	function applyLink() {
+		const href = linkDialogHref.trim();
+		if (href) cmd(toggleLinkCommand.key as CmdKey<unknown>, { href });
+		showLinkDialog = false;
+	}
+
+	function linkInputKeydown(e: KeyboardEvent) {
+		if (e.key === 'Enter') { e.preventDefault(); applyLink(); }
+		if (e.key === 'Escape') { showLinkDialog = false; }
+	}
+
 	async function toggleTag(tag: Tag) {
 		const has = noteTags.find(t => t.id === tag.id);
 		if (has) {
@@ -142,6 +163,24 @@
 		<button class="tb-btn" onclick={() => cmd(toggleStrongCommand.key)} title="Bold"><Bold size={14} /></button>
 		<button class="tb-btn" onclick={() => cmd(toggleEmphasisCommand.key)} title="Italic"><Italic size={14} /></button>
 		<button class="tb-btn" onclick={() => cmd(toggleUnderlineCommand.key)} title="Underline"><Underline size={14} /></button>
+		<div class="link-btn-wrap">
+			<button class="tb-btn" onclick={openLinkDialog} title="Insert link (Ctrl+K)"><Link size={14} /></button>
+			{#if showLinkDialog}
+				<div class="link-dialog-backdrop" onclick={() => (showLinkDialog = false)} role="presentation"></div>
+				<div class="link-dialog" role="dialog" aria-label="Insert link">
+					<!-- svelte-ignore a11y_autofocus -->
+					<input
+						class="link-dialog-input"
+						type="url"
+						placeholder="https://…"
+						bind:value={linkDialogHref}
+						onkeydown={linkInputKeydown}
+						autofocus
+					/>
+					<button class="link-dialog-btn" onclick={applyLink}>Apply</button>
+				</div>
+			{/if}
+		</div>
 		<span class="tb-sep"></span>
 		<button class="tb-btn" onclick={() => cmd(wrapInBlockquoteCommand.key)} title="Quote"><Quote size={14} /></button>
 		<button class="tb-btn" onclick={() => cmd(toggleInlineCodeCommand.key)} title="Inline code"><Code size={14} /></button>
@@ -216,6 +255,7 @@
 			value={note.body}
 			onchange={(md) => scheduleAutoSave('body', md)}
 			bind:ref={editorRef}
+			oninsertlink={openLinkDialog}
 		/>
 	{/key}
 </div>
@@ -275,6 +315,56 @@
 	}
 	.tb-spacer { flex: 1; }
 	.save-status { font-size: 0.75rem; color: #9ca3af; white-space: nowrap; }
+
+	.link-btn-wrap {
+		position: relative;
+		display: inline-flex;
+	}
+
+	.link-dialog-backdrop {
+		position: fixed;
+		inset: 0;
+		z-index: 49;
+	}
+
+	.link-dialog {
+		position: absolute;
+		top: calc(100% + 4px);
+		left: 0;
+		background: white;
+		border: 1px solid #e5e7eb;
+		border-radius: 0.5rem;
+		box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+		padding: 0.4rem;
+		display: flex;
+		gap: 0.25rem;
+		z-index: 50;
+		min-width: 14rem;
+	}
+
+	.link-dialog-input {
+		flex: 1;
+		border: 1px solid #d1d5db;
+		border-radius: 0.25rem;
+		padding: 0.25rem 0.4rem;
+		font-size: 0.8rem;
+		outline: none;
+		min-width: 0;
+	}
+	.link-dialog-input:focus { border-color: #6366f1; }
+
+	.link-dialog-btn {
+		background: #6366f1;
+		color: white;
+		border: none;
+		border-radius: 0.25rem;
+		padding: 0.25rem 0.6rem;
+		font-size: 0.8rem;
+		cursor: pointer;
+		white-space: nowrap;
+		flex-shrink: 0;
+	}
+	.link-dialog-btn:hover { background: #4f46e5; }
 
 	/* ─── Editor header ────────────────────────── */
 	.editor-header {

--- a/frontend/src/routes/notes/[id]/+page.svelte
+++ b/frontend/src/routes/notes/[id]/+page.svelte
@@ -104,6 +104,10 @@
 	let showLinkDialog = $state(false);
 	let linkDialogHref = $state('');
 
+	function focusInput(node: HTMLInputElement) {
+		node.focus();
+	}
+
 	function openLinkDialog() {
 		linkDialogHref = '';
 		showLinkDialog = true;
@@ -168,14 +172,13 @@
 			{#if showLinkDialog}
 				<div class="link-dialog-backdrop" onclick={() => (showLinkDialog = false)} role="presentation"></div>
 				<div class="link-dialog" role="dialog" aria-label="Insert link">
-					<!-- svelte-ignore a11y_autofocus -->
 					<input
 						class="link-dialog-input"
 						type="url"
 						placeholder="https://…"
 						bind:value={linkDialogHref}
 						onkeydown={linkInputKeydown}
-						autofocus
+						use:focusInput
 					/>
 					<button class="link-dialog-btn" onclick={applyLink}>Apply</button>
 				</div>

--- a/frontend/src/routes/notes/[id]/page.test.ts
+++ b/frontend/src/routes/notes/[id]/page.test.ts
@@ -11,7 +11,10 @@ vi.mock('@milkdown/kit/preset/commonmark', () => ({
 	wrapInOrderedListCommand: { key: 'WrapInOrderedList' },
 	insertHrCommand: { key: 'InsertHr' },
 	createCodeBlockCommand: { key: 'CreateCodeBlock' },
+	toggleLinkCommand: { key: 'ToggleLink' },
 }));
+
+vi.mock('$lib/milkdown/link', () => ({ linkPlugin: [] }));
 vi.mock('@milkdown/kit/plugin/history', () => ({
 	undoCommand: { key: 'Undo' },
 	redoCommand: { key: 'Redo' },
@@ -162,5 +165,71 @@ describe('/notes/[id] page', () => {
 		await waitFor(() =>
 			expect(api.tags.removeFromNote).toHaveBeenCalledWith(42, 1)
 		);
+	});
+});
+
+describe('Link toolbar', () => {
+	it('shows the Insert link button', async () => {
+		render(NotePage);
+		await waitFor(() =>
+			expect(screen.getByTitle('Insert link (Ctrl+K)')).toBeInTheDocument()
+		);
+	});
+
+	it('clicking the link button shows the URL input dialog', async () => {
+		render(NotePage);
+		await waitFor(() => screen.getByTitle('Insert link (Ctrl+K)'));
+
+		await fireEvent.click(screen.getByTitle('Insert link (Ctrl+K)'));
+
+		expect(screen.getByPlaceholderText(/https/i)).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: /apply/i })).toBeInTheDocument();
+	});
+
+	it('pressing Escape closes the dialog', async () => {
+		render(NotePage);
+		await waitFor(() => screen.getByTitle('Insert link (Ctrl+K)'));
+
+		await fireEvent.click(screen.getByTitle('Insert link (Ctrl+K)'));
+		const input = screen.getByPlaceholderText(/https/i);
+
+		await fireEvent.keyDown(input, { key: 'Escape' });
+
+		expect(screen.queryByPlaceholderText(/https/i)).not.toBeInTheDocument();
+	});
+
+	it('clicking the backdrop closes the dialog', async () => {
+		render(NotePage);
+		await waitFor(() => screen.getByTitle('Insert link (Ctrl+K)'));
+
+		await fireEvent.click(screen.getByTitle('Insert link (Ctrl+K)'));
+		expect(screen.getByPlaceholderText(/https/i)).toBeInTheDocument();
+
+		await fireEvent.click(document.querySelector('.link-dialog-backdrop')!);
+
+		expect(screen.queryByPlaceholderText(/https/i)).not.toBeInTheDocument();
+	});
+
+	it('pressing Enter in the URL input closes the dialog', async () => {
+		render(NotePage);
+		await waitFor(() => screen.getByTitle('Insert link (Ctrl+K)'));
+
+		await fireEvent.click(screen.getByTitle('Insert link (Ctrl+K)'));
+		const input = screen.getByPlaceholderText(/https/i);
+		await fireEvent.input(input, { target: { value: 'https://example.com' } });
+
+		await fireEvent.keyDown(input, { key: 'Enter' });
+
+		expect(screen.queryByPlaceholderText(/https/i)).not.toBeInTheDocument();
+	});
+
+	it('clicking Apply closes the dialog', async () => {
+		render(NotePage);
+		await waitFor(() => screen.getByTitle('Insert link (Ctrl+K)'));
+
+		await fireEvent.click(screen.getByTitle('Insert link (Ctrl+K)'));
+		await fireEvent.click(screen.getByRole('button', { name: /apply/i }));
+
+		expect(screen.queryByPlaceholderText(/https/i)).not.toBeInTheDocument();
 	});
 });

--- a/frontend/src/routes/page.test.ts
+++ b/frontend/src/routes/page.test.ts
@@ -12,7 +12,10 @@ vi.mock('@milkdown/kit/preset/commonmark', () => ({
 	wrapInOrderedListCommand: { key: 'WrapInOrderedList' },
 	insertHrCommand: { key: 'InsertHr' },
 	createCodeBlockCommand: { key: 'CreateCodeBlock' },
+	toggleLinkCommand: { key: 'ToggleLink' },
 }));
+
+vi.mock('$lib/milkdown/link', () => ({ linkPlugin: [] }));
 vi.mock('@milkdown/kit/plugin/history', () => ({
 	undoCommand: { key: 'Undo' },
 	redoCommand: { key: 'Redo' },
@@ -193,6 +196,72 @@ describe('Mobile navigation', () => {
 
 		// No navigation on desktop
 		expect(goto).not.toHaveBeenCalledWith(expect.stringMatching(/\/notes\//));
+	});
+});
+
+describe('Link toolbar', () => {
+	it('shows the Insert link button in the toolbar', async () => {
+		render(Page);
+		await waitFor(() =>
+			expect(screen.getByTitle('Insert link (Ctrl+K)')).toBeInTheDocument()
+		);
+	});
+
+	it('clicking the link button shows the URL input dialog', async () => {
+		render(Page);
+		await waitFor(() => screen.getByTitle('Insert link (Ctrl+K)'));
+
+		await fireEvent.click(screen.getByTitle('Insert link (Ctrl+K)'));
+
+		expect(screen.getByPlaceholderText(/https/i)).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: /apply/i })).toBeInTheDocument();
+	});
+
+	it('pressing Escape closes the dialog', async () => {
+		render(Page);
+		await waitFor(() => screen.getByTitle('Insert link (Ctrl+K)'));
+
+		await fireEvent.click(screen.getByTitle('Insert link (Ctrl+K)'));
+		const input = screen.getByPlaceholderText(/https/i);
+
+		await fireEvent.keyDown(input, { key: 'Escape' });
+
+		expect(screen.queryByPlaceholderText(/https/i)).not.toBeInTheDocument();
+	});
+
+	it('clicking the backdrop closes the dialog', async () => {
+		render(Page);
+		await waitFor(() => screen.getByTitle('Insert link (Ctrl+K)'));
+
+		await fireEvent.click(screen.getByTitle('Insert link (Ctrl+K)'));
+		expect(screen.getByPlaceholderText(/https/i)).toBeInTheDocument();
+
+		await fireEvent.click(document.querySelector('.link-dialog-backdrop')!);
+
+		expect(screen.queryByPlaceholderText(/https/i)).not.toBeInTheDocument();
+	});
+
+	it('pressing Enter in the URL input closes the dialog', async () => {
+		render(Page);
+		await waitFor(() => screen.getByTitle('Insert link (Ctrl+K)'));
+
+		await fireEvent.click(screen.getByTitle('Insert link (Ctrl+K)'));
+		const input = screen.getByPlaceholderText(/https/i);
+		await fireEvent.input(input, { target: { value: 'https://example.com' } });
+
+		await fireEvent.keyDown(input, { key: 'Enter' });
+
+		expect(screen.queryByPlaceholderText(/https/i)).not.toBeInTheDocument();
+	});
+
+	it('clicking Apply closes the dialog', async () => {
+		render(Page);
+		await waitFor(() => screen.getByTitle('Insert link (Ctrl+K)'));
+
+		await fireEvent.click(screen.getByTitle('Insert link (Ctrl+K)'));
+		await fireEvent.click(screen.getByRole('button', { name: /apply/i }));
+
+		expect(screen.queryByPlaceholderText(/https/i)).not.toBeInTheDocument();
 	});
 });
 


### PR DESCRIPTION
## Summary
This PR adds comprehensive link handling to the editor with three interactive features: keyboard shortcut (Ctrl/Cmd+K), smart paste detection, and inline markdown syntax conversion.

## Key Changes

- **New link plugin** (`frontend/src/lib/milkdown/link.ts`):
  - `linkKeymapPlugin`: Ctrl/Cmd+K opens a URL dialog, or applies link directly if selection is a bare URL
  - `linkPasteRule`: Intelligently handles pasted content—wraps selected text in links, converts bare URLs to linked text, and parses markdown `[text](url)` syntax
  - `linkInputRule`: Converts typed markdown link syntax `[text](url)` to actual links in real-time
  - Includes URL validation and automatic `https://` prefix normalization

- **UI components** (both `+page.svelte` files):
  - Added Link button to toolbar with Ctrl+K tooltip
  - Modal dialog for entering URLs with input field and Apply button
  - Keyboard support: Enter to apply, Escape to close
  - Auto-focus on input field when dialog opens
  - Backdrop click to dismiss

- **Editor integration** (`Editor.svelte`):
  - Integrated `linkPlugin` into editor pipeline
  - Added `oninsertlink` callback prop to trigger dialog from editor events
  - Styled links with indigo color (#4f46e5) and hover state
  - Link click handler opens URLs in new tab with security flags

## Implementation Details

- URL detection uses regex patterns for `http(s)://` and `www.` prefixes
- Paste rule handles three scenarios: bare URLs with/without selection, and markdown syntax
- Input rule uses regex to detect complete markdown link syntax at cursor position
- Dialog state managed per-page with reactive variables
- Consistent styling and behavior across both note pages

https://claude.ai/code/session_01L1qHA4f2oSzptfq8o9sjy7