### PR TITLE
Add API token authentication for external clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ npm run lint      # eslint
 | `ADMIN_USERNAME` | — | Seeded on first run if no users exist |
 | `ADMIN_PASSWORD` | — | Seeded on first run if no users exist |
 | `SESSION_TTL_DAYS` | `7` | Session lifetime in days; refreshed on activity |
+| `LOGIN_RATE_PER_MINUTE` | `5` | Per-IP rate limit on `POST /api/auth/login` |
+| `LOGIN_RATE_BURST` | `5` | Burst allowance for the login limiter |
+| `BEARER_RATE_PER_MINUTE` | `600` | Per-IP rate limit applied only to requests carrying an `Authorization` header |
+| `BEARER_RATE_BURST` | `300` | Burst allowance for the bearer-auth limiter |
 
 ---
 
@@ -118,7 +122,8 @@ Migrations live in `backend/internal/db/migrations/` as versioned SQL files (`00
 
 | Table | Purpose |
 |---|---|
-| `users` | User accounts — username, bcrypt password hash, salt, admin flag |
+| `users` | User accounts — username, bcrypt password hash, salt, admin flag, `api_tokens_enabled` flag |
+| `api_tokens` | Bearer API tokens — SHA-256 hash, `cnp_`-prefixed display prefix, scope, expiry, `last_used_at`, `revoked_at` |
 | `sessions` | Login sessions — token ID, user reference, expiry timestamp |
 | `notes` | The notes themselves — title, body (markdown), starred/pinned/archived flags, per-user |
 | `tags` | Tag definitions — name, per-user, unique per user |
@@ -161,6 +166,71 @@ Packages on non-GitHub hosts (e.g. `go.uber.org`, `golang.org/x/...`) must eithe
 POST  /api/auth/login    { username, password } → sets session cookie
 POST  /api/auth/logout   clears cookie + deletes session row
 GET   /api/auth/me       returns current user (requires auth)
+```
+
+---
+
+## API tokens
+
+For external clients (CLIs, scripts) that can't carry a session cookie. Every
+`/api/*` route accepts either a session cookie **or** an `Authorization: Bearer`
+header — bearer auth is checked first.
+
+### Getting a token
+
+1. Log in to the web UI and open **Settings → Developer**.
+2. Admins can create tokens for themselves at any time. Non-admins must be
+   enabled first — an admin toggles **API tokens** on for that user under
+   **Settings → User management**.
+3. Pick a name, a scope (`read` or `read_write`), and an expiry (default 90
+   days; `-1` = never). The raw token is shown **exactly once** on creation
+   with a `cnp_` prefix. Copy it immediately; it is stored only as a SHA-256
+   hash and cannot be recovered.
+
+### Using a token
+
+```bash
+CNP_TOKEN=cnp_xxx curl -H "Authorization: Bearer $CNP_TOKEN" \
+  http://localhost:8080/api/notes
+```
+
+### Scopes and restrictions
+
+| Scope | Reads | Writes | Admin routes | Creating more tokens |
+|---|---|---|---|---|
+| `read` | ✅ | ❌ (403) | ❌ (403) | ❌ (403) |
+| `read_write` | ✅ | ✅ | ❌ (403) | ❌ (403) |
+
+A few rules are enforced regardless of scope, to limit the blast radius of a
+leaked token:
+
+- **Admin routes (`/api/admin/*`) are never reachable via bearer auth**, even
+  when the token belongs to an admin. Admin actions require a cookie session.
+- **Creating new tokens requires a cookie session** — a leaked token cannot
+  mint more tokens and extend its own foothold.
+- Revoking an admin's `api_tokens_enabled` flag for a non-admin user
+  invalidates their outstanding tokens on the next verify.
+
+### Lifecycle
+
+- **Expiry**: configurable per-token; default 90 days.
+- **Revocation**: per-token or revoke-all, either from the UI or via
+  `DELETE /api/tokens/{id}` / `POST /api/tokens/revoke-all`.
+- **Last-used tracking**: updated asynchronously via a buffered channel so
+  verification stays off the hot path; drops on overflow rather than blocking.
+- **Rate limiting**: a dedicated per-IP limiter (see `BEARER_RATE_*` env vars
+  above) applies to any request carrying an `Authorization` header, whether or
+  not the token ends up valid.
+
+### Token endpoints
+
+```
+GET     /api/tokens              list your own tokens (no raw secrets)
+POST    /api/tokens              create a token — cookie session only
+DELETE  /api/tokens/{id}         revoke one of your tokens
+POST    /api/tokens/revoke-all   revoke all of your tokens
+
+PATCH   /api/admin/users/{id}/api-tokens    admin toggle {"enabled": bool}
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -103,6 +103,19 @@ npm run lint      # eslint
 | `BEARER_RATE_PER_MINUTE` | `600` | Per-IP rate limit applied only to requests carrying an `Authorization` header |
 | `BEARER_RATE_BURST` | `300` | Burst allowance for the bearer-auth limiter |
 
+### Frontend build-time variables
+
+Read by Vite at build time via `import.meta.env`. They must be prefixed
+`PUBLIC_` to be exposed to the client bundle, and must be set **when the
+frontend is built** (not at server runtime) — in dev that means exporting them
+before `npm run dev`; in production, before the `npm run build` step of the
+Docker image.
+
+| Variable | Default | Description |
+|---|---|---|
+| `PUBLIC_SYNC_INTERVAL_MS` | `30000` | Heartbeat interval (ms) for the offline sync loop that flushes dirty notes and pulls server changes. Clamped to a minimum of 5000. |
+| `PUBLIC_OFFLINE_NOTES_COUNT` | `50` | How many most-recent notes to mirror into IndexedDB for offline use. Clamped to a minimum of 1. |
+
 ---
 
 ## Database

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/danpicton/crapnote/internal/notes"
 	"github.com/danpicton/crapnote/internal/ratelimit"
 	"github.com/danpicton/crapnote/internal/tags"
+	"github.com/danpicton/crapnote/internal/tokens"
 	"github.com/danpicton/crapnote/internal/trash"
 )
 
@@ -41,14 +42,22 @@ func main() {
 		ttlDays = 7
 	}
 
+	userRepo := auth.NewUserRepo(database)
 	sessRepo := auth.NewSessionRepo(database)
 	authSvc := auth.NewService(
-		auth.NewUserRepo(database),
+		userRepo,
 		sessRepo,
 		time.Duration(ttlDays)*24*time.Hour,
 	)
 	authHandler := auth.NewHandler(authSvc)
-	adminHandler := auth.NewAdminHandler(auth.NewUserRepo(database))
+	adminHandler := auth.NewAdminHandler(userRepo)
+
+	// API tokens — bearer auth for external clients (CLIs, scripts).
+	tokensSvc := tokens.NewService(tokens.NewRepo(database), userRepo)
+	tokensHandler := tokens.NewHandler(tokensSvc)
+	usageRecorder := tokens.NewUsageRecorder(tokensSvc, 256)
+	usageRecorder.Start(context.Background())
+	authHandler.SetBearerAuthenticator(tokens.NewBearerAuth(tokensSvc, usageRecorder))
 
 	notesSvc := notes.NewService(notes.NewRepo(database))
 	notesHandler := notes.NewHandler(notesSvc)
@@ -119,8 +128,22 @@ func main() {
 	}
 	loginLimiter := ratelimit.New(loginRate, loginBurst)
 
+	// Bearer-auth rate limiter: caps per-IP throughput on requests that
+	// present an Authorization header. Defaults to 600 req/min with burst
+	// 300 — generous enough for CLI bursts while blunting credential-
+	// stuffing attempts and DoS against the verification path.
+	bearerRate := 10.0
+	bearerBurst := 300
+	if v, err := strconv.Atoi(os.Getenv("BEARER_RATE_PER_MINUTE")); err == nil && v > 0 {
+		bearerRate = float64(v) / 60.0
+	}
+	if v, err := strconv.Atoi(os.Getenv("BEARER_RATE_BURST")); err == nil && v > 0 {
+		bearerBurst = v
+	}
+	bearerLimiter := ratelimit.New(bearerRate, bearerBurst)
+
 	port := envOrDefault("PORT", "8080")
-	mux := newMux(authHandler, adminHandler, notesHandler, tagsHandler, trashHandler, exportHandler, imagesHandler, loginLimiter)
+	mux := newMux(authHandler, adminHandler, notesHandler, tagsHandler, trashHandler, exportHandler, imagesHandler, tokensHandler, loginLimiter, bearerLimiter)
 
 	// Wrap with observability middleware (metrics outermost, then logging, then security headers).
 	handler := middleware.Metrics()(middleware.Logging(logger)(middleware.SecurityHeaders()(mux)))

--- a/backend/cmd/server/server.go
+++ b/backend/cmd/server/server.go
@@ -11,6 +11,7 @@ import (
 	"github.com/danpicton/crapnote/internal/notes"
 	"github.com/danpicton/crapnote/internal/ratelimit"
 	"github.com/danpicton/crapnote/internal/tags"
+	"github.com/danpicton/crapnote/internal/tokens"
 	"github.com/danpicton/crapnote/internal/trash"
 )
 
@@ -22,7 +23,9 @@ func newMux(
 	trashHandler   *trash.Handler,
 	exportHandler  *export.Handler,
 	imagesHandler  *images.Handler,
+	tokensHandler  *tokens.Handler,
 	loginLimiter   *ratelimit.Limiter,
+	bearerLimiter  *ratelimit.Limiter,
 ) *http.ServeMux {
 	mux := http.NewServeMux()
 
@@ -35,64 +38,113 @@ func newMux(
 		ratelimit.Middleware(loginLimiter, ratelimit.ClientIP)(http.HandlerFunc(authHandler.Login)),
 	)
 
+	// bearerRateLimit applies a per-IP limiter only to requests that present
+	// an Authorization header — protects against credential stuffing and
+	// blunt DoS against the token-verification path while leaving cookie
+	// traffic (which browsers pace naturally) unthrottled.
+	bearerRateLimit := func(next http.Handler) http.Handler {
+		rlm := ratelimit.Middleware(bearerLimiter, ratelimit.ClientIP)
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("Authorization") != "" {
+				rlm(next).ServeHTTP(w, r)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+
 	// Helpers to reduce repetition.
 	protected := func(method, pattern string, h http.HandlerFunc) {
-		mux.Handle(method+" "+pattern, authHandler.RequireAuth(h))
+		mux.Handle(method+" "+pattern,
+			bearerRateLimit(authHandler.RequireAuth(h)),
+		)
+	}
+	// Write-scoped: requires cookie auth OR a read_write bearer token.
+	protectedWrite := func(method, pattern string, h http.HandlerFunc) {
+		mux.Handle(method+" "+pattern,
+			bearerRateLimit(authHandler.RequireAuth(authHandler.RequireWrite(h))),
+		)
 	}
 	admin := func(method, pattern string, h http.HandlerFunc) {
 		mux.Handle(method+" "+pattern,
-			authHandler.RequireAuth(authHandler.RequireAdmin(h)),
+			bearerRateLimit(authHandler.RequireAuth(authHandler.RequireAdmin(h))),
 		)
 	}
 	// Admin
 	admin("GET", "/api/admin/users", adminHandler.ListUsers)
 	admin("POST", "/api/admin/users", adminHandler.CreateUser)
 	admin("DELETE", "/api/admin/users/{id}", adminHandler.DeleteUser)
+	admin("PATCH", "/api/admin/users/{id}/api-tokens", adminHandler.SetAPITokensEnabled)
 
 	// Auth
 	protected("POST", "/api/auth/logout", authHandler.Logout)
 	protected("GET", "/api/auth/me", authHandler.Me)
 
+	// API tokens (user-facing). List/Revoke are safe over read scope; Create
+	// requires cookie auth — you can't bootstrap new tokens from a token.
+	protected("GET", "/api/tokens", tokensHandler.List)
+	mux.Handle("POST /api/tokens",
+		bearerRateLimit(authHandler.RequireAuth(authHandler.RequireWrite(cookieOnly(tokensHandler.Create)))),
+	)
+	protectedWrite("DELETE", "/api/tokens/{id}", tokensHandler.Revoke)
+	protectedWrite("POST", "/api/tokens/revoke-all", tokensHandler.RevokeAll)
+
 	// Notes
 	protected("GET", "/api/notes", notesHandler.List)
-	protected("POST", "/api/notes", notesHandler.Create)
+	protectedWrite("POST", "/api/notes", notesHandler.Create)
 	protected("GET", "/api/notes/{id}", notesHandler.Get)
-	protected("PUT", "/api/notes/{id}", notesHandler.Update)
-	protected("DELETE", "/api/notes/{id}", notesHandler.Delete)
-	protected("PATCH", "/api/notes/{id}/star", notesHandler.ToggleStar)
-	protected("PATCH", "/api/notes/{id}/pin", notesHandler.TogglePin)
-	protected("PATCH", "/api/notes/{id}/archive", notesHandler.Archive)
-	protected("PATCH", "/api/notes/{id}/unarchive", notesHandler.Unarchive)
+	protectedWrite("PUT", "/api/notes/{id}", notesHandler.Update)
+	protectedWrite("DELETE", "/api/notes/{id}", notesHandler.Delete)
+	protectedWrite("PATCH", "/api/notes/{id}/star", notesHandler.ToggleStar)
+	protectedWrite("PATCH", "/api/notes/{id}/pin", notesHandler.TogglePin)
+	protectedWrite("PATCH", "/api/notes/{id}/archive", notesHandler.Archive)
+	protectedWrite("PATCH", "/api/notes/{id}/unarchive", notesHandler.Unarchive)
 	protected("GET", "/api/archive", notesHandler.ListArchived)
 
 	// Note–tag associations
 	protected("GET", "/api/notes/{id}/tags", tagsHandler.GetForNote)
-	protected("POST", "/api/notes/{id}/tags", tagsHandler.AddToNote)
-	protected("DELETE", "/api/notes/{id}/tags/{tid}", tagsHandler.RemoveFromNote)
+	protectedWrite("POST", "/api/notes/{id}/tags", tagsHandler.AddToNote)
+	protectedWrite("DELETE", "/api/notes/{id}/tags/{tid}", tagsHandler.RemoveFromNote)
 
 	// Tags
 	protected("GET", "/api/tags", tagsHandler.List)
-	protected("POST", "/api/tags", tagsHandler.Create)
-	protected("PUT", "/api/tags/{id}", tagsHandler.Rename)
-	protected("DELETE", "/api/tags/{id}", tagsHandler.Delete)
+	protectedWrite("POST", "/api/tags", tagsHandler.Create)
+	protectedWrite("PUT", "/api/tags/{id}", tagsHandler.Rename)
+	protectedWrite("DELETE", "/api/tags/{id}", tagsHandler.Delete)
 
-	// Export
+	// Export (reads data; treat as read)
 	protected("POST", "/api/export", exportHandler.Export)
 
 	// Images
-	protected("POST", "/api/images", imagesHandler.Upload)
+	protectedWrite("POST", "/api/images", imagesHandler.Upload)
 	protected("GET", "/api/images/{id}", imagesHandler.Serve)
 
 	// Trash
 	protected("GET", "/api/trash", trashHandler.List)
-	protected("POST", "/api/trash/{id}/restore", trashHandler.Restore)
-	protected("DELETE", "/api/trash/{id}", trashHandler.DeleteOne)
-	protected("DELETE", "/api/trash", trashHandler.Empty)
+	protectedWrite("POST", "/api/trash/{id}/restore", trashHandler.Restore)
+	protectedWrite("DELETE", "/api/trash/{id}", trashHandler.DeleteOne)
+	protectedWrite("DELETE", "/api/trash", trashHandler.Empty)
 
 	// SPA frontend — catch-all after all /api/* routes.
 	mux.Handle("/", uiHandler())
 
 	return mux
+}
+
+// cookieOnly rejects bearer-authenticated requests with 403. Applied to
+// endpoints that must not be reachable through an API token — creating new
+// tokens is the motivating case: a leaked token must not be able to issue
+// more tokens and escalate persistence.
+func cookieOnly(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if auth.IsBearerAuth(r.Context()) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"error":"this endpoint is not available via api tokens"}`))
+			return
+		}
+		next(w, r)
+	}
 }
 
 func handleHealth(w http.ResponseWriter, r *http.Request) {

--- a/backend/cmd/server/server_test.go
+++ b/backend/cmd/server/server_test.go
@@ -16,12 +16,19 @@ import (
 	"github.com/danpicton/crapnote/internal/notes"
 	"github.com/danpicton/crapnote/internal/ratelimit"
 	"github.com/danpicton/crapnote/internal/tags"
+	"github.com/danpicton/crapnote/internal/tokens"
 	"github.com/danpicton/crapnote/internal/trash"
 )
 
 // permissiveLoginLimiter is a login limiter large enough that no test hits it
 // unless the test itself constructs a tighter one.
 func permissiveLoginLimiter() *ratelimit.Limiter {
+	return ratelimit.New(1000, 1000)
+}
+
+// permissiveBearerLimiter is a bearer-auth limiter that never rate-limits
+// during tests.
+func permissiveBearerLimiter() *ratelimit.Limiter {
 	return ratelimit.New(1000, 1000)
 }
 
@@ -34,21 +41,27 @@ func newTestMux(t *testing.T) *http.ServeMux {
 	}
 	t.Cleanup(func() { database.Close() })
 
+	userRepo := auth.NewUserRepo(database)
 	authSvc := auth.NewService(
-		auth.NewUserRepo(database),
+		userRepo,
 		auth.NewSessionRepo(database),
 		7*24*time.Hour,
 	)
 	notesSvc := notes.NewService(notes.NewRepo(database))
+	authH := auth.NewHandler(authSvc)
+	tokensSvc := tokens.NewService(tokens.NewRepo(database), userRepo)
+	authH.SetBearerAuthenticator(tokens.NewBearerAuth(tokensSvc, nil))
 	return newMux(
-		auth.NewHandler(authSvc),
-		auth.NewAdminHandler(auth.NewUserRepo(database)),
+		authH,
+		auth.NewAdminHandler(userRepo),
 		notes.NewHandler(notesSvc),
 		tags.NewHandler(tags.NewService(tags.NewRepo(database))),
 		trash.NewHandler(trash.NewService(trash.NewRepo(database))),
 		export.NewHandler(notesSvc, database),
 		images.NewHandler(database),
+		tokens.NewHandler(tokensSvc),
 		permissiveLoginLimiter(),
+		permissiveBearerLimiter(),
 	)
 }
 
@@ -69,15 +82,20 @@ func newAuthedMux(t *testing.T) (*http.ServeMux, *http.Cookie) {
 		t.Fatalf("seed admin: %v", err)
 	}
 	notesSvc := notes.NewService(notes.NewRepo(database))
+	authH := auth.NewHandler(authSvc)
+	tokensSvc := tokens.NewService(tokens.NewRepo(database), userRepo)
+	authH.SetBearerAuthenticator(tokens.NewBearerAuth(tokensSvc, nil))
 	mux := newMux(
-		auth.NewHandler(authSvc),
+		authH,
 		auth.NewAdminHandler(userRepo),
 		notes.NewHandler(notesSvc),
 		tags.NewHandler(tags.NewService(tags.NewRepo(database))),
 		trash.NewHandler(trash.NewService(trash.NewRepo(database))),
 		export.NewHandler(notesSvc, database),
 		images.NewHandler(database),
+		tokens.NewHandler(tokensSvc),
 		permissiveLoginLimiter(),
+		permissiveBearerLimiter(),
 	)
 
 	// Perform a login to obtain a session cookie.
@@ -162,6 +180,10 @@ var protectedRoutes = []struct {
 	{http.MethodDelete, "/api/trash"},
 	{http.MethodPost, "/api/auth/logout"},
 	{http.MethodGet, "/api/auth/me"},
+	{http.MethodGet, "/api/tokens"},
+	{http.MethodPost, "/api/tokens"},
+	{http.MethodDelete, "/api/tokens/1"},
+	{http.MethodPost, "/api/tokens/revoke-all"},
 }
 
 func TestAllProtectedRoutesRequireAuth(t *testing.T) {
@@ -200,23 +222,29 @@ func TestLogin_RateLimited(t *testing.T) {
 	}
 	t.Cleanup(func() { database.Close() })
 
+	userRepo := auth.NewUserRepo(database)
 	authSvc := auth.NewService(
-		auth.NewUserRepo(database),
+		userRepo,
 		auth.NewSessionRepo(database),
 		7*24*time.Hour,
 	)
 	notesSvc := notes.NewService(notes.NewRepo(database))
 	// Very tight limiter: burst of 2, effectively no refill during this test.
 	tightLimiter := ratelimit.New(0.01, 2)
+	authH := auth.NewHandler(authSvc)
+	tokensSvc := tokens.NewService(tokens.NewRepo(database), userRepo)
+	authH.SetBearerAuthenticator(tokens.NewBearerAuth(tokensSvc, nil))
 	mux := newMux(
-		auth.NewHandler(authSvc),
-		auth.NewAdminHandler(auth.NewUserRepo(database)),
+		authH,
+		auth.NewAdminHandler(userRepo),
 		notes.NewHandler(notesSvc),
 		tags.NewHandler(tags.NewService(tags.NewRepo(database))),
 		trash.NewHandler(trash.NewService(trash.NewRepo(database))),
 		export.NewHandler(notesSvc, database),
 		images.NewHandler(database),
+		tokens.NewHandler(tokensSvc),
 		tightLimiter,
+		permissiveBearerLimiter(),
 	)
 
 	send := func() int {

--- a/backend/internal/auth/admin_handler.go
+++ b/backend/internal/auth/admin_handler.go
@@ -90,6 +90,59 @@ func (h *AdminHandler) CreateUser(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(toUserResponse(u)) //nolint:errcheck
 }
 
+// SetAPITokensEnabled handles PATCH /api/admin/users/{id}/api-tokens
+// Body: { "enabled": bool }
+//
+// Toggles a user's ability to create API tokens. Disabling the flag does not
+// automatically revoke a user's existing tokens in storage, but the auth
+// middleware rejects them at request time, so access stops immediately.
+// The caller may additionally invoke the user's own revoke-all flow if they
+// want the tokens marked as revoked in the database.
+func (h *AdminHandler) SetAPITokensEnabled(w http.ResponseWriter, r *http.Request) {
+	caller := UserFromContext(r.Context())
+	if caller == nil {
+		writeError(w, http.StatusUnauthorized, "not authenticated")
+		return
+	}
+	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid user id")
+		return
+	}
+
+	var req struct {
+		Enabled bool `json:"enabled"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if err := h.users.SetAPITokensEnabled(r.Context(), id, req.Enabled); errors.Is(err, ErrNotFound) {
+		writeError(w, http.StatusNotFound, "user not found")
+		return
+	} else if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	slog.Info("audit: api tokens permission changed",
+		"event", "user_api_tokens_toggled",
+		"admin_id", caller.ID,
+		"target_user_id", id,
+		"enabled", req.Enabled,
+		"ip", httpx.ClientIP(r),
+	)
+
+	u, err := h.users.FindByID(r.Context(), id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(toUserResponse(u))
+}
+
 // DeleteUser handles DELETE /api/admin/users/{id}
 // An admin cannot delete themselves.
 func (h *AdminHandler) DeleteUser(w http.ResponseWriter, r *http.Request) {
@@ -129,17 +182,19 @@ func (h *AdminHandler) DeleteUser(w http.ResponseWriter, r *http.Request) {
 }
 
 type userResponse struct {
-	ID        int64  `json:"id"`
-	Username  string `json:"username"`
-	IsAdmin   bool   `json:"is_admin"`
-	CreatedAt string `json:"created_at"`
+	ID               int64  `json:"id"`
+	Username         string `json:"username"`
+	IsAdmin          bool   `json:"is_admin"`
+	APITokensEnabled bool   `json:"api_tokens_enabled"`
+	CreatedAt        string `json:"created_at"`
 }
 
 func toUserResponse(u *User) userResponse {
 	return userResponse{
-		ID:        u.ID,
-		Username:  u.Username,
-		IsAdmin:   u.IsAdmin,
-		CreatedAt: u.CreatedAt.Format("2006-01-02T15:04:05Z"),
+		ID:               u.ID,
+		Username:         u.Username,
+		IsAdmin:          u.IsAdmin,
+		APITokensEnabled: u.APITokensEnabled,
+		CreatedAt:        u.CreatedAt.Format("2006-01-02T15:04:05Z"),
 	}
 }

--- a/backend/internal/auth/admin_handler_test.go
+++ b/backend/internal/auth/admin_handler_test.go
@@ -128,6 +128,69 @@ func TestAdminHandler_CreateUser_ShortPasswordRejected(t *testing.T) {
 	}
 }
 
+func TestAdminHandler_SetAPITokensEnabled_TogglesFlag(t *testing.T) {
+	h, admin, _ := newAdminFixture(t)
+	// Create a non-admin user whose flag we'll toggle.
+	body := `{"username":"dave","password":"correct-horse-battery","is_admin":false}`
+	req := httptest.NewRequest(http.MethodPost, "/api/admin/users", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = adminRequest(req, admin)
+	w := httptest.NewRecorder()
+	h.CreateUser(w, req)
+	var created map[string]any
+	json.NewDecoder(w.Body).Decode(&created) //nolint:errcheck
+	daveID := int64(created["id"].(float64))
+
+	// Enable.
+	req2 := httptest.NewRequest(http.MethodPatch,
+		fmt.Sprintf("/api/admin/users/%d/api-tokens", daveID),
+		bytes.NewBufferString(`{"enabled":true}`))
+	req2.SetPathValue("id", fmt.Sprintf("%d", daveID))
+	req2 = adminRequest(req2, admin)
+	w2 := httptest.NewRecorder()
+	h.SetAPITokensEnabled(w2, req2)
+
+	if w2.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w2.Code, w2.Body.String())
+	}
+	var resp map[string]any
+	json.NewDecoder(w2.Body).Decode(&resp) //nolint:errcheck
+	if resp["api_tokens_enabled"] != true {
+		t.Fatalf("expected api_tokens_enabled true, got %v", resp["api_tokens_enabled"])
+	}
+
+	// Disable.
+	req3 := httptest.NewRequest(http.MethodPatch,
+		fmt.Sprintf("/api/admin/users/%d/api-tokens", daveID),
+		bytes.NewBufferString(`{"enabled":false}`))
+	req3.SetPathValue("id", fmt.Sprintf("%d", daveID))
+	req3 = adminRequest(req3, admin)
+	w3 := httptest.NewRecorder()
+	h.SetAPITokensEnabled(w3, req3)
+
+	if w3.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w3.Code)
+	}
+	var resp2 map[string]any
+	json.NewDecoder(w3.Body).Decode(&resp2) //nolint:errcheck
+	if resp2["api_tokens_enabled"] != false {
+		t.Fatalf("expected api_tokens_enabled false, got %v", resp2["api_tokens_enabled"])
+	}
+}
+
+func TestAdminHandler_SetAPITokensEnabled_UnknownUser_404(t *testing.T) {
+	h, admin, _ := newAdminFixture(t)
+	req := httptest.NewRequest(http.MethodPatch, "/api/admin/users/99999/api-tokens",
+		bytes.NewBufferString(`{"enabled":true}`))
+	req.SetPathValue("id", "99999")
+	req = adminRequest(req, admin)
+	w := httptest.NewRecorder()
+	h.SetAPITokensEnabled(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
 func TestAdminHandler_DeleteUser_CannotDeleteSelf(t *testing.T) {
 	h, admin, _ := newAdminFixture(t)
 

--- a/backend/internal/auth/handler.go
+++ b/backend/internal/auth/handler.go
@@ -124,10 +124,11 @@ func (h *Handler) Me(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
-		"id":         u.ID,
-		"username":   u.Username,
-		"is_admin":   u.IsAdmin,
-		"created_at": u.CreatedAt,
+		"id":                 u.ID,
+		"username":           u.Username,
+		"is_admin":           u.IsAdmin,
+		"api_tokens_enabled": u.APITokensEnabled,
+		"created_at":         u.CreatedAt,
 	})
 }
 

--- a/backend/internal/auth/handler.go
+++ b/backend/internal/auth/handler.go
@@ -11,7 +11,8 @@ import (
 
 // Handler holds HTTP handlers for auth endpoints.
 type Handler struct {
-	svc *Service
+	svc    *Service
+	bearer BearerAuthenticator
 }
 
 // NewHandler creates a new auth Handler.

--- a/backend/internal/auth/handler_test.go
+++ b/backend/internal/auth/handler_test.go
@@ -165,6 +165,9 @@ func TestHandler_Me(t *testing.T) {
 	if resp["username"] != "admin" {
 		t.Fatalf("expected username admin, got %v", resp["username"])
 	}
+	if _, ok := resp["api_tokens_enabled"]; !ok {
+		t.Fatalf("expected api_tokens_enabled in response, got %v", resp)
+	}
 }
 
 func TestHandler_Logout(t *testing.T) {

--- a/backend/internal/auth/middleware.go
+++ b/backend/internal/auth/middleware.go
@@ -3,12 +3,29 @@ package auth
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"net/http"
+	"strings"
+
+	"github.com/danpicton/crapnote/internal/httpx"
 )
 
 type contextKey string
 
-const userContextKey contextKey = "auth_user"
+const (
+	userContextKey         contextKey = "auth_user"
+	authFlagsContextKey    contextKey = "auth_flags"
+)
+
+// authFlags captures who authorised a request and what they're permitted to
+// do. It lives on request context alongside the User. Cookie-authenticated
+// requests have ViaBearer=false and WriteAllowed=true (browser sessions have
+// full permissions); bearer-authenticated requests get the scope the token
+// was issued with.
+type authFlags struct {
+	ViaBearer    bool
+	WriteAllowed bool
+}
 
 // WithUser returns a new context carrying the authenticated user.
 func WithUser(ctx context.Context, u *User) context.Context {
@@ -21,10 +38,73 @@ func UserFromContext(ctx context.Context) *User {
 	return u
 }
 
-// RequireAuth is middleware that validates the session cookie and injects the
-// user into the request context. Returns 401 if missing/invalid.
+// WithAuthFlags attaches authorisation flags to context.
+func WithAuthFlags(ctx context.Context, viaBearer, writeAllowed bool) context.Context {
+	return context.WithValue(ctx, authFlagsContextKey, authFlags{
+		ViaBearer:    viaBearer,
+		WriteAllowed: writeAllowed,
+	})
+}
+
+// IsBearerAuth reports whether the request was authenticated via a bearer
+// token (rather than a session cookie).
+func IsBearerAuth(ctx context.Context) bool {
+	f, _ := ctx.Value(authFlagsContextKey).(authFlags)
+	return f.ViaBearer
+}
+
+// WriteAllowed reports whether the caller is permitted to mutate state. True
+// for cookie auth and for bearer tokens with read_write scope.
+func WriteAllowed(ctx context.Context) bool {
+	f, ok := ctx.Value(authFlagsContextKey).(authFlags)
+	if !ok {
+		// No flags set: assume full access (legacy paths that only wired
+		// RequireAuth pre-bearer stay behaving as before).
+		return true
+	}
+	return f.WriteAllowed
+}
+
+// BearerAuthenticator verifies a raw bearer token and returns the associated
+// user, scope ("read" or "read_write"), and token ID. The tokens package
+// implements this; auth depends on the interface to avoid a cycle.
+type BearerAuthenticator interface {
+	AuthenticateBearer(ctx context.Context, raw string) (user *User, scope string, tokenID int64, err error)
+	RecordTokenUsage(tokenID int64)
+}
+
+// SetBearerAuthenticator wires an optional bearer verifier. If nil, bearer
+// auth is disabled and Authorization headers are ignored.
+func (h *Handler) SetBearerAuthenticator(b BearerAuthenticator) {
+	h.bearer = b
+}
+
+// RequireAuth is middleware that validates either an Authorization: Bearer
+// header or a session cookie, and injects the user into the request context.
+// Returns 401 if both are missing or invalid.
 func (h *Handler) RequireAuth(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if raw, ok := bearerFromRequest(r); ok {
+			if h.bearer == nil {
+				writeError(w, http.StatusUnauthorized, "bearer authentication disabled")
+				return
+			}
+			user, scope, tokenID, err := h.bearer.AuthenticateBearer(r.Context(), raw)
+			if err != nil {
+				slog.Warn("audit: bearer auth failed",
+					"event", "bearer_auth_failed",
+					"ip", httpx.ClientIP(r),
+				)
+				writeError(w, http.StatusUnauthorized, "invalid api token")
+				return
+			}
+			h.bearer.RecordTokenUsage(tokenID)
+			ctx := WithUser(r.Context(), user)
+			ctx = WithAuthFlags(ctx, true, scope == "read_write")
+			next.ServeHTTP(w, r.WithContext(ctx))
+			return
+		}
+
 		cookie, err := r.Cookie("session")
 		if err != nil {
 			writeError(w, http.StatusUnauthorized, "authentication required")
@@ -41,12 +121,17 @@ func (h *Handler) RequireAuth(next http.Handler) http.Handler {
 			return
 		}
 
-		next.ServeHTTP(w, r.WithContext(WithUser(r.Context(), user)))
+		ctx := WithUser(r.Context(), user)
+		ctx = WithAuthFlags(ctx, false, true)
+		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }
 
 // RequireAdmin is middleware that enforces admin access after RequireAuth.
-// Must be chained after RequireAuth.
+// Must be chained after RequireAuth. Bearer-authenticated requests are
+// rejected even when the underlying user is an admin: admin capabilities are
+// deliberately scoped to browser sessions so a leaked API token cannot, for
+// example, create users or disable the api_tokens_enabled flag on others.
 func (h *Handler) RequireAdmin(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		u := UserFromContext(r.Context())
@@ -54,8 +139,44 @@ func (h *Handler) RequireAdmin(next http.Handler) http.Handler {
 			writeError(w, http.StatusForbidden, "admin access required")
 			return
 		}
+		if IsBearerAuth(r.Context()) {
+			writeError(w, http.StatusForbidden, "admin endpoints are not available via api tokens")
+			return
+		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+// RequireWrite rejects requests from bearer tokens issued with read-only
+// scope. Must be chained after RequireAuth. Cookie auth always passes.
+func (h *Handler) RequireWrite(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !WriteAllowed(r.Context()) {
+			writeError(w, http.StatusForbidden, "this api token is read-only")
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// bearerFromRequest extracts the raw token from an Authorization: Bearer
+// header. Returns ok=false if the header is missing or malformed.
+func bearerFromRequest(r *http.Request) (string, bool) {
+	h := r.Header.Get("Authorization")
+	if h == "" {
+		return "", false
+	}
+	const prefix = "Bearer "
+	if !strings.HasPrefix(h, prefix) {
+		// Wrong scheme: signal "no bearer" so the cookie path can run. An
+		// explicit bad scheme should not leak as a bearer-auth failure.
+		return "", false
+	}
+	raw := strings.TrimSpace(h[len(prefix):])
+	if raw == "" {
+		return "", false
+	}
+	return raw, true
 }
 
 // Chain composes middleware left-to-right: Chain(f, g)(h) = f(g(h)).

--- a/backend/internal/auth/model.go
+++ b/backend/internal/auth/model.go
@@ -4,11 +4,12 @@ import "time"
 
 // User represents an application user.
 type User struct {
-	ID           int64
-	Username     string
-	PasswordHash string
-	IsAdmin      bool
-	CreatedAt    time.Time
+	ID               int64
+	Username         string
+	PasswordHash     string
+	IsAdmin          bool
+	APITokensEnabled bool
+	CreatedAt        time.Time
 }
 
 // Session represents an authenticated session stored in the database.

--- a/backend/internal/auth/repository.go
+++ b/backend/internal/auth/repository.go
@@ -50,11 +50,11 @@ func (r *UserRepo) Create(ctx context.Context, username, passwordHash string, is
 // FindByUsername returns the user with the given username, or ErrNotFound.
 func (r *UserRepo) FindByUsername(ctx context.Context, username string) (*User, error) {
 	u := &User{}
-	var isAdmin int
+	var isAdmin, apiTokensEnabled int
 	err := r.db.QueryRowContext(ctx,
-		`SELECT id, username, password_hash, is_admin, created_at FROM users WHERE username=?`,
+		`SELECT id, username, password_hash, is_admin, api_tokens_enabled, created_at FROM users WHERE username=?`,
 		username,
-	).Scan(&u.ID, &u.Username, &u.PasswordHash, &isAdmin, &u.CreatedAt)
+	).Scan(&u.ID, &u.Username, &u.PasswordHash, &isAdmin, &apiTokensEnabled, &u.CreatedAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrNotFound
 	}
@@ -62,17 +62,18 @@ func (r *UserRepo) FindByUsername(ctx context.Context, username string) (*User, 
 		return nil, fmt.Errorf("find user by username: %w", err)
 	}
 	u.IsAdmin = isAdmin != 0
+	u.APITokensEnabled = apiTokensEnabled != 0
 	return u, nil
 }
 
 // FindByID returns the user with the given id, or ErrNotFound.
 func (r *UserRepo) FindByID(ctx context.Context, id int64) (*User, error) {
 	u := &User{}
-	var isAdmin int
+	var isAdmin, apiTokensEnabled int
 	err := r.db.QueryRowContext(ctx,
-		`SELECT id, username, password_hash, is_admin, created_at FROM users WHERE id=?`,
+		`SELECT id, username, password_hash, is_admin, api_tokens_enabled, created_at FROM users WHERE id=?`,
 		id,
-	).Scan(&u.ID, &u.Username, &u.PasswordHash, &isAdmin, &u.CreatedAt)
+	).Scan(&u.ID, &u.Username, &u.PasswordHash, &isAdmin, &apiTokensEnabled, &u.CreatedAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrNotFound
 	}
@@ -80,7 +81,28 @@ func (r *UserRepo) FindByID(ctx context.Context, id int64) (*User, error) {
 		return nil, fmt.Errorf("find user by id: %w", err)
 	}
 	u.IsAdmin = isAdmin != 0
+	u.APITokensEnabled = apiTokensEnabled != 0
 	return u, nil
+}
+
+// SetAPITokensEnabled toggles whether a (non-admin) user may create API
+// tokens. Returns ErrNotFound if the user does not exist.
+func (r *UserRepo) SetAPITokensEnabled(ctx context.Context, id int64, enabled bool) error {
+	v := 0
+	if enabled {
+		v = 1
+	}
+	res, err := r.db.ExecContext(ctx,
+		`UPDATE users SET api_tokens_enabled=? WHERE id=?`, v, id,
+	)
+	if err != nil {
+		return fmt.Errorf("set api_tokens_enabled: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
 }
 
 // Count returns the total number of users.
@@ -100,7 +122,7 @@ func (r *UserRepo) Delete(ctx context.Context, id int64) error {
 
 // List returns users ordered by created_at. limit <= 0 returns all users.
 func (r *UserRepo) List(ctx context.Context, limit, offset int) ([]*User, error) {
-	query := `SELECT id, username, password_hash, is_admin, created_at FROM users ORDER BY created_at`
+	query := `SELECT id, username, password_hash, is_admin, api_tokens_enabled, created_at FROM users ORDER BY created_at`
 	var args []any
 	if limit > 0 {
 		query += ` LIMIT ? OFFSET ?`
@@ -115,11 +137,12 @@ func (r *UserRepo) List(ctx context.Context, limit, offset int) ([]*User, error)
 	var users []*User
 	for rows.Next() {
 		u := &User{}
-		var isAdmin int
-		if err := rows.Scan(&u.ID, &u.Username, &u.PasswordHash, &isAdmin, &u.CreatedAt); err != nil {
+		var isAdmin, apiTokensEnabled int
+		if err := rows.Scan(&u.ID, &u.Username, &u.PasswordHash, &isAdmin, &apiTokensEnabled, &u.CreatedAt); err != nil {
 			return nil, err
 		}
 		u.IsAdmin = isAdmin != 0
+		u.APITokensEnabled = apiTokensEnabled != 0
 		users = append(users, u)
 	}
 	return users, rows.Err()

--- a/backend/internal/db/migrations/000008_api_tokens.down.sql
+++ b/backend/internal/db/migrations/000008_api_tokens.down.sql
@@ -1,0 +1,5 @@
+DROP INDEX IF EXISTS idx_api_tokens_token_hash;
+DROP INDEX IF EXISTS idx_api_tokens_user_id;
+DROP TABLE IF EXISTS api_tokens;
+
+ALTER TABLE users DROP COLUMN api_tokens_enabled;

--- a/backend/internal/db/migrations/000008_api_tokens.up.sql
+++ b/backend/internal/db/migrations/000008_api_tokens.up.sql
@@ -1,0 +1,17 @@
+ALTER TABLE users ADD COLUMN api_tokens_enabled INTEGER NOT NULL DEFAULT 0;
+
+CREATE TABLE IF NOT EXISTS api_tokens (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id       INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    name          TEXT    NOT NULL,
+    token_hash    TEXT    NOT NULL UNIQUE,
+    prefix        TEXT    NOT NULL,
+    scope         TEXT    NOT NULL,
+    last_used_at  DATETIME,
+    expires_at    DATETIME,
+    revoked_at    DATETIME,
+    created_at    DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_api_tokens_user_id ON api_tokens(user_id);
+CREATE INDEX IF NOT EXISTS idx_api_tokens_token_hash ON api_tokens(token_hash);

--- a/backend/internal/tokens/bearer_auth.go
+++ b/backend/internal/tokens/bearer_auth.go
@@ -1,0 +1,36 @@
+package tokens
+
+import (
+	"context"
+
+	"github.com/danpicton/crapnote/internal/auth"
+)
+
+// BearerAuth adapts a tokens.Service to the auth.BearerAuthenticator
+// interface, so the auth middleware can verify bearer tokens without taking a
+// direct dependency on this package.
+type BearerAuth struct {
+	svc      *Service
+	recorder *UsageRecorder
+}
+
+// NewBearerAuth wires the service and (optional) usage recorder.
+func NewBearerAuth(svc *Service, recorder *UsageRecorder) *BearerAuth {
+	return &BearerAuth{svc: svc, recorder: recorder}
+}
+
+// AuthenticateBearer implements auth.BearerAuthenticator.
+func (b *BearerAuth) AuthenticateBearer(ctx context.Context, raw string) (*auth.User, string, int64, error) {
+	v, err := b.svc.Verify(ctx, raw)
+	if err != nil {
+		return nil, "", 0, err
+	}
+	return v.User, string(v.Scope), v.TokenID, nil
+}
+
+// RecordTokenUsage implements auth.BearerAuthenticator. Non-blocking.
+func (b *BearerAuth) RecordTokenUsage(tokenID int64) {
+	if b.recorder != nil {
+		b.recorder.Record(tokenID)
+	}
+}

--- a/backend/internal/tokens/handler.go
+++ b/backend/internal/tokens/handler.go
@@ -1,0 +1,203 @@
+package tokens
+
+import (
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/danpicton/crapnote/internal/auth"
+	"github.com/danpicton/crapnote/internal/httpx"
+)
+
+// Handler serves HTTP endpoints for managing a user's own API tokens.
+type Handler struct {
+	svc *Service
+}
+
+// NewHandler creates a new token Handler.
+func NewHandler(svc *Service) *Handler {
+	return &Handler{svc: svc}
+}
+
+// tokenResponse is the shape returned to clients for a stored token. The raw
+// secret is never included here.
+type tokenResponse struct {
+	ID         int64   `json:"id"`
+	Name       string  `json:"name"`
+	Prefix     string  `json:"prefix"`
+	Scope      string  `json:"scope"`
+	LastUsedAt *string `json:"last_used_at,omitempty"`
+	ExpiresAt  *string `json:"expires_at,omitempty"`
+	RevokedAt  *string `json:"revoked_at,omitempty"`
+	CreatedAt  string  `json:"created_at"`
+}
+
+func toTokenResponse(t *Token) tokenResponse {
+	fmt := "2006-01-02T15:04:05Z"
+	out := tokenResponse{
+		ID:        t.ID,
+		Name:      t.Name,
+		Prefix:    t.Prefix,
+		Scope:     string(t.Scope),
+		CreatedAt: t.CreatedAt.UTC().Format(fmt),
+	}
+	if t.LastUsedAt != nil {
+		s := t.LastUsedAt.UTC().Format(fmt)
+		out.LastUsedAt = &s
+	}
+	if t.ExpiresAt != nil {
+		s := t.ExpiresAt.UTC().Format(fmt)
+		out.ExpiresAt = &s
+	}
+	if t.RevokedAt != nil {
+		s := t.RevokedAt.UTC().Format(fmt)
+		out.RevokedAt = &s
+	}
+	return out
+}
+
+// List handles GET /api/tokens — returns the caller's tokens (no raw secrets).
+func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
+	u := auth.UserFromContext(r.Context())
+	if u == nil {
+		writeError(w, http.StatusUnauthorized, "not authenticated")
+		return
+	}
+	list, err := h.svc.List(r.Context(), u.ID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+	out := make([]tokenResponse, 0, len(list))
+	for _, t := range list {
+		out = append(out, toTokenResponse(t))
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(out)
+}
+
+// Create handles POST /api/tokens.
+// Body: { "name": "...", "scope": "read"|"read_write", "ttl_days": int? }
+// ttl_days > 0: that many days. 0 or omitted: default (90 days). -1: no expiry.
+// The response includes the raw token exactly once.
+func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
+	u := auth.UserFromContext(r.Context())
+	if u == nil {
+		writeError(w, http.StatusUnauthorized, "not authenticated")
+		return
+	}
+
+	var req struct {
+		Name    string `json:"name"`
+		Scope   string `json:"scope"`
+		TTLDays int    `json:"ttl_days"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	var ttl time.Duration
+	switch {
+	case req.TTLDays == 0:
+		ttl = 0 // default
+	case req.TTLDays < 0:
+		ttl = -1 // no expiry
+	default:
+		ttl = time.Duration(req.TTLDays) * 24 * time.Hour
+	}
+
+	created, err := h.svc.Create(r.Context(), u, req.Name, Scope(req.Scope), ttl)
+	switch {
+	case errors.Is(err, ErrForbidden):
+		writeError(w, http.StatusForbidden, "api tokens not permitted for this user")
+		return
+	case errors.Is(err, ErrInvalidName):
+		writeError(w, http.StatusBadRequest, "invalid token name")
+		return
+	case errors.Is(err, ErrInvalidScope):
+		writeError(w, http.StatusBadRequest, "invalid scope (want read or read_write)")
+		return
+	case err != nil:
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	slog.Info("audit: api token created",
+		"event", "api_token_created",
+		"user_id", u.ID,
+		"token_id", created.Token.ID,
+		"scope", string(created.Token.Scope),
+		"ip", httpx.ClientIP(r),
+	)
+
+	resp := struct {
+		tokenResponse
+		Token string `json:"token"`
+	}{
+		tokenResponse: toTokenResponse(created.Token),
+		Token:         created.RawToken,
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// Revoke handles DELETE /api/tokens/{id}.
+func (h *Handler) Revoke(w http.ResponseWriter, r *http.Request) {
+	u := auth.UserFromContext(r.Context())
+	if u == nil {
+		writeError(w, http.StatusUnauthorized, "not authenticated")
+		return
+	}
+	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid token id")
+		return
+	}
+	if err := h.svc.Revoke(r.Context(), u.ID, id); errors.Is(err, ErrNotFound) {
+		writeError(w, http.StatusNotFound, "token not found")
+		return
+	} else if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	slog.Info("audit: api token revoked",
+		"event", "api_token_revoked",
+		"user_id", u.ID,
+		"token_id", id,
+		"ip", httpx.ClientIP(r),
+	)
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// RevokeAll handles POST /api/tokens/revoke-all — revokes every active token
+// belonging to the caller.
+func (h *Handler) RevokeAll(w http.ResponseWriter, r *http.Request) {
+	u := auth.UserFromContext(r.Context())
+	if u == nil {
+		writeError(w, http.StatusUnauthorized, "not authenticated")
+		return
+	}
+	if err := h.svc.RevokeAll(r.Context(), u.ID); err != nil {
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+	slog.Info("audit: api tokens revoked (bulk)",
+		"event", "api_tokens_revoked_all",
+		"user_id", u.ID,
+		"ip", httpx.ClientIP(r),
+	)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func writeError(w http.ResponseWriter, code int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}

--- a/backend/internal/tokens/handler_test.go
+++ b/backend/internal/tokens/handler_test.go
@@ -1,0 +1,195 @@
+package tokens_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/danpicton/crapnote/internal/auth"
+	"github.com/danpicton/crapnote/internal/db"
+	"github.com/danpicton/crapnote/internal/tokens"
+)
+
+type handlerFixture struct {
+	database *db.DB
+	users    *auth.UserRepo
+	svc      *tokens.Service
+	handler  *tokens.Handler
+	user     *auth.User
+	admin    *auth.User
+}
+
+func newHandlerFixture(t *testing.T) *handlerFixture {
+	t.Helper()
+	database, err := db.Open(db.Config{SQLitePath: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+	users := auth.NewUserRepo(database)
+	admin, _ := users.Create(t.Context(), "root", "hash", true)
+	u, _ := users.Create(t.Context(), "alice", "hash", false)
+	svc := tokens.NewService(tokens.NewRepo(database), users)
+	return &handlerFixture{
+		database: database,
+		users:    users,
+		svc:      svc,
+		handler:  tokens.NewHandler(svc),
+		user:     u,
+		admin:    admin,
+	}
+}
+
+func withUser(req *http.Request, u *auth.User) *http.Request {
+	return req.WithContext(auth.WithUser(req.Context(), u))
+}
+
+func TestHandler_Create_ReturnsTokenOnce(t *testing.T) {
+	f := newHandlerFixture(t)
+
+	body, _ := json.Marshal(map[string]any{"name": "cli", "scope": "read_write"})
+	req := httptest.NewRequest(http.MethodPost, "/api/tokens", bytes.NewReader(body))
+	req = withUser(req, f.admin)
+	w := httptest.NewRecorder()
+	f.handler.Create(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	raw, _ := resp["token"].(string)
+	if !strings.HasPrefix(raw, tokens.TokenPrefix) {
+		t.Fatalf("expected token with prefix %q, got %q", tokens.TokenPrefix, raw)
+	}
+	if resp["scope"] != "read_write" {
+		t.Fatalf("expected scope read_write, got %v", resp["scope"])
+	}
+
+	// Listing must not expose the raw token.
+	req2 := httptest.NewRequest(http.MethodGet, "/api/tokens", nil)
+	req2 = withUser(req2, f.admin)
+	w2 := httptest.NewRecorder()
+	f.handler.List(w2, req2)
+	if strings.Contains(w2.Body.String(), raw) {
+		t.Fatalf("raw token leaked in list response: %s", w2.Body.String())
+	}
+}
+
+func TestHandler_Create_NonAdmin_Forbidden(t *testing.T) {
+	f := newHandlerFixture(t)
+
+	body, _ := json.Marshal(map[string]any{"name": "cli", "scope": "read"})
+	req := httptest.NewRequest(http.MethodPost, "/api/tokens", bytes.NewReader(body))
+	req = withUser(req, f.user)
+	w := httptest.NewRecorder()
+	f.handler.Create(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandler_Create_BadScope_400(t *testing.T) {
+	f := newHandlerFixture(t)
+
+	body, _ := json.Marshal(map[string]any{"name": "cli", "scope": "admin"})
+	req := httptest.NewRequest(http.MethodPost, "/api/tokens", bytes.NewReader(body))
+	req = withUser(req, f.admin)
+	w := httptest.NewRecorder()
+	f.handler.Create(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandler_Revoke_DeletesOwnToken(t *testing.T) {
+	f := newHandlerFixture(t)
+	created, _ := f.svc.Create(t.Context(), f.admin, "cli", tokens.ScopeRead, 0)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/tokens/{id}", nil)
+	req.SetPathValue("id", formatID(created.Token.ID))
+	req = withUser(req, f.admin)
+	w := httptest.NewRecorder()
+	f.handler.Revoke(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", w.Code)
+	}
+	if _, err := f.svc.Verify(t.Context(), created.RawToken); err != tokens.ErrInvalidToken {
+		t.Fatal("token should be invalid after revoke")
+	}
+}
+
+func TestHandler_Revoke_OtherUsersToken_404(t *testing.T) {
+	f := newHandlerFixture(t)
+	// Create a token for admin, try to revoke as alice (who has no tokens
+	// enabled, but that's ok — she's still authenticated).
+	created, _ := f.svc.Create(t.Context(), f.admin, "cli", tokens.ScopeRead, 0)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/tokens/{id}", nil)
+	req.SetPathValue("id", formatID(created.Token.ID))
+	req = withUser(req, f.user)
+	w := httptest.NewRecorder()
+	f.handler.Revoke(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestHandler_RevokeAll(t *testing.T) {
+	f := newHandlerFixture(t)
+	t1, _ := f.svc.Create(t.Context(), f.admin, "a", tokens.ScopeRead, 0)
+	t2, _ := f.svc.Create(t.Context(), f.admin, "b", tokens.ScopeReadWrite, 0)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/tokens/revoke-all", nil)
+	req = withUser(req, f.admin)
+	w := httptest.NewRecorder()
+	f.handler.RevokeAll(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", w.Code)
+	}
+	for _, raw := range []string{t1.RawToken, t2.RawToken} {
+		if _, err := f.svc.Verify(t.Context(), raw); err != tokens.ErrInvalidToken {
+			t.Fatalf("expected token to be invalid after revoke-all")
+		}
+	}
+}
+
+func TestHandler_List_ScopedToCaller(t *testing.T) {
+	f := newHandlerFixture(t)
+	_, _ = f.svc.Create(t.Context(), f.admin, "mine", tokens.ScopeRead, 0)
+	// Enable alice + create a token for her.
+	_ = f.users.SetAPITokensEnabled(t.Context(), f.user.ID, true)
+	alice, _ := f.users.FindByID(t.Context(), f.user.ID)
+	_, _ = f.svc.Create(t.Context(), alice, "hers", tokens.ScopeRead, 0)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/tokens", nil)
+	req = withUser(req, f.admin)
+	w := httptest.NewRecorder()
+	f.handler.List(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var out []map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(out) != 1 || out[0]["name"] != "mine" {
+		t.Fatalf("expected only admin's token, got %v", out)
+	}
+}
+
+func formatID(id int64) string {
+	return strconv.FormatInt(id, 10)
+}

--- a/backend/internal/tokens/middleware_integration_test.go
+++ b/backend/internal/tokens/middleware_integration_test.go
@@ -1,0 +1,213 @@
+package tokens_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/danpicton/crapnote/internal/auth"
+	"github.com/danpicton/crapnote/internal/db"
+	"github.com/danpicton/crapnote/internal/tokens"
+)
+
+type bearerFixture struct {
+	database *db.DB
+	users    *auth.UserRepo
+	authH    *auth.Handler
+	svc      *tokens.Service
+	admin    *auth.User
+	user     *auth.User
+}
+
+func newBearerFixture(t *testing.T) *bearerFixture {
+	t.Helper()
+	database, err := db.Open(db.Config{SQLitePath: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	users := auth.NewUserRepo(database)
+	sessions := auth.NewSessionRepo(database)
+	authSvc := auth.NewService(users, sessions, 24*time.Hour)
+	authH := auth.NewHandler(authSvc)
+
+	admin, err := users.Create(t.Context(), "root", "hash", true)
+	if err != nil {
+		t.Fatalf("create root: %v", err)
+	}
+	u, err := users.Create(t.Context(), "alice", "hash", false)
+	if err != nil {
+		t.Fatalf("create alice: %v", err)
+	}
+
+	tsvc := tokens.NewService(tokens.NewRepo(database), users)
+	authH.SetBearerAuthenticator(tokens.NewBearerAuth(tsvc, nil))
+
+	return &bearerFixture{
+		database: database, users: users, authH: authH, svc: tsvc,
+		admin: admin, user: u,
+	}
+}
+
+var noopHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	_ = auth.UserFromContext(r.Context())
+	w.WriteHeader(http.StatusOK)
+})
+
+func TestBearer_AcceptsValidToken_AttachesUser(t *testing.T) {
+	f := newBearerFixture(t)
+	created, err := f.svc.Create(t.Context(), f.admin, "cli", tokens.ScopeReadWrite, 0)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	var gotUser *auth.User
+	var wroteAllowed bool
+	var viaBearer bool
+	capture := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUser = auth.UserFromContext(r.Context())
+		wroteAllowed = auth.WriteAllowed(r.Context())
+		viaBearer = auth.IsBearerAuth(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	req.Header.Set("Authorization", "Bearer "+created.RawToken)
+	w := httptest.NewRecorder()
+	f.authH.RequireAuth(capture).ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if gotUser == nil || gotUser.ID != f.admin.ID {
+		t.Fatalf("expected admin user, got %+v", gotUser)
+	}
+	if !wroteAllowed {
+		t.Fatal("expected WriteAllowed=true for read_write token")
+	}
+	if !viaBearer {
+		t.Fatal("expected IsBearerAuth=true")
+	}
+}
+
+func TestBearer_ReadScope_WriteAllowedFalse(t *testing.T) {
+	f := newBearerFixture(t)
+	created, _ := f.svc.Create(t.Context(), f.admin, "cli", tokens.ScopeRead, 0)
+
+	var wroteAllowed bool
+	capture := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		wroteAllowed = auth.WriteAllowed(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	req.Header.Set("Authorization", "Bearer "+created.RawToken)
+	w := httptest.NewRecorder()
+	f.authH.RequireAuth(capture).ServeHTTP(w, req)
+
+	if wroteAllowed {
+		t.Fatal("expected WriteAllowed=false for read-only token")
+	}
+}
+
+func TestBearer_InvalidToken_401(t *testing.T) {
+	f := newBearerFixture(t)
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	req.Header.Set("Authorization", "Bearer cnp_doesnotexist")
+	w := httptest.NewRecorder()
+	f.authH.RequireAuth(noopHandler).ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestBearer_BadSchemeFallsBackToCookie(t *testing.T) {
+	f := newBearerFixture(t)
+	// Non-bearer auth header with no cookie → 401 from cookie path.
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	req.Header.Set("Authorization", "Basic dXNlcjpwYXNz")
+	w := httptest.NewRecorder()
+	f.authH.RequireAuth(noopHandler).ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 (no cookie), got %d", w.Code)
+	}
+}
+
+func TestBearer_RequireAdmin_RejectsBearerEvenForAdmin(t *testing.T) {
+	f := newBearerFixture(t)
+	created, _ := f.svc.Create(t.Context(), f.admin, "cli", tokens.ScopeReadWrite, 0)
+
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	req.Header.Set("Authorization", "Bearer "+created.RawToken)
+	w := httptest.NewRecorder()
+	f.authH.RequireAuth(f.authH.RequireAdmin(noopHandler)).ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", w.Code)
+	}
+}
+
+func TestBearer_RequireWrite_RejectsReadScope(t *testing.T) {
+	f := newBearerFixture(t)
+	created, _ := f.svc.Create(t.Context(), f.admin, "cli", tokens.ScopeRead, 0)
+
+	req := httptest.NewRequest(http.MethodPost, "/x", nil)
+	req.Header.Set("Authorization", "Bearer "+created.RawToken)
+	w := httptest.NewRecorder()
+	f.authH.RequireAuth(f.authH.RequireWrite(noopHandler)).ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for read token on write endpoint, got %d", w.Code)
+	}
+}
+
+func TestBearer_RequireWrite_AllowsReadWrite(t *testing.T) {
+	f := newBearerFixture(t)
+	created, _ := f.svc.Create(t.Context(), f.admin, "cli", tokens.ScopeReadWrite, 0)
+
+	req := httptest.NewRequest(http.MethodPost, "/x", nil)
+	req.Header.Set("Authorization", "Bearer "+created.RawToken)
+	w := httptest.NewRecorder()
+	f.authH.RequireAuth(f.authH.RequireWrite(noopHandler)).ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestBearer_CookieAuth_WriteAllowedTrue(t *testing.T) {
+	f := newBearerFixture(t)
+	// Enable cookie path: seed + login.
+	authSvc := auth.NewService(f.users, auth.NewSessionRepo(f.database), time.Hour)
+	// Reset user bob to use bcrypt hash.
+	if err := authSvc.SeedAdmin(t.Context(), "bob", "longpassword"); err != nil {
+		t.Fatalf("seed (noop since users exist): %v", err)
+	}
+	// "bob" not seeded because admin already exists. Instead create directly via login of admin by inserting a session.
+	sessRepo := auth.NewSessionRepo(f.database)
+	sess, err := sessRepo.Create(t.Context(), f.admin.ID, time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	var wroteAllowed bool
+	capture := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		wroteAllowed = auth.WriteAllowed(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	req.AddCookie(&http.Cookie{Name: "session", Value: sess.ID})
+	w := httptest.NewRecorder()
+	f.authH.RequireAuth(capture).ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if !wroteAllowed {
+		t.Fatal("expected WriteAllowed=true for cookie auth")
+	}
+}

--- a/backend/internal/tokens/model.go
+++ b/backend/internal/tokens/model.go
@@ -1,0 +1,78 @@
+// Package tokens provides personal API tokens for bearer authentication.
+//
+// Tokens are issued to users so external clients (CLIs, scripts) can access
+// the API without a browser session. The raw token is shown exactly once on
+// creation; the database stores only a SHA-256 hash, so the raw secret cannot
+// be recovered or leaked from the DB. Each token carries a scope (read or
+// read+write), an optional expiry, and an optional revocation timestamp.
+package tokens
+
+import (
+	"errors"
+	"time"
+)
+
+// TokenPrefix is the human-recognisable prefix applied to every issued token.
+// Makes tokens greppable in logs and lets secret-scanners identify them.
+const TokenPrefix = "cnp_"
+
+// DisplayPrefixLen is the number of raw-secret characters stored alongside the
+// hash so the UI can show "cnp_abc12345…" without retaining the full secret.
+const DisplayPrefixLen = 8
+
+// ErrNotFound is returned when a requested token does not exist.
+var ErrNotFound = errors.New("not found")
+
+// ErrInvalidToken is returned when a presented bearer token is malformed,
+// unknown, expired, or revoked.
+var ErrInvalidToken = errors.New("invalid token")
+
+// Scope enumerates the permissions a token can hold.
+type Scope string
+
+const (
+	// ScopeRead permits read-only API calls (GET and equivalent).
+	ScopeRead Scope = "read"
+	// ScopeReadWrite permits all API calls except admin-only endpoints.
+	ScopeReadWrite Scope = "read_write"
+)
+
+// Valid reports whether s is a recognised scope value.
+func (s Scope) Valid() bool {
+	switch s {
+	case ScopeRead, ScopeReadWrite:
+		return true
+	}
+	return false
+}
+
+// AllowsWrite reports whether the scope permits mutating operations.
+func (s Scope) AllowsWrite() bool {
+	return s == ScopeReadWrite
+}
+
+// Token is a stored API token record. The raw secret never lives on this
+// struct; only its SHA-256 hash and display prefix are persisted.
+type Token struct {
+	ID         int64
+	UserID     int64
+	Name       string
+	TokenHash  string
+	Prefix     string
+	Scope      Scope
+	LastUsedAt *time.Time
+	ExpiresAt  *time.Time
+	RevokedAt  *time.Time
+	CreatedAt  time.Time
+}
+
+// Active reports whether the token is currently usable for authentication.
+func (t *Token) Active(now time.Time) bool {
+	if t.RevokedAt != nil {
+		return false
+	}
+	if t.ExpiresAt != nil && !now.Before(*t.ExpiresAt) {
+		return false
+	}
+	return true
+}

--- a/backend/internal/tokens/repository.go
+++ b/backend/internal/tokens/repository.go
@@ -1,0 +1,153 @@
+package tokens
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/danpicton/crapnote/internal/db"
+)
+
+// Repo provides access to the api_tokens table.
+type Repo struct {
+	db *db.DB
+}
+
+// NewRepo creates a new Repo backed by the given database.
+func NewRepo(database *db.DB) *Repo {
+	return &Repo{db: database}
+}
+
+// Create inserts a new token record and returns the populated Token.
+func (r *Repo) Create(ctx context.Context, userID int64, name, tokenHash, prefix string, scope Scope, expiresAt *time.Time) (*Token, error) {
+	res, err := r.db.ExecContext(ctx,
+		`INSERT INTO api_tokens(user_id, name, token_hash, prefix, scope, expires_at)
+		 VALUES(?, ?, ?, ?, ?, ?)`,
+		userID, name, tokenHash, prefix, string(scope), expiresAt,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create token: %w", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return nil, fmt.Errorf("last insert id: %w", err)
+	}
+	return r.FindByID(ctx, id)
+}
+
+// FindByID returns the token with the given id, or ErrNotFound.
+func (r *Repo) FindByID(ctx context.Context, id int64) (*Token, error) {
+	return r.scanOne(r.db.QueryRowContext(ctx, selectColumns+` WHERE id=?`, id))
+}
+
+// FindByHash returns the token matching tokenHash, or ErrNotFound.
+func (r *Repo) FindByHash(ctx context.Context, tokenHash string) (*Token, error) {
+	return r.scanOne(r.db.QueryRowContext(ctx, selectColumns+` WHERE token_hash=?`, tokenHash))
+}
+
+// ListByUser returns all tokens for the user, most recent first.
+func (r *Repo) ListByUser(ctx context.Context, userID int64) ([]*Token, error) {
+	rows, err := r.db.QueryContext(ctx,
+		selectColumns+` WHERE user_id=? ORDER BY created_at DESC`, userID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list tokens: %w", err)
+	}
+	defer rows.Close()
+
+	var out []*Token
+	for rows.Next() {
+		t, err := scanRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, t)
+	}
+	return out, rows.Err()
+}
+
+// Revoke marks the token as revoked. No-op if already revoked. Returns
+// ErrNotFound if the token does not exist.
+func (r *Repo) Revoke(ctx context.Context, id int64, now time.Time) error {
+	res, err := r.db.ExecContext(ctx,
+		`UPDATE api_tokens SET revoked_at=? WHERE id=? AND revoked_at IS NULL`,
+		now.UTC(), id,
+	)
+	if err != nil {
+		return fmt.Errorf("revoke token: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		// Either the row is missing or already revoked. Check which.
+		if _, err := r.FindByID(ctx, id); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// RevokeAllForUser marks every non-revoked token belonging to userID as
+// revoked. Used when an admin disables API tokens for a user.
+func (r *Repo) RevokeAllForUser(ctx context.Context, userID int64, now time.Time) error {
+	_, err := r.db.ExecContext(ctx,
+		`UPDATE api_tokens SET revoked_at=? WHERE user_id=? AND revoked_at IS NULL`,
+		now.UTC(), userID,
+	)
+	if err != nil {
+		return fmt.Errorf("revoke all tokens: %w", err)
+	}
+	return nil
+}
+
+// UpdateLastUsed sets last_used_at for the given token. Best-effort: errors are
+// returned but the caller should not fail the request on failure.
+func (r *Repo) UpdateLastUsed(ctx context.Context, id int64, ts time.Time) error {
+	_, err := r.db.ExecContext(ctx,
+		`UPDATE api_tokens SET last_used_at=? WHERE id=?`, ts.UTC(), id,
+	)
+	return err
+}
+
+const selectColumns = `SELECT id, user_id, name, token_hash, prefix, scope,
+	last_used_at, expires_at, revoked_at, created_at FROM api_tokens`
+
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func (r *Repo) scanOne(row rowScanner) (*Token, error) {
+	t, err := scanRow(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	return t, err
+}
+
+func scanRow(row rowScanner) (*Token, error) {
+	t := &Token{}
+	var (
+		scope      string
+		lastUsed   sql.NullTime
+		expiresAt  sql.NullTime
+		revokedAt  sql.NullTime
+	)
+	err := row.Scan(
+		&t.ID, &t.UserID, &t.Name, &t.TokenHash, &t.Prefix, &scope,
+		&lastUsed, &expiresAt, &revokedAt, &t.CreatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	t.Scope = Scope(scope)
+	if lastUsed.Valid {
+		t.LastUsedAt = &lastUsed.Time
+	}
+	if expiresAt.Valid {
+		t.ExpiresAt = &expiresAt.Time
+	}
+	if revokedAt.Valid {
+		t.RevokedAt = &revokedAt.Time
+	}
+	return t, nil
+}

--- a/backend/internal/tokens/repository_test.go
+++ b/backend/internal/tokens/repository_test.go
@@ -1,0 +1,196 @@
+package tokens_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/danpicton/crapnote/internal/auth"
+	"github.com/danpicton/crapnote/internal/db"
+	"github.com/danpicton/crapnote/internal/tokens"
+)
+
+type repoFixture struct {
+	database *db.DB
+	repo     *tokens.Repo
+	users    *auth.UserRepo
+	user     *auth.User
+}
+
+func newRepoFixture(t *testing.T) *repoFixture {
+	t.Helper()
+	database, err := db.Open(db.Config{SQLitePath: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+	users := auth.NewUserRepo(database)
+	u, err := users.Create(t.Context(), "alice", "hash", false)
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	return &repoFixture{
+		database: database,
+		repo:     tokens.NewRepo(database),
+		users:    users,
+		user:     u,
+	}
+}
+
+func TestRepo_CreateAndFindByHash(t *testing.T) {
+	f := newRepoFixture(t)
+
+	exp := time.Now().Add(90 * 24 * time.Hour).UTC().Truncate(time.Second)
+	tok, err := f.repo.Create(t.Context(), f.user.ID, "laptop", "hash-abc", "cnp_abc1", tokens.ScopeReadWrite, &exp)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if tok.ID == 0 {
+		t.Fatal("expected non-zero id")
+	}
+	if tok.Name != "laptop" || tok.TokenHash != "hash-abc" {
+		t.Fatalf("unexpected token: %+v", tok)
+	}
+	if tok.Scope != tokens.ScopeReadWrite {
+		t.Fatalf("expected scope read_write, got %q", tok.Scope)
+	}
+	if tok.ExpiresAt == nil || !tok.ExpiresAt.Equal(exp) {
+		t.Fatalf("expected expires_at %v, got %v", exp, tok.ExpiresAt)
+	}
+	if tok.RevokedAt != nil {
+		t.Fatalf("expected no revoked_at, got %v", tok.RevokedAt)
+	}
+
+	got, err := f.repo.FindByHash(t.Context(), "hash-abc")
+	if err != nil {
+		t.Fatalf("find by hash: %v", err)
+	}
+	if got.ID != tok.ID {
+		t.Fatalf("expected id %d, got %d", tok.ID, got.ID)
+	}
+}
+
+func TestRepo_FindByHash_NotFound(t *testing.T) {
+	f := newRepoFixture(t)
+	_, err := f.repo.FindByHash(t.Context(), "does-not-exist")
+	if err != tokens.ErrNotFound {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestRepo_ListByUser_OrdersNewestFirst(t *testing.T) {
+	f := newRepoFixture(t)
+
+	first, err := f.repo.Create(t.Context(), f.user.ID, "first", "h1", "cnp_1", tokens.ScopeRead, nil)
+	if err != nil {
+		t.Fatalf("create first: %v", err)
+	}
+	time.Sleep(1100 * time.Millisecond) // created_at has 1-second resolution
+	second, err := f.repo.Create(t.Context(), f.user.ID, "second", "h2", "cnp_2", tokens.ScopeRead, nil)
+	if err != nil {
+		t.Fatalf("create second: %v", err)
+	}
+
+	list, err := f.repo.ListByUser(t.Context(), f.user.ID)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("expected 2 tokens, got %d", len(list))
+	}
+	if list[0].ID != second.ID || list[1].ID != first.ID {
+		t.Fatalf("expected newest first: got ids %d,%d", list[0].ID, list[1].ID)
+	}
+}
+
+func TestRepo_ListByUser_ScopedToUser(t *testing.T) {
+	f := newRepoFixture(t)
+
+	other, err := f.users.Create(t.Context(), "bob", "hash", false)
+	if err != nil {
+		t.Fatalf("create other: %v", err)
+	}
+	if _, err := f.repo.Create(t.Context(), f.user.ID, "mine", "h-mine", "cnp_me", tokens.ScopeRead, nil); err != nil {
+		t.Fatalf("create mine: %v", err)
+	}
+	if _, err := f.repo.Create(t.Context(), other.ID, "theirs", "h-theirs", "cnp_ot", tokens.ScopeRead, nil); err != nil {
+		t.Fatalf("create theirs: %v", err)
+	}
+
+	mine, err := f.repo.ListByUser(t.Context(), f.user.ID)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(mine) != 1 || mine[0].Name != "mine" {
+		t.Fatalf("unexpected list: %+v", mine)
+	}
+}
+
+func TestRepo_Revoke_SetsTimestamp(t *testing.T) {
+	f := newRepoFixture(t)
+	tok, err := f.repo.Create(t.Context(), f.user.ID, "t", "h", "cnp_xx", tokens.ScopeReadWrite, nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	if err := f.repo.Revoke(t.Context(), tok.ID, now); err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+
+	got, err := f.repo.FindByID(t.Context(), tok.ID)
+	if err != nil {
+		t.Fatalf("find: %v", err)
+	}
+	if got.RevokedAt == nil {
+		t.Fatal("expected revoked_at to be set")
+	}
+	if !got.RevokedAt.Equal(now) {
+		t.Fatalf("expected revoked_at %v, got %v", now, got.RevokedAt)
+	}
+}
+
+func TestRepo_Revoke_NotFound(t *testing.T) {
+	f := newRepoFixture(t)
+	err := f.repo.Revoke(t.Context(), 99999, time.Now())
+	if err != tokens.ErrNotFound {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestRepo_RevokeAllForUser(t *testing.T) {
+	f := newRepoFixture(t)
+	t1, _ := f.repo.Create(t.Context(), f.user.ID, "a", "ha", "cnp_a", tokens.ScopeRead, nil)
+	t2, _ := f.repo.Create(t.Context(), f.user.ID, "b", "hb", "cnp_b", tokens.ScopeRead, nil)
+
+	if err := f.repo.RevokeAllForUser(t.Context(), f.user.ID, time.Now().UTC()); err != nil {
+		t.Fatalf("revoke all: %v", err)
+	}
+
+	for _, id := range []int64{t1.ID, t2.ID} {
+		got, err := f.repo.FindByID(t.Context(), id)
+		if err != nil {
+			t.Fatalf("find %d: %v", id, err)
+		}
+		if got.RevokedAt == nil {
+			t.Fatalf("token %d: expected revoked_at set", id)
+		}
+	}
+}
+
+func TestRepo_UpdateLastUsed(t *testing.T) {
+	f := newRepoFixture(t)
+	tok, _ := f.repo.Create(t.Context(), f.user.ID, "t", "h", "cnp_xx", tokens.ScopeRead, nil)
+
+	ts := time.Now().UTC().Truncate(time.Second)
+	if err := f.repo.UpdateLastUsed(t.Context(), tok.ID, ts); err != nil {
+		t.Fatalf("update last used: %v", err)
+	}
+
+	got, err := f.repo.FindByID(t.Context(), tok.ID)
+	if err != nil {
+		t.Fatalf("find: %v", err)
+	}
+	if got.LastUsedAt == nil || !got.LastUsedAt.Equal(ts) {
+		t.Fatalf("expected last_used_at %v, got %v", ts, got.LastUsedAt)
+	}
+}

--- a/backend/internal/tokens/service.go
+++ b/backend/internal/tokens/service.go
@@ -1,0 +1,213 @@
+package tokens
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/danpicton/crapnote/internal/auth"
+)
+
+// DefaultTTL is the default lifetime applied to a new token when the caller
+// does not specify one.
+const DefaultTTL = 90 * 24 * time.Hour
+
+// MaxNameLen caps the length of a token name to keep UI and logs readable.
+const MaxNameLen = 80
+
+// ErrForbidden is returned when a user is not permitted to manage API tokens
+// (non-admin and their api_tokens_enabled flag is false).
+var ErrForbidden = errors.New("api tokens not permitted for this user")
+
+// ErrInvalidName is returned when a token name is empty or too long.
+var ErrInvalidName = errors.New("invalid token name")
+
+// ErrInvalidScope is returned when a provided scope value is unrecognised.
+var ErrInvalidScope = errors.New("invalid scope")
+
+// VerifiedToken is the result of a successful bearer-token verification. The
+// raw secret is never returned; only the identity and authorisation envelope
+// the caller needs to enforce access control.
+type VerifiedToken struct {
+	TokenID int64
+	User    *auth.User
+	Scope   Scope
+}
+
+// CreatedToken bundles a newly issued token's metadata with the raw secret.
+// The raw secret (RawToken) must be returned to the caller exactly once and
+// never persisted or logged.
+type CreatedToken struct {
+	Token    *Token
+	RawToken string
+}
+
+// Service implements API-token business logic. It depends on the token repo
+// for persistence and the auth user repo to resolve the owner and enforce the
+// api_tokens_enabled gate.
+type Service struct {
+	tokens *Repo
+	users  *auth.UserRepo
+	now    func() time.Time
+}
+
+// NewService creates a new token Service.
+func NewService(repo *Repo, users *auth.UserRepo) *Service {
+	return &Service{tokens: repo, users: users, now: time.Now}
+}
+
+// Create issues a new API token for user and persists a hash of it. The raw
+// token is returned in CreatedToken.RawToken and must be shown to the caller
+// exactly once. Admins may always create tokens; non-admins require
+// api_tokens_enabled to be true.
+//
+// If ttl == 0, DefaultTTL is applied. If ttl < 0, the token never expires.
+func (s *Service) Create(ctx context.Context, user *auth.User, name string, scope Scope, ttl time.Duration) (*CreatedToken, error) {
+	if user == nil {
+		return nil, ErrForbidden
+	}
+	if !user.IsAdmin && !user.APITokensEnabled {
+		return nil, ErrForbidden
+	}
+	name = strings.TrimSpace(name)
+	if name == "" || len(name) > MaxNameLen {
+		return nil, ErrInvalidName
+	}
+	if !scope.Valid() {
+		return nil, ErrInvalidScope
+	}
+
+	raw, displayPrefix, hash, err := generate()
+	if err != nil {
+		return nil, fmt.Errorf("generate token: %w", err)
+	}
+
+	var expiresAt *time.Time
+	switch {
+	case ttl == 0:
+		t := s.now().Add(DefaultTTL).UTC()
+		expiresAt = &t
+	case ttl > 0:
+		t := s.now().Add(ttl).UTC()
+		expiresAt = &t
+	}
+
+	tok, err := s.tokens.Create(ctx, user.ID, name, hash, displayPrefix, scope, expiresAt)
+	if err != nil {
+		return nil, err
+	}
+	return &CreatedToken{Token: tok, RawToken: raw}, nil
+}
+
+// Verify resolves a raw bearer token to the owning user and scope. Returns
+// ErrInvalidToken for any failure (unknown, revoked, expired, malformed, or
+// belonging to a user whose api_tokens_enabled was subsequently disabled).
+// The same error is returned in every failure case to avoid leaking which
+// condition matched.
+func (s *Service) Verify(ctx context.Context, raw string) (*VerifiedToken, error) {
+	if !strings.HasPrefix(raw, TokenPrefix) {
+		return nil, ErrInvalidToken
+	}
+	hash := hashToken(raw)
+
+	tok, err := s.tokens.FindByHash(ctx, hash)
+	if errors.Is(err, ErrNotFound) {
+		return nil, ErrInvalidToken
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// Constant-time equality: although hash was looked up by key, compare the
+	// stored hash to the computed one explicitly to harden against future
+	// changes that might introduce a prefix index or similar lookup.
+	if subtle.ConstantTimeCompare([]byte(hash), []byte(tok.TokenHash)) != 1 {
+		return nil, ErrInvalidToken
+	}
+
+	if !tok.Active(s.now()) {
+		return nil, ErrInvalidToken
+	}
+
+	user, err := s.users.FindByID(ctx, tok.UserID)
+	if errors.Is(err, auth.ErrNotFound) {
+		return nil, ErrInvalidToken
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// Runtime enforcement: disabling api_tokens_enabled invalidates the user's
+	// tokens immediately without needing to revoke each one.
+	if !user.IsAdmin && !user.APITokensEnabled {
+		return nil, ErrInvalidToken
+	}
+
+	return &VerifiedToken{TokenID: tok.ID, User: user, Scope: tok.Scope}, nil
+}
+
+// List returns all tokens belonging to user, most recent first. Raw secrets
+// are never retrievable.
+func (s *Service) List(ctx context.Context, userID int64) ([]*Token, error) {
+	return s.tokens.ListByUser(ctx, userID)
+}
+
+// Revoke marks a token as revoked if it belongs to userID. Returns
+// ErrNotFound if no such token exists for this user. Idempotent on re-revoke.
+func (s *Service) Revoke(ctx context.Context, userID, tokenID int64) error {
+	tok, err := s.tokens.FindByID(ctx, tokenID)
+	if err != nil {
+		return err
+	}
+	if tok.UserID != userID {
+		// Deliberately return ErrNotFound rather than a distinct error to
+		// avoid leaking existence of tokens owned by other users.
+		return ErrNotFound
+	}
+	return s.tokens.Revoke(ctx, tokenID, s.now())
+}
+
+// RevokeAll marks every non-revoked token belonging to userID as revoked.
+func (s *Service) RevokeAll(ctx context.Context, userID int64) error {
+	return s.tokens.RevokeAllForUser(ctx, userID, s.now())
+}
+
+// RecordUsage updates last_used_at for the given token. Best-effort: errors
+// should be logged by the caller but not surfaced to the client.
+func (s *Service) RecordUsage(ctx context.Context, tokenID int64, ts time.Time) error {
+	return s.tokens.UpdateLastUsed(ctx, tokenID, ts)
+}
+
+// ── token generation ────────────────────────────────────────────────────────
+
+// generate returns (rawToken, displayPrefix, hash). The raw token is the full
+// user-visible string ("cnp_..."); displayPrefix is the first DisplayPrefixLen
+// characters of the random suffix (used only for UI identification); hash is
+// the hex-encoded SHA-256 of the full raw token, which is what the DB stores.
+func generate() (raw, displayPrefix, hash string, err error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", "", "", err
+	}
+	suffix := base64.RawURLEncoding.EncodeToString(b)
+	raw = TokenPrefix + suffix
+	displayPrefix = TokenPrefix + suffix[:DisplayPrefixLen]
+	hash = hashToken(raw)
+	return raw, displayPrefix, hash, nil
+}
+
+// hashToken returns the hex-encoded SHA-256 of the raw token. SHA-256 is
+// chosen deliberately over bcrypt/argon2: API tokens are high-entropy (32
+// random bytes = 256 bits), so brute force is infeasible regardless of hash
+// function, and we want verification to stay fast on every API call.
+func hashToken(raw string) string {
+	sum := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(sum[:])
+}

--- a/backend/internal/tokens/service_test.go
+++ b/backend/internal/tokens/service_test.go
@@ -1,0 +1,244 @@
+package tokens_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/danpicton/crapnote/internal/auth"
+	"github.com/danpicton/crapnote/internal/db"
+	"github.com/danpicton/crapnote/internal/tokens"
+)
+
+type serviceFixture struct {
+	database *db.DB
+	users    *auth.UserRepo
+	svc      *tokens.Service
+	user     *auth.User
+	admin    *auth.User
+}
+
+func newServiceFixture(t *testing.T) *serviceFixture {
+	t.Helper()
+	database, err := db.Open(db.Config{SQLitePath: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+	users := auth.NewUserRepo(database)
+	u, err := users.Create(t.Context(), "alice", "hash", false)
+	if err != nil {
+		t.Fatalf("create alice: %v", err)
+	}
+	admin, err := users.Create(t.Context(), "root", "hash", true)
+	if err != nil {
+		t.Fatalf("create root: %v", err)
+	}
+	svc := tokens.NewService(tokens.NewRepo(database), users)
+	return &serviceFixture{database: database, users: users, svc: svc, user: u, admin: admin}
+}
+
+func TestService_Create_NonAdmin_ForbiddenWhenFlagOff(t *testing.T) {
+	f := newServiceFixture(t)
+	_, err := f.svc.Create(t.Context(), f.user, "laptop", tokens.ScopeReadWrite, 0)
+	if err != tokens.ErrForbidden {
+		t.Fatalf("expected ErrForbidden, got %v", err)
+	}
+}
+
+func TestService_Create_NonAdmin_AllowedWhenFlagOn(t *testing.T) {
+	f := newServiceFixture(t)
+	if err := f.users.SetAPITokensEnabled(t.Context(), f.user.ID, true); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	u, _ := f.users.FindByID(t.Context(), f.user.ID)
+	created, err := f.svc.Create(t.Context(), u, "laptop", tokens.ScopeReadWrite, 0)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if !strings.HasPrefix(created.RawToken, tokens.TokenPrefix) {
+		t.Fatalf("token missing prefix: %q", created.RawToken)
+	}
+	if created.Token.ExpiresAt == nil {
+		t.Fatal("expected default expiry to be set")
+	}
+}
+
+func TestService_Create_Admin_AlwaysAllowed(t *testing.T) {
+	f := newServiceFixture(t)
+	created, err := f.svc.Create(t.Context(), f.admin, "admin-cli", tokens.ScopeRead, 0)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if created.Token.UserID != f.admin.ID {
+		t.Fatalf("expected admin id %d, got %d", f.admin.ID, created.Token.UserID)
+	}
+}
+
+func TestService_Create_NegativeTTL_NoExpiry(t *testing.T) {
+	f := newServiceFixture(t)
+	created, err := f.svc.Create(t.Context(), f.admin, "forever", tokens.ScopeRead, -1)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if created.Token.ExpiresAt != nil {
+		t.Fatalf("expected no expiry, got %v", created.Token.ExpiresAt)
+	}
+}
+
+func TestService_Create_InvalidName(t *testing.T) {
+	f := newServiceFixture(t)
+	if _, err := f.svc.Create(t.Context(), f.admin, "", tokens.ScopeRead, 0); err != tokens.ErrInvalidName {
+		t.Fatalf("empty name: expected ErrInvalidName, got %v", err)
+	}
+	if _, err := f.svc.Create(t.Context(), f.admin, strings.Repeat("x", tokens.MaxNameLen+1), tokens.ScopeRead, 0); err != tokens.ErrInvalidName {
+		t.Fatalf("long name: expected ErrInvalidName, got %v", err)
+	}
+}
+
+func TestService_Create_InvalidScope(t *testing.T) {
+	f := newServiceFixture(t)
+	if _, err := f.svc.Create(t.Context(), f.admin, "n", tokens.Scope("bogus"), 0); err != tokens.ErrInvalidScope {
+		t.Fatalf("expected ErrInvalidScope, got %v", err)
+	}
+}
+
+func TestService_Verify_RoundTrip(t *testing.T) {
+	f := newServiceFixture(t)
+	created, err := f.svc.Create(t.Context(), f.admin, "cli", tokens.ScopeReadWrite, 0)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	v, err := f.svc.Verify(t.Context(), created.RawToken)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if v.User.ID != f.admin.ID {
+		t.Fatalf("expected user %d, got %d", f.admin.ID, v.User.ID)
+	}
+	if v.Scope != tokens.ScopeReadWrite {
+		t.Fatalf("expected scope read_write, got %q", v.Scope)
+	}
+	if v.TokenID != created.Token.ID {
+		t.Fatalf("expected token id %d, got %d", created.Token.ID, v.TokenID)
+	}
+}
+
+func TestService_Verify_RejectsMalformed(t *testing.T) {
+	f := newServiceFixture(t)
+
+	cases := []string{"", "not-a-token", "Bearer something", "cnp_"}
+	for _, c := range cases {
+		if _, err := f.svc.Verify(t.Context(), c); err != tokens.ErrInvalidToken {
+			t.Fatalf("input %q: expected ErrInvalidToken, got %v", c, err)
+		}
+	}
+}
+
+func TestService_Verify_RejectsRevoked(t *testing.T) {
+	f := newServiceFixture(t)
+	created, _ := f.svc.Create(t.Context(), f.admin, "cli", tokens.ScopeRead, 0)
+
+	if err := f.svc.Revoke(t.Context(), f.admin.ID, created.Token.ID); err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+	if _, err := f.svc.Verify(t.Context(), created.RawToken); err != tokens.ErrInvalidToken {
+		t.Fatalf("expected ErrInvalidToken after revoke, got %v", err)
+	}
+}
+
+func TestService_Verify_RejectsExpired(t *testing.T) {
+	f := newServiceFixture(t)
+	// 1ms TTL then sleep to ensure expiry.
+	created, err := f.svc.Create(t.Context(), f.admin, "cli", tokens.ScopeRead, 1*time.Millisecond)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	time.Sleep(10 * time.Millisecond)
+	if _, err := f.svc.Verify(t.Context(), created.RawToken); err != tokens.ErrInvalidToken {
+		t.Fatalf("expected ErrInvalidToken after expiry, got %v", err)
+	}
+}
+
+func TestService_Verify_RejectsWhenUserDisabled(t *testing.T) {
+	f := newServiceFixture(t)
+	if err := f.users.SetAPITokensEnabled(t.Context(), f.user.ID, true); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	u, _ := f.users.FindByID(t.Context(), f.user.ID)
+	created, err := f.svc.Create(t.Context(), u, "cli", tokens.ScopeRead, 0)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := f.users.SetAPITokensEnabled(t.Context(), f.user.ID, false); err != nil {
+		t.Fatalf("disable: %v", err)
+	}
+	if _, err := f.svc.Verify(t.Context(), created.RawToken); err != tokens.ErrInvalidToken {
+		t.Fatalf("expected ErrInvalidToken after user disabled, got %v", err)
+	}
+}
+
+func TestService_Revoke_OtherUsersToken_ReturnsNotFound(t *testing.T) {
+	f := newServiceFixture(t)
+	adminTok, _ := f.svc.Create(t.Context(), f.admin, "a", tokens.ScopeRead, 0)
+	// Alice tries to revoke admin's token.
+	if err := f.svc.Revoke(t.Context(), f.user.ID, adminTok.Token.ID); err != tokens.ErrNotFound {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestService_RevokeAll(t *testing.T) {
+	f := newServiceFixture(t)
+	t1, _ := f.svc.Create(t.Context(), f.admin, "a", tokens.ScopeRead, 0)
+	t2, _ := f.svc.Create(t.Context(), f.admin, "b", tokens.ScopeRead, 0)
+
+	if err := f.svc.RevokeAll(t.Context(), f.admin.ID); err != nil {
+		t.Fatalf("revoke all: %v", err)
+	}
+	if _, err := f.svc.Verify(t.Context(), t1.RawToken); err != tokens.ErrInvalidToken {
+		t.Fatalf("t1 should be invalid")
+	}
+	if _, err := f.svc.Verify(t.Context(), t2.RawToken); err != tokens.ErrInvalidToken {
+		t.Fatalf("t2 should be invalid")
+	}
+}
+
+func TestService_List(t *testing.T) {
+	f := newServiceFixture(t)
+	if _, err := f.svc.Create(t.Context(), f.admin, "cli1", tokens.ScopeRead, 0); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, err := f.svc.Create(t.Context(), f.admin, "cli2", tokens.ScopeReadWrite, 0); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	list, err := f.svc.List(t.Context(), f.admin.ID)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("expected 2 tokens, got %d", len(list))
+	}
+	for _, tok := range list {
+		if tok.TokenHash == "" || tok.Prefix == "" {
+			t.Fatalf("token missing hash/prefix: %+v", tok)
+		}
+	}
+}
+
+func TestService_CreatedToken_RawLooksSane(t *testing.T) {
+	f := newServiceFixture(t)
+	created, err := f.svc.Create(t.Context(), f.admin, "n", tokens.ScopeRead, 0)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	// cnp_ + 43 base64url chars (32 bytes raw → 43 chars unpadded)
+	if len(created.RawToken) != len(tokens.TokenPrefix)+43 {
+		t.Fatalf("unexpected raw length %d: %q", len(created.RawToken), created.RawToken)
+	}
+	// display prefix = cnp_ + first 8 of suffix
+	if len(created.Token.Prefix) != len(tokens.TokenPrefix)+tokens.DisplayPrefixLen {
+		t.Fatalf("unexpected prefix %q", created.Token.Prefix)
+	}
+}

--- a/backend/internal/tokens/usage_recorder.go
+++ b/backend/internal/tokens/usage_recorder.go
@@ -1,0 +1,88 @@
+package tokens
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// UsageRecorder records token last-used-at timestamps out of band so that
+// bearer-authenticated API requests don't pay for an extra DB write on every
+// call. Record is non-blocking: if the internal buffer is full, the event is
+// dropped. This is intentional — "last_used_at" is an audit hint, not a
+// correctness guarantee, and stalling the request path to update it would
+// turn a best-effort counter into a latency or availability risk.
+type UsageRecorder struct {
+	svc       *Service
+	ch        chan usageEvent
+	now       func() time.Time
+	logger    *slog.Logger
+	done      chan struct{}
+	closeOnce sync.Once
+}
+
+type usageEvent struct {
+	tokenID int64
+	ts      time.Time
+}
+
+// NewUsageRecorder returns a recorder with the given buffer size. The caller
+// must call Start() to begin consuming events.
+func NewUsageRecorder(svc *Service, bufferSize int) *UsageRecorder {
+	if bufferSize <= 0 {
+		bufferSize = 256
+	}
+	return &UsageRecorder{
+		svc:    svc,
+		ch:     make(chan usageEvent, bufferSize),
+		now:    time.Now,
+		logger: slog.Default(),
+		done:   make(chan struct{}),
+	}
+}
+
+// Start launches the background drain loop. It returns immediately. The loop
+// exits when ctx is cancelled or Stop is called.
+func (r *UsageRecorder) Start(ctx context.Context) {
+	go r.run(ctx)
+}
+
+// Record enqueues a last-used update for tokenID. Non-blocking: drops the
+// event if the buffer is full.
+func (r *UsageRecorder) Record(tokenID int64) {
+	select {
+	case r.ch <- usageEvent{tokenID: tokenID, ts: r.now()}:
+	default:
+		// Buffer full: drop. Intentional — see type doc.
+	}
+}
+
+// Stop closes the input channel. The drain loop will finish in-flight writes
+// and exit. Safe to call more than once.
+func (r *UsageRecorder) Stop() {
+	r.closeOnce.Do(func() { close(r.ch) })
+	<-r.done
+}
+
+func (r *UsageRecorder) run(ctx context.Context) {
+	defer close(r.done)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case ev, ok := <-r.ch:
+			if !ok {
+				return
+			}
+			// Use a detached context so a cancelled parent doesn't abort a
+			// write already in flight; cap it to a short timeout so a stuck
+			// DB can't keep the goroutine alive forever.
+			writeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			if err := r.svc.RecordUsage(writeCtx, ev.tokenID, ev.ts); err != nil {
+				r.logger.Warn("record token usage", "token_id", ev.tokenID, "error", err)
+			}
+			cancel()
+		}
+	}
+}

--- a/backend/internal/tokens/usage_recorder_test.go
+++ b/backend/internal/tokens/usage_recorder_test.go
@@ -1,0 +1,53 @@
+package tokens_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/danpicton/crapnote/internal/tokens"
+)
+
+func TestUsageRecorder_RecordsLastUsed(t *testing.T) {
+	f := newServiceFixture(t)
+	created, err := f.svc.Create(t.Context(), f.admin, "cli", tokens.ScopeRead, 0)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	rec := tokens.NewUsageRecorder(f.svc, 4)
+	rec.Start(t.Context())
+	t.Cleanup(rec.Stop)
+
+	rec.Record(created.Token.ID)
+
+	// Poll until last_used_at is populated or we time out.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		list, err := f.svc.List(t.Context(), f.admin.ID)
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		if len(list) == 1 && list[0].LastUsedAt != nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("last_used_at was not set within deadline")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+func TestUsageRecorder_DropsWhenFull(t *testing.T) {
+	f := newServiceFixture(t)
+	created, _ := f.svc.Create(t.Context(), f.admin, "cli", tokens.ScopeRead, 0)
+
+	// Zero buffer => default 256, so make a tiny buffer but never start the
+	// consumer. All events after the buffer fills must be dropped without
+	// blocking the caller.
+	rec := tokens.NewUsageRecorder(f.svc, 2)
+	// No Start(), so nothing consumes.
+
+	for i := 0; i < 100; i++ {
+		rec.Record(created.Token.ID) // must not hang
+	}
+}

--- a/e2e/tests/api-tokens.spec.ts
+++ b/e2e/tests/api-tokens.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect, type Page, request } from '@playwright/test';
+
+async function login(page: Page) {
+  await page.goto('/login');
+  await page.getByRole('textbox', { name: /username/i }).fill('admin');
+  await page.getByRole('textbox', { name: /password/i }).fill('admin123');
+  await page.getByRole('button', { name: /log in/i }).click();
+  await expect(page).toHaveURL('/');
+}
+
+test.describe('API tokens', () => {
+  test('admin can create, use, and revoke a token', async ({ page, baseURL }) => {
+    await login(page);
+    await page.goto('/settings');
+
+    // Create a token via the Developer section UI.
+    const tokenName = `e2e-${Date.now()}`;
+    await page.getByPlaceholder(/token name/i).fill(tokenName);
+    await page.getByRole('button', { name: /create token/i }).click();
+
+    // The raw token is shown exactly once inside a <code class="token-value">.
+    const tokenLocator = page.locator('code.token-value');
+    await expect(tokenLocator).toBeVisible();
+    const raw = (await tokenLocator.textContent())?.trim() ?? '';
+    expect(raw).toMatch(/^cnp_/);
+
+    // Fresh API-only client (no cookies) to prove bearer auth stands alone.
+    const apiCtx = await request.newContext({ baseURL });
+
+    // Use the token against a protected endpoint.
+    const listRes = await apiCtx.get('/api/notes', {
+      headers: { Authorization: `Bearer ${raw}` },
+    });
+    expect(listRes.status()).toBe(200);
+
+    // Admin endpoints must be blocked for bearer auth even for admin users.
+    const adminRes = await apiCtx.get('/api/admin/users', {
+      headers: { Authorization: `Bearer ${raw}` },
+    });
+    expect(adminRes.status()).toBe(403);
+
+    // Revoke via the UI.
+    page.once('dialog', (d) => d.accept());
+    await page
+      .getByRole('row', { name: new RegExp(tokenName) })
+      .getByRole('button', { name: /revoke token/i })
+      .click();
+    await expect(page.getByRole('row', { name: new RegExp(tokenName) })).toContainText(/revoked/i);
+
+    // The revoked token must no longer work.
+    const deniedRes = await apiCtx.get('/api/notes', {
+      headers: { Authorization: `Bearer ${raw}` },
+    });
+    expect(deniedRes.status()).toBe(401);
+
+    await apiCtx.dispose();
+  });
+
+  test('read-only scope cannot mutate', async ({ page, baseURL }) => {
+    await login(page);
+    await page.goto('/settings');
+
+    const tokenName = `readonly-${Date.now()}`;
+    await page.getByPlaceholder(/token name/i).fill(tokenName);
+    await page.locator('select').selectOption('read');
+    await page.getByRole('button', { name: /create token/i }).click();
+
+    const raw = (await page.locator('code.token-value').textContent())?.trim() ?? '';
+    expect(raw).toMatch(/^cnp_/);
+
+    const apiCtx = await request.newContext({ baseURL });
+
+    // Read is allowed.
+    const listRes = await apiCtx.get('/api/notes', {
+      headers: { Authorization: `Bearer ${raw}` },
+    });
+    expect(listRes.status()).toBe(200);
+
+    // Write is not.
+    const writeRes = await apiCtx.post('/api/notes', {
+      headers: { Authorization: `Bearer ${raw}` },
+      data: { title: 'nope' },
+    });
+    expect(writeRes.status()).toBe(403);
+
+    await apiCtx.dispose();
+  });
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2,7 +2,23 @@ export interface User {
 	id: number;
 	username: string;
 	is_admin: boolean;
+	api_tokens_enabled?: boolean;
 	created_at: string;
+}
+
+export interface ApiToken {
+	id: number;
+	name: string;
+	prefix: string;
+	scope: 'read' | 'read_write';
+	last_used_at?: string;
+	expires_at?: string;
+	revoked_at?: string;
+	created_at: string;
+}
+
+export interface CreatedApiToken extends ApiToken {
+	token: string;
 }
 
 export interface Note {
@@ -101,6 +117,19 @@ export const api = {
 			request<void>('POST', `/api/notes/${noteId}/tags`, { tag_id: tagId }),
 		removeFromNote: (noteId: number, tagId: number) =>
 			request<void>('DELETE', `/api/notes/${noteId}/tags/${tagId}`),
+	},
+
+	tokens: {
+		list: () => request<ApiToken[]>('GET', '/api/tokens'),
+		create: (name: string, scope: 'read' | 'read_write', ttlDays: number) =>
+			request<CreatedApiToken>('POST', '/api/tokens', { name, scope, ttl_days: ttlDays }),
+		revoke: (id: number) => request<void>('DELETE', `/api/tokens/${id}`),
+		revokeAll: () => request<void>('POST', '/api/tokens/revoke-all'),
+	},
+
+	admin: {
+		setApiTokensEnabled: (userId: number, enabled: boolean) =>
+			request<User>('PATCH', `/api/admin/users/${userId}/api-tokens`, { enabled }),
 	},
 
 	trash: {

--- a/frontend/src/lib/components/ApiTokens.svelte
+++ b/frontend/src/lib/components/ApiTokens.svelte
@@ -1,0 +1,337 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { Trash2, Copy, Check } from 'lucide-svelte';
+	import { api, ApiError, type ApiToken, type CreatedApiToken } from '$lib/api';
+
+	interface Props {
+		/** Whether the caller may create tokens. If false we still show the
+		 * list (so the user can see/revoke existing ones), but the create form
+		 * is hidden with an explanatory note. */
+		canCreate: boolean;
+	}
+
+	let { canCreate }: Props = $props();
+
+	let tokens = $state<ApiToken[]>([]);
+	let loading = $state(true);
+	let loadError = $state('');
+
+	let newName = $state('');
+	let newScope = $state<'read' | 'read_write'>('read_write');
+	let newTtlDays = $state(90);
+	let createError = $state('');
+	let creating = $state(false);
+	let justCreated = $state<CreatedApiToken | null>(null);
+	let copied = $state(false);
+
+	onMount(loadTokens);
+
+	async function loadTokens() {
+		loading = true;
+		loadError = '';
+		try {
+			tokens = (await api.tokens.list()) ?? [];
+		} catch (err) {
+			loadError = err instanceof Error ? err.message : 'Failed to load tokens.';
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function createToken(e: Event) {
+		e.preventDefault();
+		createError = '';
+		creating = true;
+		try {
+			const created = await api.tokens.create(newName.trim(), newScope, newTtlDays);
+			justCreated = created;
+			newName = '';
+			// Reload list so the new (hashed) record appears immediately.
+			await loadTokens();
+		} catch (err) {
+			if (err instanceof ApiError) createError = prettyError(err);
+			else createError = err instanceof Error ? err.message : 'Failed to create token.';
+		} finally {
+			creating = false;
+		}
+	}
+
+	function prettyError(err: ApiError): string {
+		try {
+			const parsed = JSON.parse(err.message) as { error?: string };
+			return parsed.error ?? err.message;
+		} catch {
+			return err.message;
+		}
+	}
+
+	async function copyToken() {
+		if (!justCreated) return;
+		try {
+			await navigator.clipboard.writeText(justCreated.token);
+			copied = true;
+			setTimeout(() => (copied = false), 2000);
+		} catch {
+			// Fallback: select the textarea so the user can copy manually.
+		}
+	}
+
+	function dismissCreated() {
+		justCreated = null;
+		copied = false;
+	}
+
+	async function revokeToken(id: number) {
+		if (!confirm('Revoke this token? External clients using it will stop working immediately.')) return;
+		try {
+			await api.tokens.revoke(id);
+			await loadTokens();
+		} catch (err) {
+			alert(err instanceof Error ? err.message : 'Failed to revoke token.');
+		}
+	}
+
+	async function revokeAll() {
+		if (tokens.length === 0) return;
+		if (!confirm(`Revoke all ${tokens.length} token(s)? This does not sign you out on other devices.`)) return;
+		try {
+			await api.tokens.revokeAll();
+			await loadTokens();
+		} catch (err) {
+			alert(err instanceof Error ? err.message : 'Failed to revoke tokens.');
+		}
+	}
+
+	function fmtDate(iso?: string) {
+		if (!iso) return '—';
+		return new Date(iso).toLocaleString();
+	}
+
+	function status(t: ApiToken): string {
+		if (t.revoked_at) return 'Revoked';
+		if (t.expires_at && new Date(t.expires_at) < new Date()) return 'Expired';
+		return 'Active';
+	}
+</script>
+
+<div class="tokens">
+	{#if !canCreate}
+		<p class="hint">
+			API token creation is disabled for your account. Ask an administrator to enable it if
+			you need external API access.
+		</p>
+	{/if}
+
+	{#if justCreated}
+		<div class="new-token" role="alert">
+			<strong>Your new token (shown once — copy it now):</strong>
+			<div class="token-row">
+				<code class="token-value">{justCreated.token}</code>
+				<button type="button" class="copy-btn" onclick={copyToken} aria-label="Copy token">
+					{#if copied}
+						<Check size={14} /> Copied
+					{:else}
+						<Copy size={14} /> Copy
+					{/if}
+				</button>
+			</div>
+			<p class="hint">
+				Store this somewhere safe. You won't be able to see it again.
+			</p>
+			<button type="button" class="secondary" onclick={dismissCreated}>Dismiss</button>
+		</div>
+	{/if}
+
+	{#if canCreate}
+		<form class="create-form" onsubmit={createToken}>
+			{#if createError}
+				<p role="alert" class="error">{createError}</p>
+			{/if}
+			<input
+				type="text"
+				placeholder="Token name (e.g. cli-laptop)"
+				bind:value={newName}
+				maxlength={80}
+				required
+			/>
+			<select bind:value={newScope}>
+				<option value="read">Read only</option>
+				<option value="read_write">Read and write</option>
+			</select>
+			<label class="ttl">
+				Expires in
+				<input type="number" min="-1" max="3650" bind:value={newTtlDays} />
+				days
+				<span class="hint inline">(-1 = never)</span>
+			</label>
+			<button type="submit" class="primary" disabled={creating}>
+				{creating ? 'Creating…' : 'Create token'}
+			</button>
+		</form>
+	{/if}
+
+	{#if loading}
+		<p>Loading tokens…</p>
+	{:else if loadError}
+		<p role="alert" class="error">{loadError}</p>
+	{:else if tokens.length === 0}
+		<p class="hint">No API tokens yet.</p>
+	{:else}
+		<div class="list-header">
+			<button type="button" class="secondary danger" onclick={revokeAll}>Revoke all</button>
+		</div>
+		<table class="tokens-table">
+			<thead>
+				<tr>
+					<th>Name</th>
+					<th>Prefix</th>
+					<th>Scope</th>
+					<th>Status</th>
+					<th>Last used</th>
+					<th>Expires</th>
+					<th></th>
+				</tr>
+			</thead>
+			<tbody>
+				{#each tokens as t (t.id)}
+					<tr class:revoked={!!t.revoked_at}>
+						<td>{t.name}</td>
+						<td><code>{t.prefix}…</code></td>
+						<td>{t.scope === 'read_write' ? 'Read+Write' : 'Read'}</td>
+						<td>{status(t)}</td>
+						<td>{fmtDate(t.last_used_at)}</td>
+						<td>{fmtDate(t.expires_at)}</td>
+						<td>
+							{#if !t.revoked_at}
+								<button class="icon-btn" onclick={() => revokeToken(t.id)} aria-label="Revoke token" title="Revoke token">
+									<Trash2 size={14} />
+								</button>
+							{/if}
+						</td>
+					</tr>
+				{/each}
+			</tbody>
+		</table>
+	{/if}
+</div>
+
+<style>
+	.tokens { display: flex; flex-direction: column; gap: 0.75rem; }
+	.hint { font-size: 0.8125rem; color: var(--text-3); margin: 0; }
+	.hint.inline { display: inline; }
+
+	.new-token {
+		padding: 0.75rem;
+		border: 1px solid var(--accent);
+		background: var(--accent-lt);
+		border-radius: 0.375rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+	.token-row { display: flex; gap: 0.5rem; align-items: center; }
+	.token-value {
+		flex: 1;
+		padding: 0.375rem 0.5rem;
+		background: var(--bg);
+		border: 1px solid var(--border);
+		border-radius: 0.25rem;
+		font-family: monospace;
+		font-size: 0.8125rem;
+		overflow-x: auto;
+		white-space: nowrap;
+	}
+	.copy-btn {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.25rem;
+		padding: 0.375rem 0.625rem;
+		border: 1px solid var(--border-md);
+		border-radius: 0.25rem;
+		background: var(--bg);
+		cursor: pointer;
+		font-size: 0.8125rem;
+	}
+
+	.create-form {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.5rem;
+		align-items: center;
+	}
+	.create-form input[type='text'],
+	.create-form select,
+	.create-form input[type='number'] {
+		padding: 0.375rem 0.625rem;
+		border: 1px solid var(--border-md);
+		border-radius: 0.375rem;
+		font-size: 0.875rem;
+		background: var(--bg);
+		color: var(--text);
+	}
+	.create-form input[type='number'] { width: 5rem; }
+	.ttl { display: flex; align-items: center; gap: 0.375rem; font-size: 0.875rem; color: var(--text-2); }
+
+	.primary {
+		padding: 0.375rem 0.875rem;
+		background: var(--accent);
+		color: white;
+		border: none;
+		border-radius: 0.375rem;
+		cursor: pointer;
+		font-size: 0.875rem;
+	}
+	.primary:disabled { opacity: 0.6; cursor: not-allowed; }
+	.primary:hover:not(:disabled) { background: var(--accent-dk); }
+
+	.secondary {
+		padding: 0.375rem 0.625rem;
+		background: transparent;
+		border: 1px solid var(--border-md);
+		border-radius: 0.375rem;
+		cursor: pointer;
+		color: var(--text-2);
+		font-size: 0.875rem;
+	}
+	.secondary.danger { color: var(--danger); border-color: var(--danger); }
+	.secondary:hover { background: var(--bg-hover); }
+
+	.list-header { display: flex; justify-content: flex-end; }
+
+	.tokens-table {
+		width: 100%;
+		border-collapse: collapse;
+		font-size: 0.875rem;
+	}
+	.tokens-table th,
+	.tokens-table td {
+		text-align: left;
+		padding: 0.375rem 0.5rem;
+		border-bottom: 1px solid var(--border);
+	}
+	.tokens-table th { font-weight: 600; color: var(--text-3); }
+	.tokens-table tr.revoked { opacity: 0.6; }
+
+	.icon-btn {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 1.75rem;
+		height: 1.75rem;
+		border: none;
+		border-radius: 0.25rem;
+		cursor: pointer;
+		background: transparent;
+		color: var(--danger);
+	}
+	.icon-btn:hover { background: var(--danger-bg); }
+
+	.error {
+		color: var(--danger);
+		font-size: 0.875rem;
+		padding: 0.375rem 0.625rem;
+		background: var(--danger-bg);
+		border-radius: 0.375rem;
+		margin: 0;
+	}
+</style>

--- a/frontend/src/routes/admin/+page.svelte
+++ b/frontend/src/routes/admin/+page.svelte
@@ -8,6 +8,7 @@
 		id: number;
 		username: string;
 		is_admin: boolean;
+		api_tokens_enabled: boolean;
 		created_at: string;
 	}
 
@@ -59,6 +60,21 @@
 		await fetch(`/api/admin/users/${id}`, { method: 'DELETE', credentials: 'include' });
 		users = users.filter((u) => u.id !== id);
 	}
+
+	async function toggleApiTokens(user: AdminUser, enabled: boolean) {
+		const res = await fetch(`/api/admin/users/${user.id}/api-tokens`, {
+			method: 'PATCH',
+			headers: { 'Content-Type': 'application/json' },
+			credentials: 'include',
+			body: JSON.stringify({ enabled }),
+		});
+		if (res.ok) {
+			const updated = (await res.json()) as AdminUser;
+			users = users.map((u) => (u.id === updated.id ? updated : u));
+		} else {
+			alert('Failed to update API token permission.');
+		}
+	}
 </script>
 
 <svelte:head>
@@ -101,6 +117,7 @@
 					<tr>
 						<th>Username</th>
 						<th>Role</th>
+						<th>API tokens</th>
 						<th>Created</th>
 						<th></th>
 					</tr>
@@ -110,6 +127,20 @@
 						<tr>
 							<td>{user.username}</td>
 							<td>{user.is_admin ? 'Admin' : 'User'}</td>
+							<td>
+								{#if user.is_admin}
+									<span class="hint">Always</span>
+								{:else}
+									<label class="toggle">
+										<input
+											type="checkbox"
+											checked={user.api_tokens_enabled}
+											onchange={(e) => toggleApiTokens(user, (e.currentTarget as HTMLInputElement).checked)}
+										/>
+										{user.api_tokens_enabled ? 'Enabled' : 'Disabled'}
+									</label>
+								{/if}
+							</td>
 							<td>{new Date(user.created_at).toLocaleDateString()}</td>
 							<td>
 								{#if user.id !== auth.user?.id}
@@ -223,4 +254,15 @@
 	}
 
 	.users-table th { font-weight: 600; color: var(--text-3); }
+
+	.toggle {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.375rem;
+		font-size: 0.8125rem;
+		color: var(--text-2);
+		cursor: pointer;
+	}
+
+	.hint { font-size: 0.8125rem; color: var(--text-3); }
 </style>

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -2,8 +2,13 @@
 	import { ChevronLeft, Moon, Sun, Users } from 'lucide-svelte';
 	import { auth } from '$lib/stores/auth.svelte';
 	import { theme } from '$lib/stores/theme.svelte';
+	import ApiTokens from '$lib/components/ApiTokens.svelte';
 
 	let exportPassword = $state('');
+
+	const canCreateTokens = $derived(
+		!!auth.user && (auth.user.is_admin || !!auth.user.api_tokens_enabled),
+	);
 
 	function doExport() {
 		const url = exportPassword
@@ -66,6 +71,16 @@
 				<Sun size={15} /> Enable light mode
 			{/if}
 		</button>
+	</section>
+
+	<section class="section">
+		<h2>Developer</h2>
+		<p class="hint">
+			API tokens let external clients (CLIs, scripts) call the CrapNote API with a
+			<code>Authorization: Bearer cnp_…</code> header. Each token is shown once on
+			creation and can be revoked at any time.
+		</p>
+		<ApiTokens canCreate={canCreateTokens} />
 	</section>
 
 	<section class="section">


### PR DESCRIPTION
## Summary
Implements personal API tokens for bearer authentication, allowing external clients (CLIs, scripts) to access the API without a browser session. Tokens are issued to users with configurable scopes (read or read+write) and optional expiry, with the raw secret shown exactly once on creation and only a SHA-256 hash stored in the database.

## Key Changes

**Backend**
- New `tokens` package with service, repository, and HTTP handler for managing API tokens
- Token model with SHA-256 hashing, display prefix, scope enforcement, and revocation support
- Bearer token authentication middleware integrated into the auth system
- `BearerAuth` adapter connecting token verification to the auth middleware
- `UsageRecorder` for asynchronously tracking token last-used timestamps without blocking requests
- Admin endpoint to toggle `api_tokens_enabled` flag per user (non-admins require this flag to create tokens)
- Database migration adding `api_tokens` table and `api_tokens_enabled` column to users
- Per-IP rate limiting for bearer-authenticated requests (separate from login rate limiting)
- Comprehensive test coverage for service, repository, handler, and middleware integration

**Frontend**
- New `ApiTokens.svelte` component for creating, listing, and revoking tokens
- Token creation form with name, scope, and TTL inputs
- One-time display of raw token with copy-to-clipboard functionality
- Token list showing prefix, scope, status, last-used, and expiry with revoke buttons
- Bulk revoke-all action
- Integration into settings page under Developer section
- API client methods for token CRUD operations

**Configuration**
- New environment variables for bearer-auth rate limiting (`BEARER_RATE_PER_MINUTE`, `BEARER_RATE_BURST`)
- Frontend build-time variables for sync interval and offline notes count

## Implementation Details

- **Security**: Raw tokens use `cnp_` prefix for greppability and secret-scanner detection; only hashes are persisted; raw secret shown exactly once
- **Scope enforcement**: Read-only tokens set `WriteAllowed=false` in context; write operations check this flag
- **Non-blocking usage tracking**: `UsageRecorder` buffers updates asynchronously to avoid latency impact on every request
- **Admin bypass**: Admins can always create tokens; non-admins require explicit `api_tokens_enabled` flag
- **Graceful degradation**: Disabling the flag doesn't auto-revoke existing tokens but auth middleware rejects them at request time
- **Rate limiting**: Bearer requests are rate-limited separately from cookie traffic to protect token verification without throttling browser sessions

https://claude.ai/code/session_011S6Hg8KvpqJNaJjBKJaAym