### PR TITLE
Redesign tag filtering UI with dedicated Tags pane and keyboard shortcut

### DIFF
--- a/e2e/tests/tags.spec.ts
+++ b/e2e/tests/tags.spec.ts
@@ -55,7 +55,8 @@ test.describe('Tags', () => {
     // Chip appears in the editor status bar
     await expect(page.locator('.note-tag-chip', { hasText: 'e2e-tag' })).toBeVisible();
 
-    // Checkbox in popover is checked
+    // Reopen popover (it closes automatically after tag creation) and check the checkbox
+    await openTagPopover(page);
     const checkbox = page.locator('.popover-item').filter({ hasText: 'e2e-tag' }).locator('input[type=checkbox]');
     await expect(checkbox).toBeChecked();
   });
@@ -131,7 +132,8 @@ test.describe('Tags', () => {
     await openTagPopover(page);
     await createTagInPopover(page, 'remove-tag');
 
-    // Uncheck via popover — register wait before unchecking
+    // Reopen popover (it closes automatically after tag creation) and uncheck
+    await openTagPopover(page);
     const checkbox = page.locator('.popover-item').filter({ hasText: 'remove-tag' }).locator('input[type=checkbox]');
     const deleteDone = page.waitForResponse((r) => r.url().includes('/api/notes') && r.url().includes('/tags/') && r.request().method() === 'DELETE');
     await checkbox.uncheck();

--- a/e2e/tests/tags.spec.ts
+++ b/e2e/tests/tags.spec.ts
@@ -36,6 +36,12 @@ async function createTagInPopover(page: Page, name: string) {
   await expect(page.locator('.note-tag-chip', { hasText: name })).toBeVisible();
 }
 
+/** Open the Tags pane-tab to reveal the tag panel. */
+async function openTagsTab(page: Page) {
+  await page.getByRole('group', { name: /filter notes/i }).getByRole('button', { name: /^tags/i }).click();
+  await expect(page.getByRole('group', { name: /tag filters/i })).toBeVisible();
+}
+
 test.describe('Tags', () => {
   test.beforeEach(async ({ page }) => {
     await login(page);
@@ -46,7 +52,7 @@ test.describe('Tags', () => {
     await openTagPopover(page);
     await createTagInPopover(page, 'e2e-tag');
 
-    // Chip appears above the title
+    // Chip appears in the editor status bar
     await expect(page.locator('.note-tag-chip', { hasText: 'e2e-tag' })).toBeVisible();
 
     // Checkbox in popover is checked
@@ -54,13 +60,14 @@ test.describe('Tags', () => {
     await expect(checkbox).toBeChecked();
   });
 
-  test('tag appears in sidebar filter after being applied', async ({ page }) => {
+  test('tag appears in tag panel after being applied', async ({ page }) => {
     await createNote(page, 'Sidebar filter note');
     await openTagPopover(page);
     await createTagInPopover(page, 'sidebar-tag');
 
-    // Sidebar pill should appear
-    await expect(page.locator('.filter-tags .tag-pill', { hasText: 'sidebar-tag' })).toBeVisible();
+    // Open the Tags pane-tab to reveal the tag panel
+    await openTagsTab(page);
+    await expect(page.locator('.tag-panel-item', { hasText: 'sidebar-tag' })).toBeVisible();
   });
 
   test('filtering by tag shows only tagged notes', async ({ page }) => {
@@ -72,9 +79,10 @@ test.describe('Tags', () => {
 
     await createNote(page, 'Untagged note');
 
-    // Register wait BEFORE the click — the GET fires immediately with no debounce
+    // Open the Tags tab then click the tag in the panel
+    await openTagsTab(page);
     const filterDone = page.waitForResponse((r) => r.url().includes('/api/notes') && r.request().method() === 'GET');
-    await page.locator('.filter-tags .tag-pill', { hasText: 'filter-tag' }).click();
+    await page.locator('.tag-panel-item', { hasText: 'filter-tag' }).click();
     await filterDone;
 
     // Only tagged note visible in list
@@ -82,7 +90,7 @@ test.describe('Tags', () => {
     await expect(page.getByRole('list').getByText('Untagged note')).not.toBeVisible();
   });
 
-  test('"All" pill restores full note list', async ({ page }) => {
+  test('"All" tab restores full note list', async ({ page }) => {
     await createNote(page, 'Note A');
     await openTagPopover(page);
     await createTagInPopover(page, 'restore-tag');
@@ -90,15 +98,16 @@ test.describe('Tags', () => {
 
     await createNote(page, 'Note B');
 
-    // Activate tag filter — set up wait before click
+    // Activate tag filter via the Tags pane-tab
+    await openTagsTab(page);
     let notesDone = page.waitForResponse((r) => r.url().includes('/api/notes') && r.request().method() === 'GET');
-    await page.locator('.filter-tags .tag-pill', { hasText: 'restore-tag' }).click();
+    await page.locator('.tag-panel-item', { hasText: 'restore-tag' }).click();
     await notesDone;
     await expect(page.getByRole('list').getByText('Note B')).not.toBeVisible();
 
-    // Click All — set up wait before click
+    // Click the All tab to restore the full list
     notesDone = page.waitForResponse((r) => r.url().includes('/api/notes') && r.request().method() === 'GET');
-    await page.locator('.filter-fixed .tag-pill', { hasText: 'All' }).click();
+    await page.getByRole('group', { name: /filter notes/i }).getByRole('button', { name: /^all/i }).click();
     await notesDone;
     await expect(page.getByRole('list').getByText('Note B')).toBeVisible();
   });
@@ -108,13 +117,13 @@ test.describe('Tags', () => {
     await openTagPopover(page);
     await createTagInPopover(page, 'chip-tag');
 
-    // Register wait before clicking the chip
+    // Click the chip — this activates the tag filter and opens the tag panel
     const filterDone = page.waitForResponse((r) => r.url().includes('/api/notes') && r.request().method() === 'GET');
     await page.locator('.note-tag-chip', { hasText: 'chip-tag' }).click();
     await filterDone;
 
-    // Sidebar filter pill should be active
-    await expect(page.locator('.filter-tags .tag-pill.tag-pill-active', { hasText: 'chip-tag' })).toBeVisible();
+    // The Tags tab should be active and the tag item highlighted in the panel
+    await expect(page.locator('.tag-panel-item.tag-panel-active', { hasText: 'chip-tag' })).toBeVisible();
   });
 
   test('can remove a tag from a note', async ({ page }) => {
@@ -144,29 +153,32 @@ test.describe('Tags', () => {
 
     await createNote(page, 'Plain note');
 
-    // Activate starred filter — register wait before click
+    // Activate starred filter via the Starred pane-tab
     const filterDone = page.waitForResponse((r) => r.url().includes('/api/notes') && r.request().method() === 'GET');
-    await page.locator('.filter-fixed .tag-pill', { hasText: 'Starred' }).click();
+    await page.getByRole('group', { name: /filter notes/i }).getByRole('button', { name: /^starred/i }).click();
     await filterDone;
 
     await expect(page.getByRole('list').getByText('Starred note')).toBeVisible();
     await expect(page.getByRole('list').getByText('Plain note')).not.toBeVisible();
   });
 
-  test('tag disappears from filter when no notes have it', async ({ page }) => {
+  test('tag disappears from tag panel when no notes have it', async ({ page }) => {
     await createNote(page, 'Solo tag note');
     await openTagPopover(page);
     await createTagInPopover(page, 'solo-tag');
 
-    await expect(page.locator('.filter-tags .tag-pill', { hasText: 'solo-tag' })).toBeVisible();
+    // Tag appears in panel
+    await openTagsTab(page);
+    await expect(page.locator('.tag-panel-item', { hasText: 'solo-tag' })).toBeVisible();
 
     // Remove the tag — register wait before unchecking
+    await openTagPopover(page);
     const checkbox = page.locator('.popover-item').filter({ hasText: 'solo-tag' }).locator('input[type=checkbox]');
     const deleteDone = page.waitForResponse((r) => r.url().includes('/tags/') && r.request().method() === 'DELETE');
     await checkbox.uncheck();
     await deleteDone;
 
-    // Pill should disappear (pseudo-erasure)
-    await expect(page.locator('.filter-tags .tag-pill', { hasText: 'solo-tag' })).not.toBeVisible();
+    // Tag panel item should disappear (pseudo-erasure)
+    await expect(page.locator('.tag-panel-item', { hasText: 'solo-tag' })).not.toBeVisible();
   });
 });

--- a/e2e/tests/tags.spec.ts
+++ b/e2e/tests/tags.spec.ts
@@ -106,9 +106,9 @@ test.describe('Tags', () => {
     await notesDone;
     await expect(page.getByRole('list').getByText('Note B')).not.toBeVisible();
 
-    // Click the All tab to restore the full list
+    // Click the All/Filtered tab to restore the full list
     notesDone = page.waitForResponse((r) => r.url().includes('/api/notes') && r.request().method() === 'GET');
-    await page.getByRole('group', { name: /filter notes/i }).getByRole('button', { name: /^all/i }).click();
+    await page.getByRole('group', { name: /filter notes/i }).getByRole('button', { name: /^(all|filtered)/i }).click();
     await notesDone;
     await expect(page.getByRole('list').getByText('Note B')).toBeVisible();
   });

--- a/frontend/src/lib/stores/shortcuts.svelte.ts
+++ b/frontend/src/lib/stores/shortcuts.svelte.ts
@@ -8,7 +8,8 @@ export type ShortcutId =
 	| 'bold'
 	| 'italic'
 	| 'underline'
-	| 'insert-link';
+	| 'insert-link'
+	| 'open-tags';
 
 export interface ShortcutAction {
 	id: ShortcutId;
@@ -44,6 +45,7 @@ const actions: ShortcutAction[] = [
 		allowInInputs: true,
 	},
 	{ id: 'help-modal', description: 'Show keyboard shortcuts', defaultCombo: '?' },
+	{ id: 'open-tags', description: 'Open tag popover', defaultCombo: 'Ctrl+.' },
 ];
 
 // ── Parsing / formatting ─────────────────────────────────────────────────────

--- a/frontend/src/lib/stores/shortcuts.test.ts
+++ b/frontend/src/lib/stores/shortcuts.test.ts
@@ -59,6 +59,10 @@ describe('shortcuts store', () => {
 		expect(matchShortcut(ev('k', { ctrlKey: true }))).toBe('search-focus');
 	});
 
+	it('matches open-tags on Ctrl+.', () => {
+		expect(matchShortcut(ev('.', { ctrlKey: true }))).toBe('open-tags');
+	});
+
 	it('returns null for unbound keys', () => {
 		expect(matchShortcut(ev('q'))).toBeNull();
 		expect(matchShortcut(ev('n'))).toBeNull();

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -124,7 +124,6 @@
 
 	// Only show tags that have at least one note (active or trashed); pure UI erasure
 	let visibleTags = $derived(allTags.filter(t => t.note_count > 0));
-	let starredNoteCount = $derived(notes.filter(n => n.starred).length);
 	let tagsTabActive = $derived(activeTagId !== null);
 
 	let selectedNote = $derived(notes.find((n) => n.id === selectedId) ?? null);
@@ -558,10 +557,6 @@
 			selectedId = null;
 			noteTags = [];
 		}
-	}
-
-	function filterByTag(id: number | null) {
-		return applyFilter(id, starredOnly);
 	}
 
 	function toggleStarFilter() {

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -440,6 +440,10 @@
 				// currently-focused field so the save fires immediately.
 				(document.activeElement as HTMLElement | null)?.blur();
 				break;
+			case 'open-tags':
+				e.preventDefault();
+				showTagPopover = !showTagPopover;
+				break;
 		}
 	}
 
@@ -981,7 +985,7 @@
 					<span class="status-tags-label">Tags</span>
 					{#each noteTags as tag (tag.id)}
 						{@const c = tagColor(tag)}
-						<button class="note-tag-chip" onclick={() => applyFilter(activeTagId === tag.id ? null : tag.id, starredOnly)} title="Filter by {tag.name}">
+						<button class="note-tag-chip" onclick={() => { const newId = activeTagId === tag.id ? null : tag.id; applyFilter(newId, starredOnly); if (newId !== null) showTagsPanel = true; }} title="Filter by {tag.name}">
 							<span class="status-tag-dot" style="background:{c.text}"></span>
 							<span class="status-tag-word">{tag.name}</span>
 						</button>
@@ -1007,7 +1011,7 @@
 							</div>
 						{/if}
 					</div>
-					<span class="status-shortcut" aria-hidden="true">{modKey}T</span>
+					<span class="status-shortcut" aria-hidden="true">{shortcuts.displayCombo(shortcuts.get('open-tags'))}</span>
 				</span>
 			</div>
 		{:else}

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -55,6 +55,8 @@
 	let saveTimer: ReturnType<typeof setTimeout> | null = null;
 	// Helpers for detecting mobile viewport
 	function isMobile() { return window.matchMedia('(max-width: 767px)').matches; }
+	// Platform-aware modifier key label (⌘ on Mac, Ctrl on everything else)
+	const modKey = typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.platform) ? '⌘' : 'Ctrl+';
 	// Editor command ref
 	let editorRef = $state<EditorRef | null>(null);
 	// Title input ref (used to focus + highlight on new-note creation)
@@ -793,7 +795,7 @@
 				bind:value={search}
 				oninput={handleSearch}
 			/>
-			<span class="search-shortcut" aria-hidden="true">⌘K</span>
+			<span class="search-shortcut" aria-hidden="true">{modKey}K</span>
 		</div>
 
 		<div class="pane-switcher" role="group" aria-label="Filter notes">
@@ -815,7 +817,7 @@
 				>Tags<span class="tab-sep"> · </span><span class="tab-count">{visibleTags.length}</span></button>
 			{/if}
 		</div>
-		{#if showTagsPanel || tagsTabActive}
+		{#if showTagsPanel}
 			<div class="tag-panel" role="group" aria-label="Tag filters">
 				{#each visibleTags as tag (tag.id)}
 					{@const c = tagColor(tag)}
@@ -827,7 +829,7 @@
 					><span class="tag-dot" style="background:{c.text}"></span>{tag.name}</button>
 				{/each}
 			</div>
-		{/if}
+		{:else}
 
 		<ul class="note-list" role="list">
 			{#each notes as note (note.id)}
@@ -867,6 +869,7 @@
 				<li class="empty">No notes yet.</li>
 			{/if}
 		</ul>
+		{/if}
 
 		<div class="sidebar-bottom">
 			<span class="sidebar-user">{auth.user?.username ?? ''}</span>
@@ -978,10 +981,13 @@
 					<span class="status-tags-label">Tags</span>
 					{#each noteTags as tag (tag.id)}
 						{@const c = tagColor(tag)}
-						<button class="note-tag-chip" style="--tag-bg:{c.bg};--tag-text:{c.text}" onclick={() => applyFilter(activeTagId === tag.id ? null : tag.id, starredOnly)} title="Filter by {tag.name}">{tag.name}</button>
+						<button class="note-tag-chip" onclick={() => applyFilter(activeTagId === tag.id ? null : tag.id, starredOnly)} title="Filter by {tag.name}">
+							<span class="status-tag-dot" style="background:{c.text}"></span>
+							<span class="status-tag-word">{tag.name}</span>
+						</button>
 					{/each}
 					<div class="tag-popover-wrap">
-						<button class="status-add-tag" onclick={() => (showTagPopover = !showTagPopover)} title="Tags">+ tag</button>
+						<button class="status-add-tag" onclick={() => (showTagPopover = !showTagPopover)} title="Tags">+ add tag</button>
 						{#if showTagPopover}
 							<div class="tag-popover-backdrop" onclick={() => (showTagPopover = false)} role="presentation"></div>
 							<div class="tag-popover">
@@ -1001,6 +1007,7 @@
 							</div>
 						{/if}
 					</div>
+					<span class="status-shortcut" aria-hidden="true">{modKey}T</span>
 				</span>
 			</div>
 		{:else}
@@ -1515,29 +1522,47 @@
 		margin-left: auto;
 		display: flex;
 		align-items: center;
-		gap: 0.5rem;
+		gap: 0.625rem;
 	}
 	.status-tags-label {
 		text-transform: uppercase;
 		letter-spacing: 0.08em;
-		font-size: 0.625rem;
+		font-size: 0.6875rem;
 		color: var(--text-4);
 	}
+	/* Typographic tag: dot + word, no fill or border */
 	.note-tag-chip {
-		position: relative;
-		z-index: 31;
 		display: inline-flex;
 		align-items: center;
-		gap: 0.3rem;
-		font-size: 0.6875rem;
-		font-family: var(--sans);
-		padding: 0.15rem 0.5rem;
-		background: var(--tag-bg, var(--bg-hover));
-		color: var(--tag-text, var(--text-2));
-		border: 1px solid var(--border);
+		gap: 0.375rem;
+		background: none;
+		border: none;
+		padding: 0;
 		cursor: pointer;
 	}
-	.note-tag-chip:hover { opacity: 0.75; }
+	.note-tag-chip:hover .status-tag-word { color: var(--text-2); }
+	.status-tag-dot {
+		width: 5px;
+		height: 5px;
+		border-radius: 50%;
+		flex-shrink: 0;
+	}
+	.status-tag-word {
+		font-size: 0.8125rem;
+		font-family: var(--sans);
+		font-weight: 400;
+		color: var(--text);
+	}
+	.status-shortcut {
+		font-size: 0.625rem;
+		color: var(--text-4);
+		background: var(--bg-hover);
+		border: 1px solid var(--border);
+		padding: 0.1rem 0.3rem;
+		border-radius: 2px;
+		flex-shrink: 0;
+		font-family: var(--mono);
+	}
 
 	.status-add-tag {
 		background: none;

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -823,7 +823,7 @@
 			<button
 				class="pane-tab"
 				class:pane-tab-active={!starredOnly && !showTagsPanel}
-				onclick={() => { applyFilter(null, false); showTagsPanel = false; }}
+				onclick={() => { applyFilter(activeTagId, false); showTagsPanel = false; }}
 			>{tagsTabActive && !showTagsPanel ? 'Filtered' : 'All'}</button>
 			<button
 				class="pane-tab"

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -69,6 +69,7 @@
 	let newTagName = $state('');
 	let activeTagId = $state<number | null>(null);
 	let starredOnly = $state(false);
+	let showTagsPanel = $state(false);
 	// Note action menu
 	let showNoteMenu = $state(false);
 
@@ -120,6 +121,8 @@
 
 	// Only show tags that have at least one note (active or trashed); pure UI erasure
 	let visibleTags = $derived(allTags.filter(t => t.note_count > 0));
+	let starredNoteCount = $derived(notes.filter(n => n.starred).length);
+	let tagsTabActive = $derived(activeTagId !== null);
 
 	let selectedNote = $derived(notes.find((n) => n.id === selectedId) ?? null);
 
@@ -527,22 +530,13 @@
 		selectedId = dup.id;
 	}
 
-	let tagFilterEl = $state<HTMLDivElement | null>(null);
-	let tagFilterExpanded = $state(false);
-	let tagFilterScrollable = $state(false);
-
-	function onTagFilterMouseEnter() {
-		if (isMobile()) return;
-		tagFilterExpanded = true;
-	}
-	function onTagFilterMouseLeave() {
-		if (isMobile()) return;
-		tagFilterScrollable = false;
-		tagFilterExpanded = false;
-		if (tagFilterEl) tagFilterEl.scrollTop = 0;
-	}
-	function onTagFilterTransitionEnd() {
-		if (tagFilterExpanded) tagFilterScrollable = true;
+	function toggleTagsTab() {
+		if (tagsTabActive) {
+			activeTagId = null;
+			showTagsPanel = false;
+		} else {
+			showTagsPanel = !showTagsPanel;
+		}
 	}
 
 	async function applyFilter(tagId: number | null, starred: boolean) {
@@ -793,52 +787,46 @@
 			<Search size={13} />
 			<input
 				type="search"
-				placeholder="Search notes…"
+				placeholder="Search {notes.length} notes"
 				bind:this={searchInput}
 				bind:value={search}
 				oninput={handleSearch}
 			/>
+			<span class="search-shortcut" aria-hidden="true">⌘K</span>
 		</div>
 
-		<div class="filter-bar" role="group" aria-label="Filter notes">
-			<div class="filter-fixed">
-				<button
-					class="tag-pill"
-					class:tag-pill-active={activeTagId === null && !starredOnly}
-					onclick={() => applyFilter(null, false)}
-				>All</button>
-				<button
-					class="tag-pill tag-pill-star"
-					class:tag-pill-active={starredOnly}
-					onclick={toggleStarFilter}
-					title="Starred notes"
-				><Star size={11} /> Starred</button>
-			</div>
+		<div class="pane-switcher" role="group" aria-label="Filter notes">
+			<button
+				class="pane-tab"
+				class:pane-tab-active={activeTagId === null && !starredOnly}
+				onclick={() => { applyFilter(null, false); showTagsPanel = false; }}
+			>All<span class="tab-sep"> · </span><span class="tab-count">{notes.length}</span></button>
+			<button
+				class="pane-tab"
+				class:pane-tab-active={starredOnly}
+				onclick={() => { toggleStarFilter(); showTagsPanel = false; }}
+			>Starred<span class="tab-sep"> · </span><span class="tab-count">{starredNoteCount}</span></button>
 			{#if visibleTags.length > 0}
-				<div
-					class="filter-tags"
-					class:expanded={tagFilterExpanded}
-					class:scrollable={tagFilterScrollable}
-					bind:this={tagFilterEl}
-					role="group"
-					aria-label="Tag filters"
-					onmouseenter={onTagFilterMouseEnter}
-					onmouseleave={onTagFilterMouseLeave}
-					ontransitionend={onTagFilterTransitionEnd}
-				>
-					{#each visibleTags as tag (tag.id)}
-						{@const c = tagColor(tag)}
-						<button
-							class="tag-pill"
-							class:tag-pill-active={activeTagId === tag.id}
-							style="--tag-bg:{c.bg};--tag-text:{c.text}"
-							onclick={() => filterByTag(activeTagId === tag.id ? null : tag.id)}
-							title="{tag.name} ({tag.note_count})"
-						>{tag.name}</button>
-					{/each}
-				</div>
+				<button
+					class="pane-tab"
+					class:pane-tab-active={tagsTabActive || showTagsPanel}
+					onclick={toggleTagsTab}
+				>Tags<span class="tab-sep"> · </span><span class="tab-count">{visibleTags.length}</span></button>
 			{/if}
 		</div>
+		{#if showTagsPanel || tagsTabActive}
+			<div class="tag-panel" role="group" aria-label="Tag filters">
+				{#each visibleTags as tag (tag.id)}
+					{@const c = tagColor(tag)}
+					<button
+						class="tag-panel-item"
+						class:tag-panel-active={activeTagId === tag.id}
+						onclick={() => { filterByTag(activeTagId === tag.id ? null : tag.id); showTagsPanel = false; }}
+						title="{tag.name} ({tag.note_count})"
+					><span class="tag-dot" style="background:{c.text}"></span>{tag.name}</button>
+				{/each}
+			</div>
+		{/if}
 
 		<ul class="note-list" role="list">
 			{#each notes as note (note.id)}
@@ -1134,61 +1122,78 @@
 		color: var(--text);
 	}
 	.search-box input::placeholder { color: var(--text-4); }
+	.search-shortcut {
+		font-size: 0.625rem;
+		color: var(--text-4);
+		background: var(--bg-hover);
+		border: 1px solid var(--border);
+		padding: 0.1rem 0.3rem;
+		border-radius: 2px;
+		flex-shrink: 0;
+		font-family: var(--mono);
+	}
 
-	/* Filter bar */
-	.filter-bar {
+	/* Pane switcher */
+	.pane-switcher {
 		display: flex;
-		flex-direction: column;
+		align-items: center;
+		padding: 0 1.25rem;
 		border-bottom: 1px solid var(--border);
 		flex-shrink: 0;
 	}
-	.filter-fixed {
-		display: flex;
-		gap: 0.25rem;
-		padding: 0.5rem 1.25rem 0.375rem;
-		flex-wrap: wrap;
+	.pane-tab {
+		font-family: var(--sans);
+		font-size: 0.6875rem;
+		font-weight: 500;
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+		color: var(--text-4);
+		background: none;
+		border: none;
+		border-bottom: 2px solid transparent;
+		padding: 0.6rem 0;
+		margin-right: 1.25rem;
+		cursor: pointer;
+		display: inline-flex;
+		align-items: center;
 	}
-	.filter-tags {
-		display: flex;
-		flex-wrap: nowrap;
-		gap: 0.25rem;
-		padding: 0 1.25rem 0.5rem;
-		overflow: hidden;
-		max-height: 1.875rem;
-		transition: max-height 0.2s ease;
-	}
-	.filter-tags.expanded { max-height: 10rem; flex-wrap: wrap; }
-	.filter-tags.scrollable { overflow-y: auto; }
+	.pane-tab:last-child { margin-right: 0; }
+	.pane-tab:hover { color: var(--text-2); }
+	.pane-tab-active { color: var(--text) !important; border-bottom-color: var(--accent); }
+	.tab-sep { color: var(--text-4); font-weight: 400; letter-spacing: 0; }
+	.tab-count { font-size: 0.625rem; color: var(--text-4); font-weight: 400; letter-spacing: 0; }
+	.pane-tab-active .tab-count { color: var(--text-3); }
 
-	.tag-pill {
+	/* Tag panel (shown when Tags tab is active) */
+	.tag-panel {
+		padding: 0.375rem 1.25rem 0.5rem;
+		border-bottom: 1px solid var(--border);
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.25rem;
+		flex-shrink: 0;
+	}
+	.tag-panel-item {
 		display: inline-flex;
 		align-items: center;
 		gap: 0.3rem;
 		font-family: var(--sans);
 		font-size: 0.6875rem;
-		font-weight: 500;
-		padding: 0.2rem 0.6rem;
-		border: 1px solid var(--border-md);
-		background: var(--tag-bg, var(--bg-hover));
-		color: var(--tag-text, var(--text-3));
+		color: var(--text-3);
+		background: var(--bg-hover);
+		border: 1px solid var(--border);
+		padding: 0.2rem 0.5rem;
 		cursor: pointer;
-		white-space: nowrap;
+	}
+	.tag-panel-item:hover { color: var(--text); background: var(--bg-alt); }
+	.tag-panel-active { color: var(--text) !important; background: var(--bg-alt) !important; border-color: var(--border-md) !important; }
+	.tag-dot {
+		display: inline-block;
+		width: 6px;
+		height: 6px;
+		border-radius: 50%;
 		flex-shrink: 0;
 	}
-	.tag-pill:hover { opacity: 0.8; }
-	.tag-pill-active {
-		background: var(--tag-text, var(--accent)) !important;
-		color: white !important;
-		border-color: transparent !important;
-	}
-	.tag-pill:not([style]).tag-pill-active {
-		background: var(--accent) !important;
-		color: white !important;
-	}
-	.tag-pill-star { --tag-bg: #fef9c3; --tag-text: #854d0e; }
-	.tag-pill-star.tag-pill-active { background: #854d0e !important; color: white !important; }
-	:global([data-theme="dark"]) .tag-pill-star { --tag-bg: #451a03; --tag-text: #fde68a; }
-	:global([data-theme="dark"]) .tag-pill-star.tag-pill-active { background: #fde68a !important; color: #451a03 !important; }
 
 
 

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -823,7 +823,7 @@
 			<button
 				class="pane-tab"
 				class:pane-tab-active={!starredOnly && !showTagsPanel}
-				onclick={() => { applyFilter(activeTagId, false); showTagsPanel = false; }}
+				onclick={() => { applyFilter(starredOnly ? activeTagId : null, false); showTagsPanel = false; }}
 			>{tagsTabActive && !showTagsPanel ? 'Filtered' : 'All'}</button>
 			<button
 				class="pane-tab"
@@ -847,7 +847,7 @@
 					<span class="filter-capsule">
 						<span class="filter-capsule-dot" style="background:{c.text}"></span>
 						<span class="filter-capsule-name">{activeTag.name}</span>
-						<button class="filter-capsule-clear" onclick={() => { applyFilter(null, false); }} aria-label="Clear filter">×</button>
+						<button class="filter-capsule-clear" onclick={() => { applyFilter(null, starredOnly); }} aria-label="Clear filter">×</button>
 					</span>
 				</div>
 			{/if}

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -69,6 +69,7 @@
 	let noteTags = $state<Tag[]>([]);
 	let showTagPopover = $state(false);
 	let newTagName = $state('');
+	let panelNewTagName = $state('');
 	let activeTagId = $state<number | null>(null);
 	let starredOnly = $state(false);
 	let showTagsPanel = $state(false);
@@ -580,6 +581,21 @@
 		allTags = await api.tags.list();
 	}
 
+	async function createTagFromPanel() {
+		const name = panelNewTagName.trim();
+		if (!name) return;
+		panelNewTagName = '';
+		let tag = allTags.find(t => t.name.toLowerCase() === name.toLowerCase());
+		if (!tag) {
+			tag = await api.tags.create(name);
+		}
+		if (selectedId && !noteTags.find(t => t.id === tag!.id)) {
+			await api.tags.addToNote(selectedId, tag!.id);
+			noteTags = [...noteTags, tag!];
+		}
+		allTags = await api.tags.list();
+	}
+
 	async function createAndAddTag() {
 		if (!selectedId || !newTagName.trim()) return;
 		const name = newTagName.trim();
@@ -805,37 +821,66 @@
 		<div class="pane-switcher" role="group" aria-label="Filter notes">
 			<button
 				class="pane-tab"
-				class:pane-tab-active={activeTagId === null && !starredOnly}
+				class:pane-tab-active={!starredOnly && !showTagsPanel}
 				onclick={() => { applyFilter(null, false); showTagsPanel = false; }}
-			>All<span class="tab-sep"> · </span><span class="tab-count">{notes.length}</span></button>
+			>{tagsTabActive && !showTagsPanel ? 'Filtered' : 'All'}</button>
 			<button
 				class="pane-tab"
 				class:pane-tab-active={starredOnly}
 				onclick={() => { toggleStarFilter(); showTagsPanel = false; }}
-			>Starred<span class="tab-sep"> · </span><span class="tab-count">{starredNoteCount}</span></button>
+			>Starred</button>
 			{#if visibleTags.length > 0}
 				<button
 					class="pane-tab"
-					class:pane-tab-active={tagsTabActive || showTagsPanel}
+					class:pane-tab-active={showTagsPanel}
 					onclick={toggleTagsTab}
-				>Tags<span class="tab-sep"> · </span><span class="tab-count">{visibleTags.length}</span></button>
+				>Tags</button>
 			{/if}
 		</div>
+
+		{#if tagsTabActive && !showTagsPanel}
+			{@const activeTag = allTags.find(t => t.id === activeTagId)}
+			{#if activeTag}
+				{@const c = tagColor(activeTag)}
+				<div class="filter-capsule-row">
+					<span class="filter-capsule">
+						<span class="filter-capsule-dot" style="background:{c.text}"></span>
+						<span class="filter-capsule-name">{activeTag.name}</span>
+						<button class="filter-capsule-clear" onclick={() => { applyFilter(null, false); }} aria-label="Clear filter">×</button>
+					</span>
+				</div>
+			{/if}
+		{/if}
+
 		{#if showTagsPanel}
 			<div class="tag-panel" role="group" aria-label="Tag filters">
+				<p class="tag-panel-header">Filter by tag</p>
 				{#each visibleTags as tag (tag.id)}
 					{@const c = tagColor(tag)}
 					<button
 						class="tag-panel-item"
 						class:tag-panel-active={activeTagId === tag.id}
-						onclick={() => { filterByTag(activeTagId === tag.id ? null : tag.id); showTagsPanel = false; }}
-						title="{tag.name} ({tag.note_count})"
-					><span class="tag-dot" style="background:{c.text}"></span>{tag.name}</button>
+						onclick={() => { applyFilter(tag.id, false); showTagsPanel = false; }}
+					>
+						<span class="tag-dot" style="background:{c.text}"></span>
+						<span class="tag-panel-name">{tag.name}</span>
+						<span class="tag-panel-count">{tag.note_count}</span>
+					</button>
 				{/each}
+				<div class="tag-panel-new-row">
+					<span class="tag-panel-new-plus" aria-hidden="true">+</span>
+					<input
+						class="tag-panel-new-input"
+						type="text"
+						placeholder="New tag…"
+						bind:value={panelNewTagName}
+						onkeydown={(e) => e.key === 'Enter' && createTagFromPanel()}
+					/>
+				</div>
 			</div>
 		{:else}
 
-		<ul class="note-list" role="list">
+		<ul class="note-list" role="list" class:note-list-filtered={tagsTabActive}>
 			{#each notes as note (note.id)}
 				<li class="note-item" class:selected={note.id === selectedId}>
 					<div class="note-btn" role="button" tabindex="0" onclick={() => selectNote(note.id)} onkeydown={(e) => (e.key === 'Enter' || e.key === ' ') && selectNote(note.id)}>
@@ -1172,33 +1217,108 @@
 	.pane-tab:last-child { margin-right: 0; }
 	.pane-tab:hover { color: var(--text-2); }
 	.pane-tab-active { color: var(--text) !important; border-bottom-color: var(--accent); }
-	.tab-sep { color: var(--text-4); font-weight: 400; letter-spacing: 0; }
-	.tab-count { font-size: 0.625rem; color: var(--text-4); font-weight: 400; letter-spacing: 0; }
-	.pane-tab-active .tab-count { color: var(--text-3); }
+
+	/* Filter capsule (shown below tabs when tag filter is active) */
+	.filter-capsule-row {
+		padding: 0.5rem 1.25rem;
+		flex-shrink: 0;
+	}
+	.filter-capsule {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.375rem;
+		font-family: var(--sans);
+		font-size: 0.6875rem;
+		font-weight: 500;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+		color: var(--text-2);
+		background: var(--bg-hover);
+		border: 1px solid var(--border-md);
+		padding: 0.2rem 0.375rem 0.2rem 0.5rem;
+	}
+	.filter-capsule-dot {
+		width: 6px;
+		height: 6px;
+		border-radius: 50%;
+		flex-shrink: 0;
+	}
+	.filter-capsule-clear {
+		background: none;
+		border: none;
+		cursor: pointer;
+		color: var(--text-4);
+		font-size: 1rem;
+		line-height: 1;
+		padding: 0 0.1rem;
+		display: flex;
+		align-items: center;
+	}
+	.filter-capsule-clear:hover { color: var(--text-2); }
 
 	/* Tag panel (shown when Tags tab is active) */
 	.tag-panel {
-		padding: 0.375rem 1.25rem 0.5rem;
-		border-bottom: 1px solid var(--border);
+		flex: 1;
+		min-height: 0;
+		overflow-y: auto;
 		display: flex;
-		flex-wrap: wrap;
-		gap: 0.25rem;
-		flex-shrink: 0;
+		flex-direction: column;
+	}
+	.tag-panel-header {
+		font-family: var(--sans);
+		font-size: 0.625rem;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+		color: var(--text-4);
+		padding: 0.75rem 1.25rem 0.375rem;
+		margin: 0;
 	}
 	.tag-panel-item {
-		display: inline-flex;
+		display: flex;
 		align-items: center;
-		gap: 0.3rem;
+		gap: 0.5rem;
+		width: 100%;
+		padding: 0.4rem 1.25rem;
 		font-family: var(--sans);
-		font-size: 0.6875rem;
-		color: var(--text-3);
-		background: var(--bg-hover);
-		border: 1px solid var(--border);
-		padding: 0.2rem 0.5rem;
+		font-size: 0.875rem;
+		color: var(--text-2);
+		background: none;
+		border: none;
 		cursor: pointer;
+		text-align: left;
 	}
-	.tag-panel-item:hover { color: var(--text); background: var(--bg-alt); }
-	.tag-panel-active { color: var(--text) !important; background: var(--bg-alt) !important; border-color: var(--border-md) !important; }
+	.tag-panel-item:hover { background: var(--bg-hover); }
+	.tag-panel-active { color: var(--text) !important; background: var(--bg-alt) !important; }
+	.tag-panel-name { flex: 1; min-width: 0; }
+	.tag-panel-count {
+		font-size: 0.75rem;
+		color: var(--text-4);
+		font-family: var(--mono);
+		flex-shrink: 0;
+	}
+	.tag-panel-new-row {
+		display: flex;
+		align-items: center;
+		gap: 0.375rem;
+		padding: 0.4rem 1.25rem 0.75rem;
+		color: var(--text-4);
+	}
+	.tag-panel-new-plus {
+		font-size: 0.875rem;
+		line-height: 1;
+	}
+	.tag-panel-new-input {
+		font-family: var(--sans);
+		font-size: 0.875rem;
+		color: var(--text-2);
+		background: none;
+		border: none;
+		outline: none;
+		flex: 1;
+		padding: 0;
+	}
+	.tag-panel-new-input::placeholder { color: var(--text-4); }
 	.tag-dot {
 		display: inline-block;
 		width: 6px;
@@ -1222,6 +1342,7 @@
 		scrollbar-width: thin;
 		scrollbar-color: transparent transparent;
 	}
+	.note-list-filtered { padding-top: 0; }
 	.note-list::-webkit-scrollbar { width: 5px; }
 	.note-list::-webkit-scrollbar-thumb { background: transparent; }
 	.note-list::-webkit-scrollbar-track { background: transparent; }

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -542,6 +542,7 @@
 			activeTagId = null;
 			showTagsPanel = false;
 		} else {
+			starredOnly = false;
 			showTagsPanel = !showTagsPanel;
 		}
 	}

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -586,6 +586,7 @@
 			noteTags = [...noteTags, tag];
 		}
 		newTagName = '';
+		showTagPopover = false;
 		allTags = await api.tags.list();
 	}
 

--- a/frontend/src/routes/page.test.ts
+++ b/frontend/src/routes/page.test.ts
@@ -354,7 +354,7 @@ describe('Tag popover', () => {
 	});
 });
 
-describe('Tag filter hover', () => {
+describe('Pane switcher', () => {
 	const mockTags = [
 		{ id: 1, name: 'Alpha', note_count: 1 },
 		{ id: 2, name: 'Beta',  note_count: 1 },
@@ -364,38 +364,39 @@ describe('Tag filter hover', () => {
 		vi.mocked(api.tags.list).mockResolvedValue(mockTags);
 	});
 
-	it('adds expanded class on mouseenter on desktop', async () => {
-		mockViewport(false); // desktop
+	it('shows All, Starred and Tags tabs', async () => {
 		render(Page);
-		await waitFor(() => screen.getByText('Alpha'));
-
-		const filterTags = screen.getByRole('group', { name: /tag filters/i });
-		await fireEvent.mouseEnter(filterTags);
-
-		expect(filterTags).toHaveClass('expanded');
+		await waitFor(() => {
+			expect(screen.getByRole('button', { name: /^all/i })).toBeInTheDocument();
+			expect(screen.getByRole('button', { name: /^starred/i })).toBeInTheDocument();
+			expect(screen.getByRole('button', { name: /^tags/i })).toBeInTheDocument();
+		});
 	});
 
-	it('does NOT add expanded class on mouseenter on mobile', async () => {
-		mockViewport(true); // mobile
+	it('clicking the Tags tab reveals the tag panel', async () => {
 		render(Page);
-		await waitFor(() => screen.getByText('Alpha'));
+		await waitFor(() => screen.getByRole('button', { name: /^tags/i }));
 
-		const filterTags = screen.getByRole('group', { name: /tag filters/i });
-		await fireEvent.mouseEnter(filterTags);
+		await fireEvent.click(screen.getByRole('button', { name: /^tags/i }));
 
-		expect(filterTags).not.toHaveClass('expanded');
+		await waitFor(() =>
+			expect(screen.getByRole('group', { name: /tag filters/i })).toBeInTheDocument()
+		);
+		expect(screen.getByRole('button', { name: /alpha/i })).toBeInTheDocument();
 	});
 
-	it('removes expanded class on mouseleave on desktop', async () => {
-		mockViewport(false); // desktop
+	it('clicking All tab hides the tag panel', async () => {
 		render(Page);
-		await waitFor(() => screen.getByText('Alpha'));
+		await waitFor(() => screen.getByRole('button', { name: /^tags/i }));
 
-		const filterTags = screen.getByRole('group', { name: /tag filters/i });
-		await fireEvent.mouseEnter(filterTags);
-		await fireEvent.mouseLeave(filterTags);
+		await fireEvent.click(screen.getByRole('button', { name: /^tags/i }));
+		await waitFor(() => screen.getByRole('group', { name: /tag filters/i }));
 
-		expect(filterTags).not.toHaveClass('expanded');
+		await fireEvent.click(screen.getByRole('button', { name: /^all/i }));
+
+		await waitFor(() =>
+			expect(screen.queryByRole('group', { name: /tag filters/i })).not.toBeInTheDocument()
+		);
 	});
 });
 

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -62,7 +62,6 @@
 		}
 	}
 
-	let themeLabel = $derived(theme.current === 'light' ? 'Enable dark mode' : 'Enable light mode');
 </script>
 
 <svelte:head>
@@ -156,7 +155,17 @@
 				<p>How Crapnote looks on this device.</p>
 			</div>
 			<div class="section-body">
-				<button class="btn-default" onclick={() => theme.toggle()}>{themeLabel}</button>
+				<label class="theme-toggle-row">
+					<input
+						type="checkbox"
+						role="switch"
+						aria-label="Dark mode"
+						checked={theme.current === 'dark'}
+						onchange={() => theme.toggle()}
+					/>
+					<span class="toggle-track" aria-hidden="true"><span class="toggle-thumb"></span></span>
+					<span class="toggle-text">Dark mode</span>
+				</label>
 			</div>
 		</section>
 
@@ -341,6 +350,38 @@
 	.btn-chevron .chevron { color: var(--text-3); }
 
 	.export-row { display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap; margin-bottom: 0.5rem; }
+
+	/* Dark mode toggle switch */
+	.theme-toggle-row {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.625rem;
+		cursor: pointer;
+		user-select: none;
+	}
+	.theme-toggle-row input[type="checkbox"] { position: absolute; opacity: 0; width: 0; height: 0; }
+	.toggle-track {
+		position: relative;
+		width: 2.25rem;
+		height: 1.25rem;
+		border-radius: 9999px;
+		background: var(--border-md);
+		flex-shrink: 0;
+		transition: background 0.15s;
+	}
+	.theme-toggle-row input:checked ~ .toggle-track { background: var(--accent); }
+	.toggle-thumb {
+		position: absolute;
+		top: 0.1875rem;
+		left: 0.1875rem;
+		width: 0.875rem;
+		height: 0.875rem;
+		border-radius: 50%;
+		background: white;
+		transition: transform 0.15s;
+	}
+	.theme-toggle-row input:checked ~ .toggle-track .toggle-thumb { transform: translateX(1rem); }
+	.toggle-text { font-size: 0.875rem; color: var(--text); font-family: var(--sans); }
 
 	.hint { font-size: 0.8125rem; color: var(--text-3); margin: 0; line-height: 1.5; }
 	.hint code { font-family: var(--mono); font-size: 0.75rem; background: var(--bg-hover); padding: 1px 5px; color: var(--text-2); }

--- a/frontend/src/routes/settings/page.test.ts
+++ b/frontend/src/routes/settings/page.test.ts
@@ -51,28 +51,28 @@ describe('Settings — Appearance', () => {
 		expect(screen.getByRole('heading', { name: /appearance/i })).toBeInTheDocument();
 	});
 
-	it('shows a theme toggle button', () => {
+	it('shows a Dark mode toggle switch', () => {
 		render(SettingsPage);
-		expect(screen.getByRole('button', { name: /dark mode|light mode/i })).toBeInTheDocument();
+		expect(screen.getByRole('switch', { name: /dark mode/i })).toBeInTheDocument();
 	});
 
-	it('labels the button "Enable dark mode" when theme is light', () => {
+	it('toggle is unchecked when theme is light', () => {
 		mockTheme.current = 'light';
 		render(SettingsPage);
-		expect(screen.getByRole('button', { name: /enable dark mode/i })).toBeInTheDocument();
+		expect(screen.getByRole('switch', { name: /dark mode/i })).not.toBeChecked();
 	});
 
-	it('labels the button "Enable light mode" when theme is dark', () => {
+	it('toggle is checked when theme is dark', () => {
 		mockTheme.current = 'dark';
 		render(SettingsPage);
-		expect(screen.getByRole('button', { name: /enable light mode/i })).toBeInTheDocument();
+		expect(screen.getByRole('switch', { name: /dark mode/i })).toBeChecked();
 	});
 
-	it('calls theme.toggle() when the button is clicked', async () => {
+	it('calls theme.toggle() when the switch is clicked', async () => {
 		mockTheme.current = 'light';
 		mockTheme.toggle = vi.fn();
 		render(SettingsPage);
-		await fireEvent.click(screen.getByRole('button', { name: /enable dark mode/i }));
+		await fireEvent.click(screen.getByRole('switch', { name: /dark mode/i }));
 		expect(mockTheme.toggle).toHaveBeenCalledOnce();
 	});
 });


### PR DESCRIPTION
## Summary
Refactored the tag filtering interface from an inline hover-expandable filter bar to a dedicated "Tags" pane tab with a full-featured tag panel. Added keyboard shortcut support (Ctrl+. / Cmd+.) to toggle the tag popover, and improved the overall tag interaction model.

## Key Changes

- **New pane-based tag filtering**: Replaced the hover-expandable `.filter-tags` component with a dedicated "Tags" tab in the pane switcher that reveals a full `.tag-panel` with all available tags
- **Tag panel features**: 
  - Displays all tags with note counts
  - Includes inline "New tag" input field for quick tag creation
  - Shows active tag selection state
  - Closes automatically when a tag is selected
- **Filter capsule display**: When a tag filter is active, shows a visual capsule below the pane tabs indicating the active filter with a clear button
- **Keyboard shortcut**: Added `open-tags` shortcut (Ctrl+. on Windows/Linux, Cmd+. on Mac) to toggle the tag popover in the editor
- **Platform-aware modifier key labels**: Added `modKey` constant to display ⌘ on Mac and Ctrl+ on other platforms in UI hints
- **Improved tag chip styling**: Refactored `.note-tag-chip` from a pill-style button to a typographic link with dot + word, matching the new design language
- **Settings theme toggle**: Replaced button-based theme toggle with a proper checkbox switch component with animated track and thumb
- **Updated tests**: Refactored E2E and unit tests to work with the new pane-based UI structure

## Implementation Details

- The tag panel is conditionally rendered when `showTagsPanel` is true
- Tag filtering now uses `tagsTabActive` derived state to determine if a tag filter is currently applied
- The `toggleTagsTab()` function manages the relationship between tag selection and panel visibility
- New `createTagFromPanel()` function allows tag creation directly from the panel's input field
- Search box now displays dynamic placeholder showing note count and includes a keyboard shortcut hint
- All tag-related styling updated to use the new `.tag-panel-*` and `.filter-capsule-*` class names

https://claude.ai/code/session_01G2iiBFAPZgu2Cebcy7VCMz