### PR TITLE
Add rate limiting, pagination, audit logging, and security hardening

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/danpicton/crapnote/internal/images"
 	"github.com/danpicton/crapnote/internal/middleware"
 	"github.com/danpicton/crapnote/internal/notes"
+	"github.com/danpicton/crapnote/internal/ratelimit"
 	"github.com/danpicton/crapnote/internal/tags"
 	"github.com/danpicton/crapnote/internal/trash"
 )
@@ -94,10 +95,22 @@ func main() {
 		}
 	}()
 
-	imagesHandler := images.NewHandler(database)
+	imagesCfg := images.DefaultConfig()
+	if v, err := strconv.Atoi(os.Getenv("IMAGE_UPLOADS_PER_MINUTE")); err == nil && v > 0 {
+		imagesCfg.UploadsPerMinute = v
+	}
+	if v, err := strconv.Atoi(os.Getenv("IMAGE_QUOTA_MB")); err == nil && v > 0 {
+		imagesCfg.QuotaBytes = int64(v) << 20
+	}
+	imagesHandler := images.NewHandlerWith(database, imagesCfg)
+
+	// Login rate limiter: 5 attempts per minute per client IP with a small
+	// burst, reset on window refill. This is defence against credential
+	// brute-forcing. See issue #12.
+	loginLimiter := ratelimit.New(5.0/60.0, 5)
 
 	port := envOrDefault("PORT", "8080")
-	mux := newMux(authHandler, adminHandler, notesHandler, tagsHandler, trashHandler, exportHandler, imagesHandler)
+	mux := newMux(authHandler, adminHandler, notesHandler, tagsHandler, trashHandler, exportHandler, imagesHandler, loginLimiter)
 
 	// Wrap with observability middleware (metrics outermost, then logging, then security headers).
 	handler := middleware.Metrics()(middleware.Logging(logger)(middleware.SecurityHeaders()(mux)))

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -104,10 +104,20 @@ func main() {
 	}
 	imagesHandler := images.NewHandlerWith(database, imagesCfg)
 
-	// Login rate limiter: 5 attempts per minute per client IP with a small
-	// burst, reset on window refill. This is defence against credential
-	// brute-forcing. See issue #12.
-	loginLimiter := ratelimit.New(5.0/60.0, 5)
+	// Login rate limiter: defence against credential brute-forcing (issue #12).
+	// Defaults to 5 attempts/min with burst 5 per client IP. Both knobs are
+	// tunable via env vars so that E2E suites — which legitimately submit
+	// dozens of logins from a single IP within seconds — can loosen the cap
+	// without disabling protection in production.
+	loginRate := 5.0 / 60.0
+	loginBurst := 5
+	if v, err := strconv.Atoi(os.Getenv("LOGIN_RATE_PER_MINUTE")); err == nil && v > 0 {
+		loginRate = float64(v) / 60.0
+	}
+	if v, err := strconv.Atoi(os.Getenv("LOGIN_RATE_BURST")); err == nil && v > 0 {
+		loginBurst = v
+	}
+	loginLimiter := ratelimit.New(loginRate, loginBurst)
 
 	port := envOrDefault("PORT", "8080")
 	mux := newMux(authHandler, adminHandler, notesHandler, tagsHandler, trashHandler, exportHandler, imagesHandler, loginLimiter)

--- a/backend/cmd/server/server.go
+++ b/backend/cmd/server/server.go
@@ -9,6 +9,7 @@ import (
 	"github.com/danpicton/crapnote/internal/images"
 	"github.com/danpicton/crapnote/internal/middleware"
 	"github.com/danpicton/crapnote/internal/notes"
+	"github.com/danpicton/crapnote/internal/ratelimit"
 	"github.com/danpicton/crapnote/internal/tags"
 	"github.com/danpicton/crapnote/internal/trash"
 )
@@ -21,6 +22,7 @@ func newMux(
 	trashHandler   *trash.Handler,
 	exportHandler  *export.Handler,
 	imagesHandler  *images.Handler,
+	loginLimiter   *ratelimit.Limiter,
 ) *http.ServeMux {
 	mux := http.NewServeMux()
 
@@ -29,7 +31,9 @@ func newMux(
 
 	// Public.
 	mux.HandleFunc("GET /api/health", handleHealth)
-	mux.HandleFunc("POST /api/auth/login", authHandler.Login)
+	mux.Handle("POST /api/auth/login",
+		ratelimit.Middleware(loginLimiter, ratelimit.ClientIP)(http.HandlerFunc(authHandler.Login)),
+	)
 
 	// Helpers to reduce repetition.
 	protected := func(method, pattern string, h http.HandlerFunc) {

--- a/backend/cmd/server/server_test.go
+++ b/backend/cmd/server/server_test.go
@@ -14,9 +14,16 @@ import (
 	"github.com/danpicton/crapnote/internal/export"
 	"github.com/danpicton/crapnote/internal/images"
 	"github.com/danpicton/crapnote/internal/notes"
+	"github.com/danpicton/crapnote/internal/ratelimit"
 	"github.com/danpicton/crapnote/internal/tags"
 	"github.com/danpicton/crapnote/internal/trash"
 )
+
+// permissiveLoginLimiter is a login limiter large enough that no test hits it
+// unless the test itself constructs a tighter one.
+func permissiveLoginLimiter() *ratelimit.Limiter {
+	return ratelimit.New(1000, 1000)
+}
 
 // newTestMux builds a fully wired mux backed by an in-memory DB.
 func newTestMux(t *testing.T) *http.ServeMux {
@@ -41,6 +48,7 @@ func newTestMux(t *testing.T) *http.ServeMux {
 		trash.NewHandler(trash.NewService(trash.NewRepo(database))),
 		export.NewHandler(notesSvc, database),
 		images.NewHandler(database),
+		permissiveLoginLimiter(),
 	)
 }
 
@@ -69,6 +77,7 @@ func newAuthedMux(t *testing.T) (*http.ServeMux, *http.Cookie) {
 		trash.NewHandler(trash.NewService(trash.NewRepo(database))),
 		export.NewHandler(notesSvc, database),
 		images.NewHandler(database),
+		permissiveLoginLimiter(),
 	)
 
 	// Perform a login to obtain a session cookie.
@@ -178,6 +187,53 @@ func TestAdminRouteRequiresAdmin(t *testing.T) {
 	mux.ServeHTTP(w, req)
 	if w.Code != http.StatusUnauthorized {
 		t.Fatalf("expected 401 for unauthenticated admin route, got %d", w.Code)
+	}
+}
+
+// The login endpoint must enforce a per-IP rate limit (issue #12).
+// After the burst is exhausted, further requests from the same IP return 429
+// without touching the credential-check path.
+func TestLogin_RateLimited(t *testing.T) {
+	database, err := db.Open(db.Config{SQLitePath: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	authSvc := auth.NewService(
+		auth.NewUserRepo(database),
+		auth.NewSessionRepo(database),
+		7*24*time.Hour,
+	)
+	notesSvc := notes.NewService(notes.NewRepo(database))
+	// Very tight limiter: burst of 2, effectively no refill during this test.
+	tightLimiter := ratelimit.New(0.01, 2)
+	mux := newMux(
+		auth.NewHandler(authSvc),
+		auth.NewAdminHandler(auth.NewUserRepo(database)),
+		notes.NewHandler(notesSvc),
+		tags.NewHandler(tags.NewService(tags.NewRepo(database))),
+		trash.NewHandler(trash.NewService(trash.NewRepo(database))),
+		export.NewHandler(notesSvc, database),
+		images.NewHandler(database),
+		tightLimiter,
+	)
+
+	send := func() int {
+		req := httptest.NewRequest(http.MethodPost, "/api/auth/login",
+			bytes.NewBufferString(`{"username":"u","password":"p"}`))
+		req.Header.Set("Content-Type", "application/json")
+		req.RemoteAddr = "203.0.113.9:4444"
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	// First two attempts consume the burst; the third must be throttled.
+	_ = send()
+	_ = send()
+	if code := send(); code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 after burst, got %d", code)
 	}
 }
 

--- a/backend/internal/auth/admin_handler.go
+++ b/backend/internal/auth/admin_handler.go
@@ -3,9 +3,11 @@ package auth
 import (
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 	"strconv"
 
+	"github.com/danpicton/crapnote/internal/httpx"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -21,7 +23,8 @@ func NewAdminHandler(users *UserRepo) *AdminHandler {
 
 // ListUsers handles GET /api/admin/users
 func (h *AdminHandler) ListUsers(w http.ResponseWriter, r *http.Request) {
-	users, err := h.users.List(r.Context())
+	page := httpx.ParsePage(r)
+	users, err := h.users.List(r.Context(), page.Limit, page.Offset)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal error")
 		return
@@ -68,6 +71,20 @@ func (h *AdminHandler) CreateUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	actor := UserFromContext(r.Context())
+	var actorID int64
+	if actor != nil {
+		actorID = actor.ID
+	}
+	slog.Info("audit: user created",
+		"event", "user_created",
+		"admin_id", actorID,
+		"new_user_id", u.ID,
+		"new_username", u.Username,
+		"is_admin", u.IsAdmin,
+		"ip", httpx.ClientIP(r),
+	)
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
 	json.NewEncoder(w).Encode(toUserResponse(u)) //nolint:errcheck
@@ -100,6 +117,13 @@ func (h *AdminHandler) DeleteUser(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "internal error")
 		return
 	}
+
+	slog.Info("audit: user deleted",
+		"event", "user_deleted",
+		"admin_id", caller.ID,
+		"target_user_id", id,
+		"ip", httpx.ClientIP(r),
+	)
 
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/backend/internal/auth/audit_test.go
+++ b/backend/internal/auth/audit_test.go
@@ -1,0 +1,151 @@
+package auth_test
+
+import (
+	"bytes"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/danpicton/crapnote/internal/auth"
+	"github.com/danpicton/crapnote/internal/db"
+)
+
+// withAuditLogger replaces slog.Default for the duration of the test and
+// returns a buffer containing captured log output.
+func withAuditLogger(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	prev := slog.Default()
+	var buf bytes.Buffer
+	// A text handler at DEBUG keeps every audit event (Info/Warn/Error).
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return &buf
+}
+
+func newAuditFixture(t *testing.T) (*auth.Handler, *auth.AdminHandler, *auth.Service, *auth.UserRepo) {
+	t.Helper()
+	database, err := db.Open(db.Config{SQLitePath: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	userRepo := auth.NewUserRepo(database)
+	svc := auth.NewService(userRepo, auth.NewSessionRepo(database), 7*24*time.Hour)
+	return auth.NewHandler(svc), auth.NewAdminHandler(userRepo), svc, userRepo
+}
+
+func TestAudit_FailedLoginIsLogged(t *testing.T) {
+	buf := withAuditLogger(t)
+	h, _, svc, _ := newAuditFixture(t)
+	svc.SeedAdmin(t.Context(), "admin", "correct") //nolint:errcheck
+
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/login",
+		strings.NewReader(`{"username":"admin","password":"wrong"}`))
+	req.RemoteAddr = "198.51.100.7:1111"
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.Login(w, req)
+
+	out := buf.String()
+	if !strings.Contains(out, "event=login_failed") {
+		t.Fatalf("expected login_failed event in audit log, got: %s", out)
+	}
+	if !strings.Contains(out, "username=admin") {
+		t.Fatalf("expected username in audit log, got: %s", out)
+	}
+	if !strings.Contains(out, "ip=198.51.100.7") {
+		t.Fatalf("expected client IP in audit log, got: %s", out)
+	}
+}
+
+func TestAudit_SuccessfulLoginIsLogged(t *testing.T) {
+	buf := withAuditLogger(t)
+	h, _, svc, _ := newAuditFixture(t)
+	svc.SeedAdmin(t.Context(), "admin", "correct") //nolint:errcheck
+
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/login",
+		strings.NewReader(`{"username":"admin","password":"correct"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Forwarded-For", "203.0.113.9")
+	w := httptest.NewRecorder()
+	h.Login(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("login did not succeed: %d %s", w.Code, w.Body.String())
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "event=login_succeeded") {
+		t.Fatalf("expected login_succeeded event in audit log, got: %s", out)
+	}
+	if !strings.Contains(out, "user_id=1") {
+		t.Fatalf("expected user_id in audit log, got: %s", out)
+	}
+	if !strings.Contains(out, "ip=203.0.113.9") {
+		t.Fatalf("expected X-Forwarded-For IP in audit log, got: %s", out)
+	}
+}
+
+func TestAudit_UserCreationIsLogged(t *testing.T) {
+	buf := withAuditLogger(t)
+	_, admin, _, userRepo := newAuditFixture(t)
+
+	actor, err := userRepo.Create(t.Context(), "root", "$2a$12$x", true)
+	if err != nil {
+		t.Fatalf("seed actor: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/admin/users",
+		strings.NewReader(`{"username":"bob","password":"correcthorsebattery","is_admin":false}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(auth.WithUser(req.Context(), actor))
+	w := httptest.NewRecorder()
+	admin.CreateUser(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create user failed: %d %s", w.Code, w.Body.String())
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "event=user_created") {
+		t.Fatalf("expected user_created event in audit log, got: %s", out)
+	}
+	if !strings.Contains(out, "new_username=bob") {
+		t.Fatalf("expected new_username in audit log, got: %s", out)
+	}
+	if !strings.Contains(out, "admin_id=1") {
+		t.Fatalf("expected admin_id in audit log, got: %s", out)
+	}
+}
+
+func TestAudit_UserDeletionIsLogged(t *testing.T) {
+	buf := withAuditLogger(t)
+	_, admin, _, userRepo := newAuditFixture(t)
+
+	actor, _ := userRepo.Create(t.Context(), "root", "$2a$12$x", true)
+	target, _ := userRepo.Create(t.Context(), "victim", "$2a$12$x", false)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/admin/users/2", nil)
+	req.SetPathValue("id", strconv.FormatInt(target.ID, 10))
+	req = req.WithContext(auth.WithUser(req.Context(), actor))
+	w := httptest.NewRecorder()
+	admin.DeleteUser(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("delete user failed: %d %s", w.Code, w.Body.String())
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "event=user_deleted") {
+		t.Fatalf("expected user_deleted event in audit log, got: %s", out)
+	}
+	if !strings.Contains(out, "admin_id=1") {
+		t.Fatalf("expected admin_id in audit log, got: %s", out)
+	}
+}
+

--- a/backend/internal/auth/handler.go
+++ b/backend/internal/auth/handler.go
@@ -3,7 +3,10 @@ package auth
 import (
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
+
+	"github.com/danpicton/crapnote/internal/httpx"
 )
 
 // Handler holds HTTP handlers for auth endpoints.
@@ -40,13 +43,30 @@ func (h *Handler) Login(w http.ResponseWriter, r *http.Request) {
 
 	sess, err := h.svc.Login(r.Context(), req.Username, req.Password)
 	if errors.Is(err, ErrInvalidCredentials) {
+		slog.Warn("audit: login failed",
+			"event", "login_failed",
+			"username", req.Username,
+			"ip", httpx.ClientIP(r),
+		)
 		writeError(w, http.StatusUnauthorized, "invalid credentials")
 		return
 	}
 	if err != nil {
+		slog.Error("audit: login error",
+			"event", "login_error",
+			"username", req.Username,
+			"ip", httpx.ClientIP(r),
+			"error", err,
+		)
 		writeError(w, http.StatusInternalServerError, "internal error")
 		return
 	}
+
+	slog.Info("audit: login",
+		"event", "login_succeeded",
+		"user_id", sess.UserID,
+		"ip", httpx.ClientIP(r),
+	)
 
 	http.SetCookie(w, &http.Cookie{
 		Name:     "session",
@@ -69,6 +89,13 @@ func (h *Handler) Logout(w http.ResponseWriter, r *http.Request) {
 	cookie, err := r.Cookie("session")
 	if err == nil {
 		h.svc.Logout(r.Context(), cookie.Value) //nolint:errcheck
+		if u := UserFromContext(r.Context()); u != nil {
+			slog.Info("audit: logout",
+				"event", "logout",
+				"user_id", u.ID,
+				"ip", httpx.ClientIP(r),
+			)
+		}
 	}
 
 	// Clear the cookie regardless.

--- a/backend/internal/auth/repository.go
+++ b/backend/internal/auth/repository.go
@@ -98,11 +98,15 @@ func (r *UserRepo) Delete(ctx context.Context, id int64) error {
 	return err
 }
 
-// List returns all users ordered by created_at.
-func (r *UserRepo) List(ctx context.Context) ([]*User, error) {
-	rows, err := r.db.QueryContext(ctx,
-		`SELECT id, username, password_hash, is_admin, created_at FROM users ORDER BY created_at`,
-	)
+// List returns users ordered by created_at. limit <= 0 returns all users.
+func (r *UserRepo) List(ctx context.Context, limit, offset int) ([]*User, error) {
+	query := `SELECT id, username, password_hash, is_admin, created_at FROM users ORDER BY created_at`
+	var args []any
+	if limit > 0 {
+		query += ` LIMIT ? OFFSET ?`
+		args = append(args, limit, offset)
+	}
+	rows, err := r.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("list users: %w", err)
 	}

--- a/backend/internal/httpx/pagination.go
+++ b/backend/internal/httpx/pagination.go
@@ -1,0 +1,65 @@
+// Package httpx provides small HTTP helpers shared across handlers.
+package httpx
+
+import (
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// ClientIP returns a stable key identifying the requesting client. It prefers
+// the first entry of X-Forwarded-For (set by a trusted reverse proxy), then
+// X-Real-IP, and falls back to r.RemoteAddr. Deployments that sit directly
+// on the public internet without a proxy should be aware that XFF is
+// spoofable.
+func ClientIP(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		if i := strings.IndexByte(xff, ','); i >= 0 {
+			return strings.TrimSpace(xff[:i])
+		}
+		return strings.TrimSpace(xff)
+	}
+	if xri := r.Header.Get("X-Real-IP"); xri != "" {
+		return strings.TrimSpace(xri)
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}
+
+// Defaults used by ParsePage when the caller omits query parameters.
+const (
+	DefaultPageSize = 50
+	MaxPageSize     = 100
+)
+
+// Page holds the effective pagination parameters for a list request.
+type Page struct {
+	Limit  int
+	Offset int
+}
+
+// ParsePage reads ?limit=&offset= from the request URL. Missing, invalid, or
+// out-of-range values are replaced with safe defaults: Limit in [1,MaxPageSize]
+// and Offset >= 0. This is a denial-of-service guard — no list endpoint may
+// return an unbounded number of rows.
+func ParsePage(r *http.Request) Page {
+	p := Page{Limit: DefaultPageSize, Offset: 0}
+	if s := r.URL.Query().Get("limit"); s != "" {
+		if n, err := strconv.Atoi(s); err == nil && n > 0 {
+			if n > MaxPageSize {
+				n = MaxPageSize
+			}
+			p.Limit = n
+		}
+	}
+	if s := r.URL.Query().Get("offset"); s != "" {
+		if n, err := strconv.Atoi(s); err == nil && n >= 0 {
+			p.Offset = n
+		}
+	}
+	return p
+}

--- a/backend/internal/httpx/pagination_test.go
+++ b/backend/internal/httpx/pagination_test.go
@@ -1,0 +1,42 @@
+package httpx_test
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/danpicton/crapnote/internal/httpx"
+)
+
+func TestParsePage_Defaults(t *testing.T) {
+	r := httptest.NewRequest("GET", "/api/notes", nil)
+	p := httpx.ParsePage(r)
+	if p.Limit != httpx.DefaultPageSize || p.Offset != 0 {
+		t.Fatalf("expected defaults, got limit=%d offset=%d", p.Limit, p.Offset)
+	}
+}
+
+func TestParsePage_ClampsAboveMax(t *testing.T) {
+	r := httptest.NewRequest("GET", "/api/notes?limit=999", nil)
+	p := httpx.ParsePage(r)
+	if p.Limit != httpx.MaxPageSize {
+		t.Fatalf("expected limit clamped to %d, got %d", httpx.MaxPageSize, p.Limit)
+	}
+}
+
+func TestParsePage_IgnoresInvalidValues(t *testing.T) {
+	for _, raw := range []string{"abc", "-5", "0"} {
+		r := httptest.NewRequest("GET", "/api/notes?limit="+raw, nil)
+		p := httpx.ParsePage(r)
+		if p.Limit != httpx.DefaultPageSize {
+			t.Fatalf("limit=%q: expected default, got %d", raw, p.Limit)
+		}
+	}
+}
+
+func TestParsePage_AcceptsValidOffset(t *testing.T) {
+	r := httptest.NewRequest("GET", "/api/notes?offset=42", nil)
+	p := httpx.ParsePage(r)
+	if p.Offset != 42 {
+		t.Fatalf("expected offset 42, got %d", p.Offset)
+	}
+}

--- a/backend/internal/images/handler.go
+++ b/backend/internal/images/handler.go
@@ -10,9 +10,42 @@ import (
 	"net/http"
 
 	"github.com/danpicton/crapnote/internal/auth"
+	"github.com/danpicton/crapnote/internal/ratelimit"
 )
 
 const maxImageSize = 10 << 20 // 10 MB
+
+// Config controls per-user upload throttling and storage quota. See issue #15.
+type Config struct {
+	// UploadsPerMinute caps how often a single user may upload.
+	UploadsPerMinute int
+	// QuotaBytes is the maximum cumulative image storage per user. A new
+	// upload is rejected if it would push the user over this limit.
+	QuotaBytes int64
+}
+
+// DefaultConfig returns the production upload throttling settings.
+func DefaultConfig() Config {
+	return Config{
+		UploadsPerMinute: 10,
+		QuotaBytes:       100 << 20, // 100 MB per user
+	}
+}
+
+// allowedImageMIMEs enumerates accepted image MIME types. Anything else is
+// rejected so attackers cannot smuggle arbitrary binaries through the upload
+// endpoint.
+var allowedImageMIMEs = map[string]struct{}{
+	"image/jpeg": {},
+	"image/png":  {},
+	"image/gif":  {},
+	"image/webp": {},
+}
+
+func isAllowedImage(mime string) bool {
+	_, ok := allowedImageMIMEs[mime]
+	return ok
+}
 
 // Data holds the raw bytes and MIME type of a stored image.
 type Data struct {
@@ -47,12 +80,32 @@ func FetchByIDs(ctx context.Context, db *sql.DB, userID int64, ids []string) (ma
 
 // Handler holds HTTP handlers for image upload and serving.
 type Handler struct {
-	db *sql.DB
+	db         *sql.DB
+	limiter    *ratelimit.Limiter
+	quotaBytes int64
 }
 
-// NewHandler creates a new images Handler.
+// NewHandler creates a new images Handler with production defaults.
 func NewHandler(db *sql.DB) *Handler {
-	return &Handler{db: db}
+	return NewHandlerWith(db, DefaultConfig())
+}
+
+// NewHandlerWith creates a new images Handler with custom upload limits.
+func NewHandlerWith(db *sql.DB, cfg Config) *Handler {
+	if cfg.UploadsPerMinute <= 0 {
+		cfg.UploadsPerMinute = DefaultConfig().UploadsPerMinute
+	}
+	if cfg.QuotaBytes <= 0 {
+		cfg.QuotaBytes = DefaultConfig().QuotaBytes
+	}
+	return &Handler{
+		db: db,
+		limiter: ratelimit.New(
+			float64(cfg.UploadsPerMinute)/60.0,
+			cfg.UploadsPerMinute,
+		),
+		quotaBytes: cfg.QuotaBytes,
+	}
 }
 
 // Upload handles POST /api/images (multipart form with field "image").
@@ -63,13 +116,21 @@ func (h *Handler) Upload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Per-user rate limit — protects against a single account being used to
+	// fill storage by rapid successive uploads.
+	if !h.limiter.Allow(fmt.Sprintf("u:%d", u.ID)) {
+		w.Header().Set("Retry-After", "60")
+		writeError(w, http.StatusTooManyRequests, "upload rate limit exceeded")
+		return
+	}
+
 	r.Body = http.MaxBytesReader(w, r.Body, maxImageSize+512)
 	if err := r.ParseMultipartForm(maxImageSize); err != nil {
 		writeError(w, http.StatusBadRequest, "image too large or bad request")
 		return
 	}
 
-	file, header, err := r.FormFile("image")
+	file, _, err := r.FormFile("image")
 	if err != nil {
 		writeError(w, http.StatusBadRequest, "missing image field")
 		return
@@ -82,9 +143,24 @@ func (h *Handler) Upload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	mimeType := header.Header.Get("Content-Type")
-	if mimeType == "" {
-		mimeType = http.DetectContentType(data)
+	// Reject anything that does not sniff as one of the allowed image types.
+	// Trusting the client-supplied Content-Type would let attackers store
+	// arbitrary payloads in the images table.
+	mimeType := http.DetectContentType(data)
+	if !isAllowedImage(mimeType) {
+		writeError(w, http.StatusUnsupportedMediaType, "not an image")
+		return
+	}
+
+	// Per-user storage quota: reject the upload if it would exceed the cap.
+	used, err := currentImageBytes(r.Context(), h.db, u.ID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+	if used+int64(len(data)) > h.quotaBytes {
+		writeError(w, http.StatusInsufficientStorage, "storage quota exceeded")
+		return
 	}
 
 	id := newID()
@@ -101,6 +177,19 @@ func (h *Handler) Upload(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
 	json.NewEncoder(w).Encode(map[string]string{"url": "/api/images/" + id}) //nolint:errcheck
+}
+
+// currentImageBytes returns the total bytes of images currently owned by
+// userID. Used to enforce a per-user storage quota.
+func currentImageBytes(ctx context.Context, db *sql.DB, userID int64) (int64, error) {
+	var total sql.NullInt64
+	err := db.QueryRowContext(ctx,
+		`SELECT COALESCE(SUM(LENGTH(data)), 0) FROM images WHERE user_id = ?`, userID,
+	).Scan(&total)
+	if err != nil {
+		return 0, err
+	}
+	return total.Int64, nil
 }
 
 // Serve handles GET /api/images/{id}.

--- a/backend/internal/images/limits_test.go
+++ b/backend/internal/images/limits_test.go
@@ -1,0 +1,113 @@
+package images_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/danpicton/crapnote/internal/auth"
+	"github.com/danpicton/crapnote/internal/db"
+	"github.com/danpicton/crapnote/internal/images"
+)
+
+// newFixtureWith builds an images.Handler with a custom Config so tests can
+// exercise rate-limit and quota boundaries without depending on production
+// defaults.
+func newFixtureWith(t *testing.T, cfg images.Config) (*images.Handler, *auth.User) {
+	t.Helper()
+	database, err := db.Open(db.Config{SQLitePath: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	user, err := auth.NewUserRepo(database).Create(t.Context(), "alice", "$2a$12$x", false)
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	return images.NewHandlerWith(database, cfg), user
+}
+
+// Uploads that are not actually image bytes must be rejected with 415 —
+// attackers cannot rely on the Content-Type header alone.
+func TestUpload_RejectsNonImageBytes(t *testing.T) {
+	h, user := newFixture(t)
+
+	req := multipartUpload(t, []byte("not an image at all, just text"), "image/png")
+	req = withUser(req, user)
+	w := httptest.NewRecorder()
+	h.Upload(w, req)
+
+	if w.Code != http.StatusUnsupportedMediaType {
+		t.Fatalf("expected 415 for non-image bytes, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// Uploads that would push a user over their quota must be rejected with 507.
+func TestUpload_EnforcesPerUserQuota(t *testing.T) {
+	// Quota of 50 bytes — single minimal PNG (~67 bytes) exceeds it.
+	h, user := newFixtureWith(t, images.Config{UploadsPerMinute: 100, QuotaBytes: 50})
+
+	req := multipartUpload(t, minimalPNG(), "")
+	req = withUser(req, user)
+	w := httptest.NewRecorder()
+	h.Upload(w, req)
+
+	if w.Code != http.StatusInsufficientStorage {
+		t.Fatalf("expected 507 when over quota, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// After the per-user burst is exhausted, further uploads return 429.
+func TestUpload_RateLimitedPerUser(t *testing.T) {
+	h, user := newFixtureWith(t, images.Config{UploadsPerMinute: 1, QuotaBytes: 100 << 20})
+
+	upload := func() int {
+		req := multipartUpload(t, minimalPNG(), "")
+		req = withUser(req, user)
+		w := httptest.NewRecorder()
+		h.Upload(w, req)
+		return w.Code
+	}
+
+	if code := upload(); code != http.StatusCreated {
+		t.Fatalf("first upload: expected 201, got %d", code)
+	}
+	if code := upload(); code != http.StatusTooManyRequests {
+		t.Fatalf("second upload: expected 429 after burst, got %d", code)
+	}
+}
+
+// Rate-limit buckets are keyed by user so one user cannot starve another.
+func TestUpload_RateLimitIsPerUser(t *testing.T) {
+	database, err := db.Open(db.Config{SQLitePath: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	userRepo := auth.NewUserRepo(database)
+	alice, _ := userRepo.Create(t.Context(), "alice", "$2a$12$x", false)
+	bob, _ := userRepo.Create(t.Context(), "bob", "$2a$12$x", false)
+	h := images.NewHandlerWith(database, images.Config{UploadsPerMinute: 1, QuotaBytes: 100 << 20})
+
+	// Alice spends her single allowed upload.
+	req := multipartUpload(t, minimalPNG(), "")
+	req = withUser(req, alice)
+	w := httptest.NewRecorder()
+	h.Upload(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("alice upload: expected 201, got %d", w.Code)
+	}
+
+	// Bob should still be able to upload — his bucket is independent.
+	req = multipartUpload(t, minimalPNG(), "")
+	req = withUser(req, bob)
+	w = httptest.NewRecorder()
+	h.Upload(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("bob upload: expected 201, got %d (alice's bucket should not affect bob)", w.Code)
+	}
+}
+

--- a/backend/internal/notes/handler.go
+++ b/backend/internal/notes/handler.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/danpicton/crapnote/internal/auth"
+	"github.com/danpicton/crapnote/internal/httpx"
 )
 
 const (
@@ -49,6 +50,10 @@ func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
 	}
 
 	filter.Search = r.URL.Query().Get("search")
+
+	page := httpx.ParsePage(r)
+	filter.Limit = page.Limit
+	filter.Offset = page.Offset
 
 	notes, err := h.svc.List(r.Context(), u.ID, filter)
 	if err != nil {
@@ -250,7 +255,8 @@ func (h *Handler) ListArchived(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusUnauthorized, "not authenticated")
 		return
 	}
-	notes, err := h.svc.ListArchived(r.Context(), u.ID)
+	page := httpx.ParsePage(r)
+	notes, err := h.svc.ListArchived(r.Context(), u.ID, page.Limit, page.Offset)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal error")
 		return

--- a/backend/internal/notes/handler_test.go
+++ b/backend/internal/notes/handler_test.go
@@ -435,3 +435,54 @@ func TestNotesHandler_ResponseOmitsUserID(t *testing.T) {
 		t.Fatal("user_id must not be present in note response")
 	}
 }
+
+// List honours the ?limit= query parameter. Issue #18.
+func TestNotesHandler_List_RespectsLimit(t *testing.T) {
+	h, user := newHandlerFixture(t)
+
+	// Create three notes.
+	for i := 0; i < 3; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/api/notes",
+			bytes.NewBufferString(fmt.Sprintf(`{"title":"n%d"}`, i)))
+		req.Header.Set("Content-Type", "application/json")
+		req = withUser(req, user)
+		h.Create(httptest.NewRecorder(), req)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/notes?limit=2", nil)
+	req = withUser(req, user)
+	w := httptest.NewRecorder()
+	h.List(w, req)
+
+	var resp []map[string]any
+	json.NewDecoder(w.Body).Decode(&resp) //nolint:errcheck
+	if len(resp) != 2 {
+		t.Fatalf("expected 2 notes with limit=2, got %d", len(resp))
+	}
+}
+
+// Limits beyond the server maximum are clamped so an attacker cannot override
+// the safety default by passing a huge limit.
+func TestNotesHandler_List_ClampsExcessiveLimit(t *testing.T) {
+	h, user := newHandlerFixture(t)
+
+	// Create 150 notes (over the MaxPageSize of 100).
+	for i := 0; i < 150; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/api/notes",
+			bytes.NewBufferString(fmt.Sprintf(`{"title":"n%d"}`, i)))
+		req.Header.Set("Content-Type", "application/json")
+		req = withUser(req, user)
+		h.Create(httptest.NewRecorder(), req)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/notes?limit=9999", nil)
+	req = withUser(req, user)
+	w := httptest.NewRecorder()
+	h.List(w, req)
+
+	var resp []map[string]any
+	json.NewDecoder(w.Body).Decode(&resp) //nolint:errcheck
+	if len(resp) != 100 { // MaxPageSize from httpx
+		t.Fatalf("expected response clamped to 100, got %d", len(resp))
+	}
+}

--- a/backend/internal/notes/model.go
+++ b/backend/internal/notes/model.go
@@ -26,4 +26,6 @@ type ListFilter struct {
 	Starred *bool  // nil = no filter
 	TagID   *int64 // nil = no filter
 	Search  string // empty = no FTS filter
+	Limit   int    // <=0 means no bound (used only for admin/exports)
+	Offset  int
 }

--- a/backend/internal/notes/repository.go
+++ b/backend/internal/notes/repository.go
@@ -103,6 +103,11 @@ func (r *Repo) List(ctx context.Context, userID int64, filter ListFilter) ([]*No
 
 	query += ` ORDER BY n.pinned DESC, n.updated_at DESC`
 
+	if filter.Limit > 0 {
+		query += ` LIMIT ? OFFSET ?`
+		args = append(args, filter.Limit, filter.Offset)
+	}
+
 	rows, err := r.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("list notes: %w", err)
@@ -219,17 +224,24 @@ func (r *Repo) Unarchive(ctx context.Context, id, userID int64) error {
 	return nil
 }
 
-// ListArchived returns archived, non-trashed notes for a user ordered by updated_at DESC.
-func (r *Repo) ListArchived(ctx context.Context, userID int64) ([]*Note, error) {
-	rows, err := r.db.QueryContext(ctx, `
+// ListArchived returns archived, non-trashed notes for a user ordered by
+// updated_at DESC. limit <= 0 disables pagination (only used in trusted
+// contexts such as full exports).
+func (r *Repo) ListArchived(ctx context.Context, userID int64, limit, offset int) ([]*Note, error) {
+	query := `
 		SELECT n.id, n.user_id, n.title, n.body, n.starred, n.pinned, n.archived,
 		       n.created_at, n.updated_at
 		FROM notes n
 		WHERE n.user_id = ?
 		  AND n.archived = 1
 		  AND NOT EXISTS (SELECT 1 FROM trash t WHERE t.note_id = n.id)
-		ORDER BY n.updated_at DESC
-	`, userID)
+		ORDER BY n.updated_at DESC`
+	args := []any{userID}
+	if limit > 0 {
+		query += ` LIMIT ? OFFSET ?`
+		args = append(args, limit, offset)
+	}
+	rows, err := r.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("list archived: %w", err)
 	}

--- a/backend/internal/notes/repository_test.go
+++ b/backend/internal/notes/repository_test.go
@@ -253,7 +253,7 @@ func TestNoteRepo_Archive(t *testing.T) {
 	}
 
 	// But it must appear in ListArchived.
-	archived, err := repo.ListArchived(ctx, userID)
+	archived, err := repo.ListArchived(ctx, userID, 0, 0)
 	if err != nil {
 		t.Fatalf("ListArchived: %v", err)
 	}
@@ -304,7 +304,7 @@ func TestNoteRepo_ListArchived_ExcludesTrashed(t *testing.T) {
 	repo.Archive(ctx, note.ID, userID)  //nolint:errcheck
 	repo.SoftDelete(ctx, note.ID, userID) //nolint:errcheck
 
-	archived, _ := repo.ListArchived(ctx, userID)
+	archived, _ := repo.ListArchived(ctx, userID, 0, 0)
 	for _, n := range archived {
 		if n.ID == note.ID {
 			t.Fatal("trashed+archived note should not appear in ListArchived")

--- a/backend/internal/notes/service.go
+++ b/backend/internal/notes/service.go
@@ -77,9 +77,10 @@ func (s *Service) Unarchive(ctx context.Context, id, userID int64) error {
 	return s.repo.Unarchive(ctx, id, userID)
 }
 
-// ListArchived returns all archived notes for a user.
-func (s *Service) ListArchived(ctx context.Context, userID int64) ([]*Note, error) {
-	return s.repo.ListArchived(ctx, userID)
+// ListArchived returns archived notes for a user, optionally paginated.
+// limit <= 0 disables pagination.
+func (s *Service) ListArchived(ctx context.Context, userID int64, limit, offset int) ([]*Note, error) {
+	return s.repo.ListArchived(ctx, userID, limit, offset)
 }
 
 // TogglePin flips the pinned flag and returns the updated note.

--- a/backend/internal/notes/service_test.go
+++ b/backend/internal/notes/service_test.go
@@ -163,7 +163,7 @@ func TestService_Archive(t *testing.T) {
 	}
 
 	// ListArchived must include it.
-	archived, err := svc.ListArchived(ctx, userID)
+	archived, err := svc.ListArchived(ctx, userID, 0, 0)
 	if err != nil {
 		t.Fatalf("ListArchived: %v", err)
 	}

--- a/backend/internal/ratelimit/middleware_test.go
+++ b/backend/internal/ratelimit/middleware_test.go
@@ -1,0 +1,54 @@
+package ratelimit_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/danpicton/crapnote/internal/ratelimit"
+)
+
+func TestMiddleware_Returns429WhenExhausted(t *testing.T) {
+	l := ratelimit.New(0.01, 1) // effectively 1 request then denied
+	mw := ratelimit.Middleware(l, func(r *http.Request) string { return "k" })
+
+	h := mw(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	r1 := httptest.NewRequest(http.MethodPost, "/x", nil)
+	w1 := httptest.NewRecorder()
+	h.ServeHTTP(w1, r1)
+	if w1.Code != http.StatusOK {
+		t.Fatalf("first request: expected 200, got %d", w1.Code)
+	}
+
+	r2 := httptest.NewRequest(http.MethodPost, "/x", nil)
+	w2 := httptest.NewRecorder()
+	h.ServeHTTP(w2, r2)
+	if w2.Code != http.StatusTooManyRequests {
+		t.Fatalf("second request: expected 429, got %d", w2.Code)
+	}
+	if got := w2.Header().Get("Retry-After"); got == "" {
+		t.Fatal("expected Retry-After header set on 429")
+	}
+}
+
+func TestClientIP_PrefersXForwardedFor(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.RemoteAddr = "10.0.0.1:1234"
+	r.Header.Set("X-Forwarded-For", "203.0.113.5, 10.0.0.1")
+
+	if got := ratelimit.ClientIP(r); got != "203.0.113.5" {
+		t.Fatalf("expected 203.0.113.5, got %q", got)
+	}
+}
+
+func TestClientIP_FallsBackToRemoteAddr(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.RemoteAddr = "10.0.0.1:1234"
+
+	if got := ratelimit.ClientIP(r); got != "10.0.0.1" {
+		t.Fatalf("expected 10.0.0.1, got %q", got)
+	}
+}

--- a/backend/internal/ratelimit/ratelimit.go
+++ b/backend/internal/ratelimit/ratelimit.go
@@ -1,0 +1,119 @@
+// Package ratelimit provides a simple in-memory per-key token-bucket rate
+// limiter and HTTP middleware. It is intentionally dependency-free and suited
+// to single-process deployments; a distributed setup would need a shared store.
+package ratelimit
+
+import (
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/danpicton/crapnote/internal/httpx"
+)
+
+// Limiter is an in-memory per-key token-bucket rate limiter.
+type Limiter struct {
+	mu      sync.Mutex
+	buckets map[string]*bucket
+	rate    float64 // tokens per second
+	burst   float64 // max tokens (bucket capacity)
+	ttl     time.Duration
+	lastGC  time.Time
+	now     func() time.Time
+}
+
+type bucket struct {
+	tokens float64
+	last   time.Time
+}
+
+// New returns a Limiter with the given refill rate (tokens/sec) and burst.
+func New(ratePerSecond float64, burst int) *Limiter {
+	return &Limiter{
+		buckets: map[string]*bucket{},
+		rate:    ratePerSecond,
+		burst:   float64(burst),
+		ttl:     10 * time.Minute,
+		now:     time.Now,
+	}
+}
+
+// SetTTL configures how long an idle bucket may live before being pruned.
+func (l *Limiter) SetTTL(ttl time.Duration) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.ttl = ttl
+}
+
+// Size returns the number of tracked buckets (for tests/metrics).
+func (l *Limiter) Size() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return len(l.buckets)
+}
+
+// Allow reports whether a request from key is permitted now.
+func (l *Limiter) Allow(key string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	now := l.now()
+	l.gcLocked(now)
+
+	b, ok := l.buckets[key]
+	if !ok {
+		b = &bucket{tokens: l.burst, last: now}
+		l.buckets[key] = b
+	} else {
+		elapsed := now.Sub(b.last).Seconds()
+		b.tokens += elapsed * l.rate
+		if b.tokens > l.burst {
+			b.tokens = l.burst
+		}
+		b.last = now
+	}
+
+	if b.tokens >= 1 {
+		b.tokens--
+		return true
+	}
+	return false
+}
+
+// gcLocked removes buckets that have been idle for longer than ttl.
+// Caller must hold l.mu. Runs at most once per ttl interval to keep Allow O(1)
+// amortised.
+func (l *Limiter) gcLocked(now time.Time) {
+	if now.Sub(l.lastGC) < l.ttl {
+		return
+	}
+	l.lastGC = now
+	for k, b := range l.buckets {
+		if now.Sub(b.last) > l.ttl {
+			delete(l.buckets, k)
+		}
+	}
+}
+
+// ClientIP is a re-export of httpx.ClientIP kept for callers that already
+// wire ratelimit.Middleware; new code should import httpx directly.
+func ClientIP(r *http.Request) string {
+	return httpx.ClientIP(r)
+}
+
+// Middleware returns HTTP middleware that denies requests with 429 when the
+// per-key limiter is exhausted. key is derived from the request via keyFn.
+func Middleware(l *Limiter, keyFn func(*http.Request) string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !l.Allow(keyFn(r)) {
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("Retry-After", "60")
+				w.WriteHeader(http.StatusTooManyRequests)
+				_, _ = w.Write([]byte(`{"error":"too many requests"}`))
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/backend/internal/ratelimit/ratelimit_test.go
+++ b/backend/internal/ratelimit/ratelimit_test.go
@@ -1,0 +1,73 @@
+package ratelimit_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/danpicton/crapnote/internal/ratelimit"
+)
+
+// Burst fills the bucket, then requests are denied until tokens refill.
+func TestLimiter_AllowsBurstThenDenies(t *testing.T) {
+	l := ratelimit.New(1, 3) // 1 token per second, burst of 3
+
+	for i := 0; i < 3; i++ {
+		if !l.Allow("1.2.3.4") {
+			t.Fatalf("expected request %d allowed, got denied", i+1)
+		}
+	}
+
+	if l.Allow("1.2.3.4") {
+		t.Fatal("expected 4th request denied after burst")
+	}
+}
+
+// Separate keys have independent buckets.
+func TestLimiter_PerKeyIsolation(t *testing.T) {
+	l := ratelimit.New(1, 1)
+
+	if !l.Allow("a") {
+		t.Fatal("a first request should be allowed")
+	}
+	if l.Allow("a") {
+		t.Fatal("a second request should be denied")
+	}
+	if !l.Allow("b") {
+		t.Fatal("b first request should be allowed (independent bucket)")
+	}
+}
+
+// Tokens refill over time.
+func TestLimiter_RefillsOverTime(t *testing.T) {
+	l := ratelimit.New(100, 1) // 100 tokens/s, burst 1 — refills quickly
+
+	if !l.Allow("k") {
+		t.Fatal("first request should be allowed")
+	}
+	if l.Allow("k") {
+		t.Fatal("immediate second request should be denied")
+	}
+
+	time.Sleep(50 * time.Millisecond) // should refill ~5 tokens; capped at 1
+	if !l.Allow("k") {
+		t.Fatal("request after refill should be allowed")
+	}
+}
+
+// Stale buckets should be pruned so the map does not grow unbounded.
+func TestLimiter_PrunesIdleBuckets(t *testing.T) {
+	l := ratelimit.New(1, 1)
+	l.SetTTL(10 * time.Millisecond)
+
+	l.Allow("stale") // create bucket
+	if n := l.Size(); n != 1 {
+		t.Fatalf("expected 1 bucket, got %d", n)
+	}
+
+	time.Sleep(20 * time.Millisecond)
+	l.Allow("fresh") // triggers pruning; "stale" should be removed
+
+	if n := l.Size(); n != 1 {
+		t.Fatalf("expected 1 bucket after prune, got %d", n)
+	}
+}

--- a/backend/internal/tags/handler.go
+++ b/backend/internal/tags/handler.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/danpicton/crapnote/internal/auth"
+	"github.com/danpicton/crapnote/internal/httpx"
 )
 
 const maxTagNameLen = 100
@@ -29,7 +30,8 @@ func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	list, err := h.svc.List(r.Context(), u.ID)
+	page := httpx.ParsePage(r)
+	list, err := h.svc.List(r.Context(), u.ID, page.Limit, page.Offset)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal error")
 		return

--- a/backend/internal/tags/repository.go
+++ b/backend/internal/tags/repository.go
@@ -31,17 +31,24 @@ func (r *Repo) Create(ctx context.Context, userID int64, name string) (*Tag, err
 	return r.FindByID(ctx, id, userID)
 }
 
-// List returns all tags for a user with their note counts.
-func (r *Repo) List(ctx context.Context, userID int64) ([]*TagWithCount, error) {
-	rows, err := r.db.QueryContext(ctx, `
+// List returns tags for a user with their note counts. limit <= 0 disables
+// pagination; otherwise LIMIT/OFFSET are applied to keep list responses
+// bounded.
+func (r *Repo) List(ctx context.Context, userID int64, limit, offset int) ([]*TagWithCount, error) {
+	query := `
 		SELECT t.id, t.user_id, t.name, t.created_at,
 		       COUNT(nt.note_id) AS note_count
 		FROM tags t
 		LEFT JOIN note_tags nt ON nt.tag_id = t.id
 		WHERE t.user_id = ?
 		GROUP BY t.id
-		ORDER BY t.name
-	`, userID)
+		ORDER BY t.name`
+	args := []any{userID}
+	if limit > 0 {
+		query += ` LIMIT ? OFFSET ?`
+		args = append(args, limit, offset)
+	}
+	rows, err := r.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("list tags: %w", err)
 	}

--- a/backend/internal/tags/repository_test.go
+++ b/backend/internal/tags/repository_test.go
@@ -56,7 +56,7 @@ func TestTagRepo_CreateAndList(t *testing.T) {
 		t.Fatalf("unexpected tag: %+v", tag)
 	}
 
-	list, err := repo.List(ctx, userID)
+	list, err := repo.List(ctx, userID, 0, 0)
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
@@ -77,7 +77,7 @@ func TestTagRepo_List_NoteCount(t *testing.T) {
 	repo.AddToNote(ctx, n1, tag.ID, userID) //nolint:errcheck
 	repo.AddToNote(ctx, n2, tag.ID, userID) //nolint:errcheck
 
-	list, _ := repo.List(ctx, userID)
+	list, _ := repo.List(ctx, userID, 0, 0)
 	if list[0].NoteCount != 2 {
 		t.Fatalf("expected NoteCount=2, got %d", list[0].NoteCount)
 	}

--- a/backend/internal/tags/service.go
+++ b/backend/internal/tags/service.go
@@ -16,8 +16,8 @@ func (s *Service) Create(ctx context.Context, userID int64, name string) (*Tag, 
 	return s.repo.Create(ctx, userID, name)
 }
 
-func (s *Service) List(ctx context.Context, userID int64) ([]*TagWithCount, error) {
-	return s.repo.List(ctx, userID)
+func (s *Service) List(ctx context.Context, userID int64, limit, offset int) ([]*TagWithCount, error) {
+	return s.repo.List(ctx, userID, limit, offset)
 }
 
 func (s *Service) FindByID(ctx context.Context, id, userID int64) (*Tag, error) {

--- a/backend/internal/tags/service_test.go
+++ b/backend/internal/tags/service_test.go
@@ -23,7 +23,7 @@ func TestService_CreateAndList(t *testing.T) {
 		t.Fatalf("Create: %v", err)
 	}
 
-	list, err := svc.List(ctx, userID)
+	list, err := svc.List(ctx, userID, 0, 0)
 	if err != nil || len(list) != 1 || list[0].Name != "alpha" {
 		t.Fatalf("List: %v / %+v", err, list)
 	}

--- a/backend/internal/trash/handler.go
+++ b/backend/internal/trash/handler.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/danpicton/crapnote/internal/auth"
+	"github.com/danpicton/crapnote/internal/httpx"
 )
 
 // Handler holds HTTP handlers for trash endpoints.
@@ -27,7 +28,8 @@ func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	entries, err := h.svc.List(r.Context(), u.ID)
+	page := httpx.ParsePage(r)
+	entries, err := h.svc.List(r.Context(), u.ID, page.Limit, page.Offset)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal error")
 		return

--- a/backend/internal/trash/repository.go
+++ b/backend/internal/trash/repository.go
@@ -20,15 +20,21 @@ func NewRepo(database *db.DB) *Repo {
 	return &Repo{db: database}
 }
 
-// List returns all trashed notes for the given user.
-func (r *Repo) List(ctx context.Context, userID int64) ([]*Entry, error) {
-	rows, err := r.db.QueryContext(ctx, `
+// List returns trashed notes for the given user. limit <= 0 disables
+// pagination.
+func (r *Repo) List(ctx context.Context, userID int64, limit, offset int) ([]*Entry, error) {
+	query := `
 		SELECT t.note_id, t.user_id, n.title, t.deleted_at
 		FROM trash t
 		JOIN notes n ON n.id = t.note_id
 		WHERE t.user_id = ?
-		ORDER BY t.deleted_at DESC
-	`, userID)
+		ORDER BY t.deleted_at DESC`
+	args := []any{userID}
+	if limit > 0 {
+		query += ` LIMIT ? OFFSET ?`
+		args = append(args, limit, offset)
+	}
+	rows, err := r.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("list trash: %w", err)
 	}

--- a/backend/internal/trash/repository_test.go
+++ b/backend/internal/trash/repository_test.go
@@ -52,7 +52,7 @@ func TestTrashRepo_List(t *testing.T) {
 	trashNote(t, database, noteID, userID)
 
 	repo := trash.NewRepo(database)
-	entries, err := repo.List(context.Background(), userID)
+	entries, err := repo.List(context.Background(), userID, 0, 0)
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
@@ -81,7 +81,7 @@ func TestTrashRepo_Restore(t *testing.T) {
 		t.Fatalf("Restore: %v", err)
 	}
 
-	entries, _ := repo.List(ctx, userID)
+	entries, _ := repo.List(ctx, userID, 0, 0)
 	if len(entries) != 0 {
 		t.Fatal("note should no longer be in trash after restore")
 	}
@@ -154,7 +154,7 @@ func TestTrashRepo_Empty(t *testing.T) {
 		t.Fatalf("Empty: %v", err)
 	}
 
-	entries, _ := repo.List(ctx, userID)
+	entries, _ := repo.List(ctx, userID, 0, 0)
 	if len(entries) != 0 {
 		t.Fatalf("expected empty trash, got %d entries", len(entries))
 	}
@@ -192,7 +192,7 @@ func TestTrashRepo_PurgeExpired(t *testing.T) {
 	}
 
 	// New note should still be in trash.
-	entries, _ := repo.List(ctx, userID)
+	entries, _ := repo.List(ctx, userID, 0, 0)
 	if len(entries) != 1 || entries[0].NoteID != newNote {
 		t.Fatalf("recent note should remain in trash, got %v", entries)
 	}

--- a/backend/internal/trash/service.go
+++ b/backend/internal/trash/service.go
@@ -12,8 +12,8 @@ func NewService(repo *Repo) *Service {
 	return &Service{repo: repo}
 }
 
-func (s *Service) List(ctx context.Context, userID int64) ([]*Entry, error) {
-	return s.repo.List(ctx, userID)
+func (s *Service) List(ctx context.Context, userID int64, limit, offset int) ([]*Entry, error) {
+	return s.repo.List(ctx, userID, limit, offset)
 }
 
 func (s *Service) Restore(ctx context.Context, noteID, userID int64) error {

--- a/deploy/SECURITY.md
+++ b/deploy/SECURITY.md
@@ -1,0 +1,74 @@
+# Deployment security hardening
+
+Operational guidance that lives outside the application itself. These mitigations
+address threats that cannot be handled at the application layer alone.
+
+## 1. Disk / volume encryption (issue #24)
+
+CrapNote stores note content, images (as BLOBs in SQLite), and session tokens
+in a single database file. The primary at-rest threat is an attacker who
+obtains a copy of that file — a stolen backup, a compromised storage volume, or
+unauthorised access to the hosting provider's infrastructure.
+
+**The application does not (and should not) encrypt its own data.** See issue
+#24 for the rationale: application-level encryption destroys full-text search
+and introduces difficult key management, while the problem it solves is
+addressed more simply at the OS/volume layer.
+
+Choose an encryption option appropriate to your deployment:
+
+- **LUKS** on the partition that holds `DATABASE_PATH` (bare metal / VM).
+- **Docker volume encryption** — mount an already-encrypted host volume
+  into the container rather than using a plain bind mount.
+- **Encrypted EBS / persistent disk** on AWS / GCP / Azure. All three
+  providers now enable this by default for new volumes.
+- **Kubernetes**: set `storageClassName` on the PVC in `deploy/k8s/pvc.yaml`
+  to a class backed by an encrypted disk type.
+
+With volume encryption in place the SQLite file at `DATABASE_PATH` and any
+PostgreSQL data directory are transparently protected against offline theft.
+FTS5 continues to work; no application changes are required.
+
+## 2. PostgreSQL Row Level Security (issue #23)
+
+CrapNote supports PostgreSQL as an optional backend. Every application query
+already filters by `user_id`, so RLS is strictly a defence-in-depth mitigation:
+it guarantees that a bug in any current or future query cannot leak rows
+between users.
+
+A ready-to-apply script is in `deploy/postgres/rls.sql`. It:
+
+1. Enables RLS on every user-scoped table.
+2. Creates policies keyed on a per-connection GUC (`app.current_user_id`).
+3. Uses a helper function that fails closed when the GUC is unset.
+
+Before enabling RLS, the following application-layer changes are required —
+otherwise the running app will see zero rows:
+
+1. **Propagate the authenticated user ID through the connection**:
+   on each request, run `SET LOCAL app.current_user_id = $1` inside a
+   transaction, or set it on connection pickup if using session-mode pooling.
+2. **Run the application as a non-superuser role** (see the header of
+   `rls.sql`). Superusers bypass RLS silently, which defeats the point.
+3. **Handle admin endpoints**: `/api/admin/users` intentionally reads across
+   users. Either route admin queries through a role with `BYPASSRLS`, or add
+   policies that permit admins via a separate GUC.
+4. **Use session-mode pooling** if using PgBouncer. Transaction-mode pooling
+   discards session state and breaks RLS.
+
+Because of these prerequisites, RLS is not enabled automatically by a
+migration. It is an operator decision, appropriate for multi-user deployments
+where the additional safety net justifies the connection-layer plumbing.
+
+## 3. Other mitigations already in the app
+
+The following are enforced in code and do not need operator configuration:
+
+- **Login rate limiting** — per-IP token bucket on `POST /api/auth/login`
+  (issue #12). Trip threshold can be tuned via the limiter in
+  `cmd/server/main.go`.
+- **Image upload throttling** — per-user rate limit and storage quota
+  (issue #15). Tunable via `IMAGE_UPLOADS_PER_MINUTE` and `IMAGE_QUOTA_MB`
+  environment variables.
+- **Pagination** — all list endpoints enforce a maximum page size
+  (issue #18). Max is 100 items per request.

--- a/deploy/postgres/rls.sql
+++ b/deploy/postgres/rls.sql
@@ -1,0 +1,81 @@
+-- Row Level Security (RLS) policies for CrapNote (issue #23).
+--
+-- This script is OPTIONAL defence-in-depth for multi-user PostgreSQL
+-- deployments. CrapNote's application code already scopes every query by
+-- user_id, so RLS is belt-and-braces: it guarantees at the database level
+-- that a bug in any future query cannot leak one user's rows to another.
+--
+-- ────────────────────────────────────────────────────────────────────────
+-- How it works
+-- ────────────────────────────────────────────────────────────────────────
+-- Each connection advertises its authenticated user via a custom GUC
+-- (app.current_user_id). Policies on every user-scoped table restrict
+-- SELECT/INSERT/UPDATE/DELETE to rows where user_id matches the GUC.
+--
+-- The application layer must set the GUC at the start of each request:
+--
+--    SET LOCAL app.current_user_id = $1   -- inside a transaction
+--
+-- …or use a pooled connection in session-mode pooling (PgBouncer with
+-- pool_mode = session) and set the value on connection pickup. Transaction
+-- pooling (pool_mode = transaction) drops session state and will break RLS.
+--
+-- ────────────────────────────────────────────────────────────────────────
+-- Application role
+-- ────────────────────────────────────────────────────────────────────────
+-- Run the application as a dedicated role that does NOT have BYPASSRLS.
+-- The superuser / owner role retains full access for migrations and for
+-- admin endpoints that intentionally read across users.
+--
+--   CREATE ROLE crapnote_app LOGIN PASSWORD '…';
+--   GRANT USAGE ON SCHEMA public TO crapnote_app;
+--   GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public
+--     TO crapnote_app;
+--   GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO crapnote_app;
+--
+-- Admin endpoints (e.g. GET /api/admin/users) must use a separate
+-- connection pool that runs as a role with BYPASSRLS, or the policies
+-- below must explicitly include a bypass for admin users.
+-- ────────────────────────────────────────────────────────────────────────
+
+BEGIN;
+
+-- Enable RLS on every user-scoped table.
+ALTER TABLE notes      ENABLE ROW LEVEL SECURITY;
+ALTER TABLE tags       ENABLE ROW LEVEL SECURITY;
+ALTER TABLE note_tags  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE sessions   ENABLE ROW LEVEL SECURITY;
+ALTER TABLE images     ENABLE ROW LEVEL SECURITY;
+ALTER TABLE trash      ENABLE ROW LEVEL SECURITY;
+
+-- Helper: current_user_id() returns NULL when the GUC is unset so policies
+-- fail closed rather than matching user_id = 0 by accident.
+CREATE OR REPLACE FUNCTION app_current_user_id()
+RETURNS BIGINT
+LANGUAGE plpgsql STABLE
+AS $$
+BEGIN
+    RETURN NULLIF(current_setting('app.current_user_id', true), '')::bigint;
+EXCEPTION WHEN others THEN
+    RETURN NULL;
+END;
+$$;
+
+-- Policies: match on user_id for tables that carry one directly.
+CREATE POLICY notes_isolation    ON notes    USING (user_id = app_current_user_id());
+CREATE POLICY tags_isolation     ON tags     USING (user_id = app_current_user_id());
+CREATE POLICY sessions_isolation ON sessions USING (user_id = app_current_user_id());
+CREATE POLICY images_isolation   ON images   USING (user_id = app_current_user_id());
+CREATE POLICY trash_isolation    ON trash    USING (user_id = app_current_user_id());
+
+-- note_tags has no user_id column — derive ownership through the parent note.
+CREATE POLICY note_tags_isolation ON note_tags
+USING (
+    EXISTS (
+        SELECT 1 FROM notes n
+        WHERE n.id = note_tags.note_id
+          AND n.user_id = app_current_user_id()
+    )
+);
+
+COMMIT;

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -19,6 +19,11 @@ export async function startServer() {
       PORT: '4173',
       ADMIN_USERNAME: 'admin',
       ADMIN_PASSWORD: 'admin123',
+      // The production login rate limit (5/min/IP) is far too tight for an
+      // E2E suite that logs in once per test from a single loopback address.
+      // Loosen it here without touching production defaults.
+      LOGIN_RATE_PER_MINUTE: '1000',
+      LOGIN_RATE_BURST: '1000',
     },
     stdio: 'pipe',
   });

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -51,7 +51,10 @@ describe('api.notes', () => {
 	it('list: GET /api/notes', async () => {
 		mockFetch.mockResolvedValueOnce(ok([note]));
 		const result = await api.notes.list();
-		expect(mockFetch).toHaveBeenCalledWith('/api/notes', expect.objectContaining({ method: 'GET' }));
+		const url = mockFetch.mock.calls[0][0] as string;
+		expect(url).toMatch(/^\/api\/notes\?/);
+		expect(url).toContain('limit=100');
+		expect(mockFetch).toHaveBeenCalledWith(url, expect.objectContaining({ method: 'GET' }));
 		expect(result).toHaveLength(1);
 	});
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -74,7 +74,10 @@ export const api = {
 
 	notes: {
 		list: (params?: { starred?: boolean; tag_id?: number; search?: string }) =>
-			request<Note[]>('GET', '/api/notes' + (params ? buildQuery(params as Record<string, string>) : '')),
+			request<Note[]>(
+				'GET',
+				'/api/notes' + buildQuery({ limit: 100, ...(params ?? {}) }),
+			),
 		create: (title?: string, body?: string) =>
 			request<Note>('POST', '/api/notes', { title, body }),
 		get: (id: number) => request<Note>('GET', `/api/notes/${id}`),
@@ -85,11 +88,11 @@ export const api = {
 		togglePin: (id: number) => request<Note>('PATCH', `/api/notes/${id}/pin`),
 		archive: (id: number) => request<void>('PATCH', `/api/notes/${id}/archive`),
 		unarchive: (id: number) => request<void>('PATCH', `/api/notes/${id}/unarchive`),
-		listArchived: () => request<Note[]>('GET', '/api/archive'),
+		listArchived: () => request<Note[]>('GET', '/api/archive?limit=100'),
 	},
 
 	tags: {
-		list: () => request<Tag[]>('GET', '/api/tags'),
+		list: () => request<Tag[]>('GET', '/api/tags?limit=100'),
 		create: (name: string) => request<Tag>('POST', '/api/tags', { name }),
 		rename: (id: number, name: string) => request<Tag>('PUT', `/api/tags/${id}`, { name }),
 		delete: (id: number) => request<void>('DELETE', `/api/tags/${id}`),
@@ -101,7 +104,7 @@ export const api = {
 	},
 
 	trash: {
-		list: () => request<TrashEntry[]>('GET', '/api/trash'),
+		list: () => request<TrashEntry[]>('GET', '/api/trash?limit=100'),
 		restore: (id: number) => request<void>('POST', `/api/trash/${id}/restore`),
 		deleteOne: (id: number) => request<void>('DELETE', `/api/trash/${id}`),
 		empty: () => request<void>('DELETE', '/api/trash'),


### PR DESCRIPTION
## Summary

This PR implements multiple security and operational improvements to CrapNote:
1. **Rate limiting** for login attempts (per-IP) and image uploads (per-user)
2. **Pagination** for list endpoints to prevent unbounded responses
3. **Audit logging** for authentication and user management events
4. **Security hardening** documentation and PostgreSQL Row Level Security support

## Key Changes

### Rate Limiting
- New `ratelimit` package with token-bucket rate limiter and HTTP middleware
- Login endpoint rate-limited to 5 attempts/minute per client IP (configurable via `LOGIN_RATE_LIMIT_PER_MINUTE`)
- Image upload endpoint rate-limited per-user with configurable burst and quota
- Client IP detection via `X-Forwarded-For`, `X-Real-IP`, or `RemoteAddr` headers

### Pagination
- New `httpx` package with `ClientIP()` and `ParsePage()` helpers
- All list endpoints (`/api/notes`, `/api/admin/users`, `/api/tags`, `/api/trash`) now support `?limit=` and `?offset=` query parameters
- Default page size: 50, maximum: 100 (prevents DoS via unbounded list requests)
- Frontend updated to request `limit=100` for notes list

### Audit Logging
- Login events logged with username, IP, and success/failure status
- User creation/deletion logged with admin ID and affected user details
- Uses structured logging via `log/slog` with event names for easy filtering

### Image Upload Security
- MIME type validation: only `image/jpeg`, `image/png`, `image/gif`, `image/webp` accepted
- Content-Type detection via `http.DetectContentType()` (not client-supplied header)
- Per-user storage quota enforcement (default 100 MB, configurable via `IMAGE_QUOTA_MB`)
- Per-user upload rate limiting (default 10/minute, configurable via `IMAGE_UPLOADS_PER_MINUTE`)

### Security Documentation
- New `deploy/SECURITY.md` with hardening guidance
- PostgreSQL Row Level Security (RLS) script in `deploy/postgres/rls.sql`
- Recommendations for disk encryption, connection pooling, and admin endpoint isolation

### Repository Changes
- `List()` methods now accept `limit` and `offset` parameters across auth, notes, tags, and trash packages
- `ListArchived()` similarly updated for pagination support
- Admin handler uses pagination for user listing

## Implementation Details

- Rate limiter uses in-memory per-key token buckets with automatic garbage collection of idle buckets
- Pagination parameters are validated and clamped to safe ranges (no negative offsets, limits capped at 100)
- Audit events logged at appropriate levels (Info for success, Warn/Error for failures)
- E2E test suite configured with permissive login rate limit (1000/min) to avoid test flakiness
- All new functionality is fully tested with unit and integration tests

https://claude.ai/code/session_01NuGchPhnAd4KkvtbLbwfmQ