### PR TITLE
Add comprehensive test coverage for images, auth, export, and server

### DIFF
--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+func TestEnvOrDefault(t *testing.T) {
+	const key = "CRAPNOTE_TEST_VAR_XYZ"
+	os.Unsetenv(key)
+
+	if got := envOrDefault(key, "fallback"); got != "fallback" {
+		t.Fatalf("expected fallback, got %q", got)
+	}
+
+	os.Setenv(key, "custom")
+	defer os.Unsetenv(key)
+	if got := envOrDefault(key, "fallback"); got != "custom" {
+		t.Fatalf("expected custom, got %q", got)
+	}
+}
+
+func TestNewLogger_Levels(t *testing.T) {
+	for _, level := range []string{"", "debug", "warn", "error", "info"} {
+		t.Run("level="+level, func(t *testing.T) {
+			os.Setenv("LOG_LEVEL", level)
+			defer os.Unsetenv("LOG_LEVEL")
+			l := newLogger()
+			if l == nil {
+				t.Fatal("expected non-nil logger")
+			}
+		})
+	}
+}
+
+func TestNewLogger_JSONFormat(t *testing.T) {
+	os.Setenv("LOG_FORMAT", "json")
+	defer os.Unsetenv("LOG_FORMAT")
+	l := newLogger()
+	if l == nil {
+		t.Fatal("expected non-nil logger")
+	}
+}
+
+func TestUIHandler_SPA_Route(t *testing.T) {
+	mux := newTestMux(t)
+
+	// Extensionless path → SPA index.html
+	req := httptest.NewRequest(http.MethodGet, "/some/spa/route", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	// Should return 200 (served by embedded index.html placeholder)
+	if w.Code != http.StatusOK {
+		t.Fatalf("SPA route: expected 200, got %d", w.Code)
+	}
+}
+
+func TestUIHandler_Asset_Route(t *testing.T) {
+	mux := newTestMux(t)
+
+	// Path with extension → tries to serve static asset; 404 if not present is fine
+	req := httptest.NewRequest(http.MethodGet, "/nonexistent.js", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	// We don't assert the code since assets may or may not exist in the embedded FS;
+	// we just verify the handler doesn't panic.
+	if w.Code == 0 {
+		t.Fatal("expected a non-zero status code")
+	}
+}

--- a/backend/cmd/server/server_test.go
+++ b/backend/cmd/server/server_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -42,6 +44,55 @@ func newTestMux(t *testing.T) *http.ServeMux {
 	)
 }
 
+// newAuthedMux creates a mux and seeds an admin user; returns the mux and a valid session cookie.
+func newAuthedMux(t *testing.T) (*http.ServeMux, *http.Cookie) {
+	t.Helper()
+	database, err := db.Open(db.Config{SQLitePath: ":memory:"})
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	userRepo := auth.NewUserRepo(database)
+	sessRepo := auth.NewSessionRepo(database)
+	authSvc := auth.NewService(userRepo, sessRepo, 7*24*time.Hour)
+
+	if err := authSvc.SeedAdmin(t.Context(), "admin", "pass"); err != nil {
+		t.Fatalf("seed admin: %v", err)
+	}
+	notesSvc := notes.NewService(notes.NewRepo(database))
+	mux := newMux(
+		auth.NewHandler(authSvc),
+		auth.NewAdminHandler(userRepo),
+		notes.NewHandler(notesSvc),
+		tags.NewHandler(tags.NewService(tags.NewRepo(database))),
+		trash.NewHandler(trash.NewService(trash.NewRepo(database))),
+		export.NewHandler(notesSvc, database),
+		images.NewHandler(database),
+	)
+
+	// Perform a login to obtain a session cookie.
+	loginBody := `{"username":"admin","password":"pass"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/login", bytes.NewBufferString(loginBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("login failed: %d %s", w.Code, w.Body.String())
+	}
+	var sessionCookie *http.Cookie
+	for _, c := range w.Result().Cookies() {
+		if c.Name == "session" {
+			sessionCookie = c
+			break
+		}
+	}
+	if sessionCookie == nil {
+		t.Fatal("no session cookie after login")
+	}
+	return mux, sessionCookie
+}
+
 func TestHealthCheck(t *testing.T) {
 	mux := newTestMux(t)
 
@@ -71,5 +122,161 @@ func TestProtectedRouteRequiresAuth(t *testing.T) {
 
 	if w.Code != http.StatusUnauthorized {
 		t.Fatalf("expected 401 for unauthenticated /api/auth/me, got %d", w.Code)
+	}
+}
+
+// protectedRoutes lists routes that must return 401 when no session cookie is present.
+var protectedRoutes = []struct {
+	method string
+	path   string
+}{
+	{http.MethodGet, "/api/notes"},
+	{http.MethodPost, "/api/notes"},
+	{http.MethodGet, "/api/notes/1"},
+	{http.MethodPut, "/api/notes/1"},
+	{http.MethodDelete, "/api/notes/1"},
+	{http.MethodPatch, "/api/notes/1/star"},
+	{http.MethodPatch, "/api/notes/1/pin"},
+	{http.MethodPatch, "/api/notes/1/archive"},
+	{http.MethodPatch, "/api/notes/1/unarchive"},
+	{http.MethodGet, "/api/archive"},
+	{http.MethodGet, "/api/tags"},
+	{http.MethodPost, "/api/tags"},
+	{http.MethodPut, "/api/tags/1"},
+	{http.MethodDelete, "/api/tags/1"},
+	{http.MethodGet, "/api/export"},
+	{http.MethodPost, "/api/images"},
+	{http.MethodGet, "/api/images/someid"},
+	{http.MethodGet, "/api/trash"},
+	{http.MethodPost, "/api/trash/1/restore"},
+	{http.MethodDelete, "/api/trash/1"},
+	{http.MethodDelete, "/api/trash"},
+	{http.MethodPost, "/api/auth/logout"},
+	{http.MethodGet, "/api/auth/me"},
+}
+
+func TestAllProtectedRoutesRequireAuth(t *testing.T) {
+	mux := newTestMux(t)
+	for _, tc := range protectedRoutes {
+		t.Run(tc.method+" "+tc.path, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, req)
+			if w.Code != http.StatusUnauthorized {
+				t.Fatalf("expected 401, got %d", w.Code)
+			}
+		})
+	}
+}
+
+func TestAdminRouteRequiresAdmin(t *testing.T) {
+	mux := newTestMux(t)
+
+	// Admin routes need auth — without it we get 401.
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/users", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for unauthenticated admin route, got %d", w.Code)
+	}
+}
+
+func TestLogin_Endpoint(t *testing.T) {
+	mux := newTestMux(t)
+
+	// Seed a user first via SeedAdmin — but we only have the mux, not the service.
+	// Use the login endpoint: wrong credentials → 401.
+	body := `{"username":"nobody","password":"bad"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/login", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for bad credentials, got %d", w.Code)
+	}
+}
+
+func TestAuthenticatedEndpoints(t *testing.T) {
+	mux, cookie := newAuthedMux(t)
+
+	authedReq := func(method, path string, body string) *httptest.ResponseRecorder {
+		var reqBody *bytes.Buffer
+		if body != "" {
+			reqBody = bytes.NewBufferString(body)
+		} else {
+			reqBody = &bytes.Buffer{}
+		}
+		req := httptest.NewRequest(method, path, reqBody)
+		if body != "" {
+			req.Header.Set("Content-Type", "application/json")
+		}
+		req.AddCookie(cookie)
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		return w
+	}
+
+	// GET /api/auth/me
+	w := authedReq(http.MethodGet, "/api/auth/me", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /api/auth/me: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// GET /api/notes
+	w = authedReq(http.MethodGet, "/api/notes", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /api/notes: expected 200, got %d", w.Code)
+	}
+
+	// POST /api/notes
+	w = authedReq(http.MethodPost, "/api/notes", `{"title":"Server Test","body":"hello"}`)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("POST /api/notes: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var created map[string]any
+	json.NewDecoder(w.Body).Decode(&created) //nolint:errcheck
+	noteID := int64(created["id"].(float64))
+
+	// GET /api/notes/{id}
+	w = authedReq(http.MethodGet, fmt.Sprintf("/api/notes/%d", noteID), "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /api/notes/%d: expected 200, got %d", noteID, w.Code)
+	}
+
+	// GET /api/tags
+	w = authedReq(http.MethodGet, "/api/tags", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /api/tags: expected 200, got %d", w.Code)
+	}
+
+	// GET /api/archive
+	w = authedReq(http.MethodGet, "/api/archive", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /api/archive: expected 200, got %d", w.Code)
+	}
+
+	// GET /api/trash
+	w = authedReq(http.MethodGet, "/api/trash", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /api/trash: expected 200, got %d", w.Code)
+	}
+
+	// GET /api/export
+	w = authedReq(http.MethodGet, "/api/export", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /api/export: expected 200, got %d", w.Code)
+	}
+
+	// GET /api/admin/users (admin user is logged in)
+	w = authedReq(http.MethodGet, "/api/admin/users", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /api/admin/users: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// POST /api/auth/logout
+	w = authedReq(http.MethodPost, "/api/auth/logout", "")
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("POST /api/auth/logout: expected 204, got %d", w.Code)
 	}
 }

--- a/backend/internal/auth/middleware_test.go
+++ b/backend/internal/auth/middleware_test.go
@@ -1,0 +1,182 @@
+package auth_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/danpicton/crapnote/internal/auth"
+	"github.com/danpicton/crapnote/internal/db"
+)
+
+func newMiddlewareFixture(t *testing.T) (*auth.Handler, *auth.Service) {
+	t.Helper()
+	database, err := db.Open(db.Config{SQLitePath: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+	svc := auth.NewService(
+		auth.NewUserRepo(database),
+		auth.NewSessionRepo(database),
+		7*24*time.Hour,
+	)
+	return auth.NewHandler(svc), svc
+}
+
+// okHandler is a sentinel next handler that writes 200.
+var okHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+})
+
+func TestRequireAuth_NoCookie(t *testing.T) {
+	h, _ := newMiddlewareFixture(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	h.RequireAuth(okHandler).ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestRequireAuth_InvalidSession(t *testing.T) {
+	h, _ := newMiddlewareFixture(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.AddCookie(&http.Cookie{Name: "session", Value: "bogus-session-token"})
+	w := httptest.NewRecorder()
+	h.RequireAuth(okHandler).ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for invalid session, got %d", w.Code)
+	}
+}
+
+func TestRequireAuth_ValidSession_InjectsUser(t *testing.T) {
+	h, svc := newMiddlewareFixture(t)
+	svc.SeedAdmin(t.Context(), "alice", "pass") //nolint:errcheck
+	sess, err := svc.Login(t.Context(), "alice", "pass")
+	if err != nil {
+		t.Fatalf("login: %v", err)
+	}
+
+	var capturedUser *auth.User
+	captureHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedUser = auth.UserFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.AddCookie(&http.Cookie{Name: "session", Value: sess.ID})
+	w := httptest.NewRecorder()
+	h.RequireAuth(captureHandler).ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if capturedUser == nil {
+		t.Fatal("expected user in context, got nil")
+	}
+	if capturedUser.Username != "alice" {
+		t.Fatalf("expected username alice, got %q", capturedUser.Username)
+	}
+}
+
+func TestRequireAdmin_NoUser(t *testing.T) {
+	h, _ := newMiddlewareFixture(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	// No user in context
+	w := httptest.NewRecorder()
+	h.RequireAdmin(okHandler).ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", w.Code)
+	}
+}
+
+func TestRequireAdmin_NonAdmin(t *testing.T) {
+	h, _ := newMiddlewareFixture(t)
+
+	nonAdmin := &auth.User{ID: 1, Username: "bob", IsAdmin: false}
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req = req.WithContext(auth.WithUser(req.Context(), nonAdmin))
+	w := httptest.NewRecorder()
+	h.RequireAdmin(okHandler).ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for non-admin, got %d", w.Code)
+	}
+}
+
+func TestRequireAdmin_Admin(t *testing.T) {
+	h, _ := newMiddlewareFixture(t)
+
+	admin := &auth.User{ID: 1, Username: "admin", IsAdmin: true}
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req = req.WithContext(auth.WithUser(req.Context(), admin))
+	w := httptest.NewRecorder()
+	h.RequireAdmin(okHandler).ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for admin, got %d", w.Code)
+	}
+}
+
+func TestChain_ComposesMiddleware(t *testing.T) {
+	// Chain two middlewares: first adds header A, second adds header B.
+	// Verify both fire in correct order around the inner handler.
+	var order []string
+
+	mwA := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			order = append(order, "A-before")
+			next.ServeHTTP(w, r)
+			order = append(order, "A-after")
+		})
+	}
+	mwB := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			order = append(order, "B-before")
+			next.ServeHTTP(w, r)
+			order = append(order, "B-after")
+		})
+	}
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		order = append(order, "handler")
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	auth.Chain(inner, mwA, mwB).ServeHTTP(w, req)
+
+	want := []string{"A-before", "B-before", "handler", "B-after", "A-after"}
+	if len(order) != len(want) {
+		t.Fatalf("chain order: got %v, want %v", order, want)
+	}
+	for i, s := range order {
+		if s != want[i] {
+			t.Errorf("order[%d]: got %q, want %q", i, s, want[i])
+		}
+	}
+}
+
+func TestWithUser_And_UserFromContext(t *testing.T) {
+	u := &auth.User{ID: 42, Username: "test"}
+	ctx := auth.WithUser(t.Context(), u)
+	got := auth.UserFromContext(ctx)
+	if got == nil || got.ID != 42 {
+		t.Fatalf("UserFromContext: got %v", got)
+	}
+}
+
+func TestUserFromContext_Nil(t *testing.T) {
+	got := auth.UserFromContext(t.Context())
+	if got != nil {
+		t.Fatalf("expected nil, got %v", got)
+	}
+}

--- a/backend/internal/export/export_internal_test.go
+++ b/backend/internal/export/export_internal_test.go
@@ -1,0 +1,170 @@
+// Package export (internal test) covers unexported helper functions.
+package export
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSanitiseFilename(t *testing.T) {
+	tests := []struct {
+		title string
+		want  string
+	}{
+		{"Hello World", "hello-world.md"},
+		// unsafe chars replaced, then collapsed — trailing/leading hyphens trimmed
+		{"Hello/World & More!", "hello-world-more.md"},
+		{"", "note.md"},
+		{"---", "note.md"},
+		{"My Note", "my-note.md"},
+		{"2024-01-15 Meeting Notes", "2024-01-15-meeting-notes.md"},
+		// all unsafe FS chars removed and collapsed
+		{`File:Name*With?Bad<Chars>|`, "file-name-with-bad-chars.md"},
+		// unicode letters pass IsLetter so é is preserved
+		{"Café Notes", "café-notes.md"},
+	}
+	for _, tc := range tests {
+		got := sanitiseFilename(tc.title)
+		if got != tc.want {
+			t.Errorf("sanitiseFilename(%q) = %q, want %q", tc.title, got, tc.want)
+		}
+	}
+}
+
+func TestSanitiseFilename_Truncation(t *testing.T) {
+	title := strings.Repeat("a", 200)
+	got := sanitiseFilename(title)
+	base := strings.TrimSuffix(got, ".md")
+	if len(base) > 80 {
+		t.Errorf("expected base ≤ 80 chars, got %d", len(base))
+	}
+	if !strings.HasSuffix(got, ".md") {
+		t.Errorf("expected .md suffix, got %q", got)
+	}
+}
+
+func TestMimeToExt(t *testing.T) {
+	tests := []struct {
+		mime string
+		want string
+	}{
+		{"image/png", "png"},
+		{"image/jpeg", "jpg"},
+		{"image/jpg", "jpg"},
+		{"image/gif", "gif"},
+		{"image/webp", "webp"},
+		{"image/svg+xml", "svg"},
+		{"image/avif", "avif"},
+		{"IMAGE/PNG", "png"},     // case insensitive
+		{"  image/png  ", "png"}, // whitespace trimmed
+		{"image/tiff", "tiff"},   // unknown → subtype
+		{"image/bmp", "bmp"},     // unknown → subtype
+		{"noslash", "bin"},       // no slash → "bin"
+	}
+	for _, tc := range tests {
+		got := mimeToExt(tc.mime)
+		if got != tc.want {
+			t.Errorf("mimeToExt(%q) = %q, want %q", tc.mime, got, tc.want)
+		}
+	}
+}
+
+func TestExtractImageIDs(t *testing.T) {
+	// The regex matches [a-f0-9\-]+ so IDs must be lowercase hex + hyphens.
+	id1 := "abc12345-def0-4abc-89ab-cdef01234567"
+	id2 := "fedcba98-7654-3210-fedc-ba9876543210"
+
+	tests := []struct {
+		name string
+		body string
+		want []string
+	}{
+		{
+			name: "no images",
+			body: "Just some text with no images",
+			want: nil,
+		},
+		{
+			name: "single image",
+			body: `/api/images/` + id1,
+			want: []string{id1},
+		},
+		{
+			name: "multiple images",
+			body: `/api/images/` + id1 + ` text /api/images/` + id2,
+			want: []string{id1, id2},
+		},
+		{
+			name: "deduplication",
+			body: `/api/images/` + id1 + ` text /api/images/` + id1,
+			want: []string{id1},
+		},
+		{
+			name: "mixed order preserved",
+			body: `/api/images/` + id1 + ` other /api/images/` + id2 + ` /api/images/` + id1,
+			want: []string{id1, id2},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractImageIDs(tc.body)
+			if len(got) != len(tc.want) {
+				t.Fatalf("extractImageIDs(%q): got %v, want %v", tc.body, got, tc.want)
+			}
+			for i, id := range got {
+				if id != tc.want[i] {
+					t.Errorf("[%d]: got %q, want %q", i, id, tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestRewriteImageSrcs(t *testing.T) {
+	id1 := "abc12345-def0-4abc-89ab-cdef01234567"
+	id2 := "fedcba98-7654-3210-fedc-ba9876543210"
+	imgFiles := map[string]string{
+		id1: id1 + ".png",
+		id2: id2 + ".jpg",
+	}
+
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "no images",
+			body: "plain text",
+			want: "plain text",
+		},
+		{
+			name: "known image replaced",
+			body: `/api/images/` + id1,
+			want: `images/` + id1 + `.png`,
+		},
+		{
+			name: "unknown image left alone",
+			body: `/api/images/000000-0000-0000-0000-000000000000`,
+			want: `/api/images/000000-0000-0000-0000-000000000000`,
+		},
+		{
+			name: "both known images replaced",
+			body: `/api/images/` + id1 + ` and /api/images/` + id2,
+			want: `images/` + id1 + `.png and images/` + id2 + `.jpg`,
+		},
+		{
+			name: "known and unknown mixed",
+			body: `/api/images/` + id1 + ` /api/images/000000-0000-0000-0000-000000000000`,
+			want: `images/` + id1 + `.png /api/images/000000-0000-0000-0000-000000000000`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := rewriteImageSrcs(tc.body, imgFiles)
+			if got != tc.want {
+				t.Errorf("rewriteImageSrcs: got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/backend/internal/images/handler_test.go
+++ b/backend/internal/images/handler_test.go
@@ -1,0 +1,315 @@
+package images_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/danpicton/crapnote/internal/auth"
+	"github.com/danpicton/crapnote/internal/db"
+	"github.com/danpicton/crapnote/internal/images"
+)
+
+func newFixture(t *testing.T) (*images.Handler, *auth.User) {
+	t.Helper()
+	database, err := db.Open(db.Config{SQLitePath: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	userRepo := auth.NewUserRepo(database)
+	user, err := userRepo.Create(t.Context(), "alice", "$2a$12$x", false)
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	return images.NewHandler(database), user
+}
+
+func withUser(r *http.Request, u *auth.User) *http.Request {
+	return r.WithContext(auth.WithUser(r.Context(), u))
+}
+
+// multipartUpload builds a multipart/form-data request with an "image" field.
+// An optional Content-Type part header can be set via partContentType (empty = no header).
+func multipartUpload(t *testing.T, content []byte, partContentType string) *http.Request {
+	t.Helper()
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+
+	if partContentType != "" {
+		h := make(map[string][]string)
+		h["Content-Disposition"] = []string{`form-data; name="image"; filename="upload"`}
+		h["Content-Type"] = []string{partContentType}
+		part, err := mw.CreatePart(h)
+		if err != nil {
+			t.Fatalf("create part: %v", err)
+		}
+		io.Copy(part, bytes.NewReader(content)) //nolint:errcheck
+	} else {
+		part, err := mw.CreateFormFile("image", "upload")
+		if err != nil {
+			t.Fatalf("create form file: %v", err)
+		}
+		io.Copy(part, bytes.NewReader(content)) //nolint:errcheck
+	}
+	mw.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/images", &buf)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	return req
+}
+
+func TestUpload_Success(t *testing.T) {
+	h, user := newFixture(t)
+
+	req := multipartUpload(t, minimalPNG(), "")
+	req = withUser(req, user)
+	w := httptest.NewRecorder()
+	h.Upload(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	url, ok := resp["url"]
+	if !ok || !strings.HasPrefix(url, "/api/images/") {
+		t.Fatalf("expected url starting with /api/images/, got %q", url)
+	}
+}
+
+func TestUpload_ExplicitContentType(t *testing.T) {
+	h, user := newFixture(t)
+
+	req := multipartUpload(t, minimalPNG(), "image/jpeg")
+	req = withUser(req, user)
+	w := httptest.NewRecorder()
+	h.Upload(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpload_NoAuth(t *testing.T) {
+	h, _ := newFixture(t)
+
+	req := multipartUpload(t, minimalPNG(), "")
+	// No user injected
+	w := httptest.NewRecorder()
+	h.Upload(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestUpload_MissingImageField(t *testing.T) {
+	h, user := newFixture(t)
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	part, _ := mw.CreateFormFile("not_image", "file.png")
+	io.Copy(part, bytes.NewReader(minimalPNG())) //nolint:errcheck
+	mw.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/images", &buf)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	req = withUser(req, user)
+	w := httptest.NewRecorder()
+	h.Upload(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestServe_Success(t *testing.T) {
+	h, user := newFixture(t)
+
+	// Upload first
+	req := multipartUpload(t, minimalPNG(), "")
+	req = withUser(req, user)
+	w := httptest.NewRecorder()
+	h.Upload(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("upload failed: %d %s", w.Code, w.Body.String())
+	}
+
+	var uploadResp map[string]string
+	json.NewDecoder(w.Body).Decode(&uploadResp) //nolint:errcheck
+	imageID := strings.TrimPrefix(uploadResp["url"], "/api/images/")
+
+	// Serve it back
+	req2 := httptest.NewRequest(http.MethodGet, "/api/images/"+imageID, nil)
+	req2.SetPathValue("id", imageID)
+	req2 = withUser(req2, user)
+	w2 := httptest.NewRecorder()
+	h.Serve(w2, req2)
+
+	if w2.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w2.Code, w2.Body.String())
+	}
+	if w2.Body.Len() == 0 {
+		t.Fatal("expected image bytes in response body")
+	}
+	if cc := w2.Header().Get("Cache-Control"); cc == "" {
+		t.Fatal("expected Cache-Control header")
+	}
+	if ct := w2.Header().Get("Content-Type"); ct == "" {
+		t.Fatal("expected Content-Type header")
+	}
+}
+
+func TestServe_NotFound(t *testing.T) {
+	h, user := newFixture(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/images/no-such-id", nil)
+	req.SetPathValue("id", "no-such-id")
+	req = withUser(req, user)
+	w := httptest.NewRecorder()
+	h.Serve(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestServe_NoAuth(t *testing.T) {
+	h, _ := newFixture(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/images/some-id", nil)
+	req.SetPathValue("id", "some-id")
+	w := httptest.NewRecorder()
+	h.Serve(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestServe_WrongUser(t *testing.T) {
+	database, err := db.Open(db.Config{SQLitePath: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	userRepo := auth.NewUserRepo(database)
+	alice, _ := userRepo.Create(t.Context(), "alice", "$2a$12$x", false)
+	bob, _ := userRepo.Create(t.Context(), "bob", "$2a$12$x", false)
+	h := images.NewHandler(database)
+
+	// Alice uploads an image
+	req := multipartUpload(t, minimalPNG(), "")
+	req = withUser(req, alice)
+	w := httptest.NewRecorder()
+	h.Upload(w, req)
+	var uploadResp map[string]string
+	json.NewDecoder(w.Body).Decode(&uploadResp) //nolint:errcheck
+	imageID := strings.TrimPrefix(uploadResp["url"], "/api/images/")
+
+	// Bob tries to access Alice's image — should get 404 (not 403, to avoid leaking existence)
+	req2 := httptest.NewRequest(http.MethodGet, "/api/images/"+imageID, nil)
+	req2.SetPathValue("id", imageID)
+	req2 = withUser(req2, bob)
+	w2 := httptest.NewRecorder()
+	h.Serve(w2, req2)
+
+	if w2.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for cross-user access, got %d", w2.Code)
+	}
+}
+
+func TestFetchByIDs_Empty(t *testing.T) {
+	database, err := db.Open(db.Config{SQLitePath: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer database.Close()
+
+	result, err := images.FetchByIDs(t.Context(), database, 1, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != nil {
+		t.Fatalf("expected nil for empty ids, got %v", result)
+	}
+}
+
+func TestFetchByIDs_OwnershipCheck(t *testing.T) {
+	database, err := db.Open(db.Config{SQLitePath: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer database.Close()
+
+	userRepo := auth.NewUserRepo(database)
+	alice, _ := userRepo.Create(t.Context(), "alice", "$2a$12$x", false)
+	bob, _ := userRepo.Create(t.Context(), "bob", "$2a$12$x", false)
+
+	h := images.NewHandler(database)
+	req := multipartUpload(t, minimalPNG(), "")
+	req = withUser(req, alice)
+	w := httptest.NewRecorder()
+	h.Upload(w, req)
+	var uploadResp map[string]string
+	json.NewDecoder(w.Body).Decode(&uploadResp) //nolint:errcheck
+	imageID := strings.TrimPrefix(uploadResp["url"], "/api/images/")
+
+	aliceData, err := images.FetchByIDs(t.Context(), database, alice.ID, []string{imageID})
+	if err != nil {
+		t.Fatalf("FetchByIDs alice: %v", err)
+	}
+	if len(aliceData) != 1 {
+		t.Fatalf("alice: expected 1 image, got %d", len(aliceData))
+	}
+
+	bobData, err := images.FetchByIDs(t.Context(), database, bob.ID, []string{imageID})
+	if err != nil {
+		t.Fatalf("FetchByIDs bob: %v", err)
+	}
+	if len(bobData) != 0 {
+		t.Fatalf("bob: expected 0 images (silently omitted), got %d", len(bobData))
+	}
+}
+
+func TestFetchByIDs_NonExistent(t *testing.T) {
+	database, err := db.Open(db.Config{SQLitePath: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer database.Close()
+
+	result, err := images.FetchByIDs(t.Context(), database, 1, []string{"does-not-exist"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 0 {
+		t.Fatalf("expected empty map for non-existent id, got %v", result)
+	}
+}
+
+// minimalPNG returns a valid 1x1 pixel PNG image.
+func minimalPNG() []byte {
+	return []byte{
+		0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+		0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+		0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+		0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53,
+		0xde, 0x00, 0x00, 0x00, 0x0c, 0x49, 0x44, 0x41,
+		0x54, 0x08, 0xd7, 0x63, 0xf8, 0xcf, 0xc0, 0x00,
+		0x00, 0x00, 0x02, 0x00, 0x01, 0xe2, 0x21, 0xbc,
+		0x33, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e,
+		0x44, 0xae, 0x42, 0x60, 0x82,
+	}
+}


### PR DESCRIPTION
## Summary
This PR adds extensive test coverage for the image upload/serve functionality, authentication middleware, export utilities, and server integration tests. The changes ensure critical paths are well-tested and establish patterns for future test development.

## Key Changes

### Image Handler Tests (`backend/internal/images/handler_test.go`)
- Added `TestUpload_Success`: Verifies successful image upload returns 201 with valid URL
- Added `TestUpload_ExplicitContentType`: Tests upload with explicit MIME type header
- Added `TestUpload_NoAuth`: Ensures unauthenticated uploads return 401
- Added `TestUpload_MissingImageField`: Validates 400 response when "image" form field is missing
- Added `TestServe_Success`: Tests image retrieval with proper Cache-Control and Content-Type headers
- Added `TestServe_NotFound`: Verifies 404 for non-existent images
- Added `TestServe_NoAuth`: Ensures unauthenticated access returns 401
- Added `TestServe_WrongUser`: Confirms cross-user access returns 404 (not 403, to avoid leaking existence)
- Added `TestFetchByIDs_*`: Tests for the `FetchByIDs` utility function covering empty IDs, ownership checks, and non-existent images
- Added `minimalPNG()` helper: Returns a valid 1×1 pixel PNG for testing

### Authentication Middleware Tests (`backend/internal/auth/middleware_test.go`)
- Added `TestRequireAuth_NoCookie`: Verifies 401 when no session cookie present
- Added `TestRequireAuth_InvalidSession`: Tests 401 for bogus session tokens
- Added `TestRequireAuth_ValidSession_InjectsUser`: Confirms valid sessions inject user into context
- Added `TestRequireAdmin_*`: Tests admin middleware with no user, non-admin, and admin users
- Added `TestChain_ComposesMiddleware`: Verifies middleware composition order
- Added `TestWithUser_And_UserFromContext`: Tests context user injection/retrieval
- Added `TestUserFromContext_Nil`: Confirms nil return when no user in context

### Export Utility Tests (`backend/internal/export/export_internal_test.go`)
- Added `TestSanitiseFilename`: Tests filename sanitization with unsafe characters, unicode, and edge cases
- Added `TestSanitiseFilename_Truncation`: Verifies filenames are truncated to 80 chars + .md extension
- Added `TestMimeToExt`: Tests MIME type to file extension conversion (case-insensitive, whitespace-tolerant)
- Added `TestExtractImageIDs`: Tests regex-based image ID extraction with deduplication
- Added `TestRewriteImageSrcs`: Tests rewriting `/api/images/` URLs to local `images/` paths in export

### Server Integration Tests (`backend/cmd/server/server_test.go`)
- Added `newAuthedMux()`: Helper to create authenticated test mux with seeded admin user and session cookie
- Added `protectedRoutes`: Comprehensive list of routes requiring authentication
- Added `TestAllProtectedRoutesRequireAuth`: Parametrized test verifying all protected routes return 401 without auth
- Added `TestAdminRouteRequiresAdmin`: Confirms admin routes require authentication
- Added `TestLogin_Endpoint`: Tests login endpoint with invalid credentials
- Added `TestAuthenticatedEndpoints`: Integration test covering GET/POST operations on notes, tags, archive, trash, export, and admin endpoints with valid session

### Server Utility Tests (`backend/cmd/server/main_test.go`)
- Added `TestEnvOrDefault`: Tests environment variable fallback logic
- Added `TestNewLogger_Levels`: Tests logger initialization with various log levels
- Added `TestNewLogger_JSONFormat`: Tests JSON format logger initialization
- Added `TestUIHandler_SPA_Route`: Tests SPA routing for extensionless paths
- Added `TestUIHandler_Asset_Route`: Tests static asset serving

## Notable Implementation Details

- Tests use in-memory SQLite databases for isolation and speed
- Image tests include both successful and error paths (missing auth, missing fields, wrong user)
- Cross-

https://claude.ai/code/session_01MFBP2f6xetQQtTME9fpJS6