### PR TITLE
Redesign UI with improved navigation and editor focus management

### DIFF
--- a/frontend/src/__mocks__/lucide-svelte.ts
+++ b/frontend/src/__mocks__/lucide-svelte.ts
@@ -30,6 +30,7 @@ export {
 	noop as Link,
 	noop as List,
 	noop as ListOrdered,
+	noop as ListTodo,
 	noop as Lock,
 	noop as LockOpen,
 	noop as LogIn,

--- a/frontend/src/lib/components/Editor.svelte
+++ b/frontend/src/lib/components/Editor.svelte
@@ -107,29 +107,23 @@
 	/* Task list items */
 	.editor-container :global(.ProseMirror li[data-item-type="task"]) {
 		list-style: none;
-		position: relative;
+		display: flex;
+		align-items: flex-start;
+		gap: 0.4em;
 	}
-	.editor-container :global(.ProseMirror li[data-item-type="task"]::before) {
-		content: '';
-		position: absolute;
-		left: -1.25em;
-		top: 0.2em;
+	.editor-container :global(.ProseMirror li[data-item-type="task"] .task-checkbox) {
+		flex-shrink: 0;
+		margin-top: 0.25em;
 		width: 0.875em;
 		height: 0.875em;
-		border: 1.5px solid #9ca3af;
-		border-radius: 2px;
-		box-sizing: border-box;
-		background-color: transparent;
+		accent-color: var(--accent);
+		cursor: pointer;
 	}
-	.editor-container :global(.ProseMirror li[data-item-type="task"][data-checked="true"]::before) {
-		background-color: var(--accent);
-		border-color: var(--accent);
-		background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 8'%3E%3Cpath d='M1 4l3 3 5-5' stroke='white' stroke-width='1.5' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
-		background-size: 75%;
-		background-position: center;
-		background-repeat: no-repeat;
+	.editor-container :global(.ProseMirror li[data-item-type="task"] .task-content) {
+		flex: 1;
+		min-width: 0;
 	}
-	.editor-container :global(.ProseMirror li[data-item-type="task"][data-checked="true"] p) {
+	.editor-container :global(.ProseMirror li[data-item-type="task"][data-checked="true"] .task-content p) {
 		opacity: 0.5;
 		text-decoration: line-through;
 	}

--- a/frontend/src/lib/components/Editor.svelte
+++ b/frontend/src/lib/components/Editor.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
 	import { onMount, onDestroy } from 'svelte';
-	import { Editor, rootCtx, defaultValueCtx, commandsCtx, type CmdKey } from '@milkdown/kit/core';
+	import { Editor, rootCtx, defaultValueCtx, commandsCtx, editorViewCtx, type CmdKey } from '@milkdown/kit/core';
 	import {
 		commonmark,
 	} from '@milkdown/kit/preset/commonmark';
 	import { gfm } from '@milkdown/kit/preset/gfm';
 	import { history } from '@milkdown/kit/plugin/history';
 	import { listener, listenerCtx } from '@milkdown/kit/plugin/listener';
+	import { TextSelection } from '@milkdown/kit/prose/state';
 	import { underlinePlugin } from '$lib/milkdown/underline';
 	import { imagePlugin } from '$lib/milkdown/image';
 	import { linkPlugin } from '$lib/milkdown/link';
@@ -14,6 +15,8 @@
 
 	export interface EditorRef {
 		call: (key: string | CmdKey<unknown>, payload?: unknown) => void;
+		focusEnd: () => void;
+		blur: () => void;
 	}
 
 	interface Props {
@@ -49,9 +52,33 @@
 
 		container.addEventListener('crapnote:insert-link', () => oninsertlink?.());
 
+		// Click in empty space below content → place cursor at end
+		container.addEventListener('click', (e) => {
+			if (!_editor) return;
+			if (!(e.target as Element).closest('.ProseMirror')) {
+				_editor.action((ctx) => {
+					const view = ctx.get(editorViewCtx);
+					view.dispatch(view.state.tr.setSelection(TextSelection.atEnd(view.state.doc)));
+					view.focus();
+				});
+			}
+		});
+
 		ref = {
 			call: (key, payload) => {
 				_editor?.action((ctx) => ctx.get(commandsCtx).call(key, payload));
+			},
+			focusEnd: () => {
+				_editor?.action((ctx) => {
+					const view = ctx.get(editorViewCtx);
+					view.dispatch(view.state.tr.setSelection(TextSelection.atEnd(view.state.doc)));
+					view.focus();
+				});
+			},
+			blur: () => {
+				_editor?.action((ctx) => {
+					ctx.get(editorViewCtx).dom.blur();
+				});
 			},
 		};
 	});
@@ -71,10 +98,12 @@
 		overflow-y: auto;
 		padding: 1rem 2rem;
 		min-height: 0;
+		cursor: text;
 	}
 
 	.editor-container :global(.milkdown) {
 		max-width: 720px;
+		min-height: 100%;
 	}
 
 	.editor-container :global(.ProseMirror) {
@@ -104,12 +133,13 @@
 		line-height: 1.5;
 	}
 
-	/* Task list items */
+	/* Task list items — checkbox aligned with the bullet of a regular <li> */
 	.editor-container :global(.ProseMirror li[data-item-type="task"]) {
 		list-style: none;
 		display: flex;
 		align-items: flex-start;
-		gap: 0.4em;
+		gap: 0.625em;
+		margin-left: -1.5em; /* pull into <ul> padding so checkbox sits where the bullet would */
 	}
 	.editor-container :global(.ProseMirror li[data-item-type="task"] .task-checkbox) {
 		flex-shrink: 0;

--- a/frontend/src/lib/components/Editor.svelte
+++ b/frontend/src/lib/components/Editor.svelte
@@ -133,15 +133,18 @@
 		line-height: 1.5;
 	}
 
-	/* Task list items — checkbox vertically centred with text, at content edge */
+	/* Task list items — text aligned with regular list item text, checkbox in margin */
 	.editor-container :global(.ProseMirror li[data-item-type="task"]) {
 		list-style: none;
 		display: flex;
 		align-items: center;
-		gap: 0.5em;
+		gap: 0.375em;
+		margin-left: -1.25em; /* pull into ul padding so text aligns with regular <li> text */
 	}
 	.editor-container :global(.ProseMirror li[data-item-type="task"] .task-checkbox) {
 		flex-shrink: 0;
+		width: 0.875em;
+		height: 0.875em;
 		accent-color: var(--accent);
 		cursor: pointer;
 	}

--- a/frontend/src/lib/components/Editor.svelte
+++ b/frontend/src/lib/components/Editor.svelte
@@ -104,6 +104,36 @@
 		line-height: 1.5;
 	}
 
+	/* Task list items */
+	.editor-container :global(.ProseMirror li[data-item-type="task"]) {
+		list-style: none;
+		position: relative;
+	}
+	.editor-container :global(.ProseMirror li[data-item-type="task"]::before) {
+		content: '';
+		position: absolute;
+		left: -1.25em;
+		top: 0.2em;
+		width: 0.875em;
+		height: 0.875em;
+		border: 1.5px solid #9ca3af;
+		border-radius: 2px;
+		box-sizing: border-box;
+		background-color: transparent;
+	}
+	.editor-container :global(.ProseMirror li[data-item-type="task"][data-checked="true"]::before) {
+		background-color: var(--accent);
+		border-color: var(--accent);
+		background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 8'%3E%3Cpath d='M1 4l3 3 5-5' stroke='white' stroke-width='1.5' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+		background-size: 75%;
+		background-position: center;
+		background-repeat: no-repeat;
+	}
+	.editor-container :global(.ProseMirror li[data-item-type="task"][data-checked="true"] p) {
+		opacity: 0.5;
+		text-decoration: line-through;
+	}
+
 	.editor-container :global(.ProseMirror blockquote) {
 		margin: 0.4em 0;
 		padding-left: 1em;

--- a/frontend/src/lib/components/Editor.svelte
+++ b/frontend/src/lib/components/Editor.svelte
@@ -133,19 +133,15 @@
 		line-height: 1.5;
 	}
 
-	/* Task list items — checkbox aligned with the bullet of a regular <li> */
+	/* Task list items — checkbox vertically centred with text, at content edge */
 	.editor-container :global(.ProseMirror li[data-item-type="task"]) {
 		list-style: none;
 		display: flex;
-		align-items: flex-start;
-		gap: 0.625em;
-		margin-left: -1.5em; /* pull into <ul> padding so checkbox sits where the bullet would */
+		align-items: center;
+		gap: 0.5em;
 	}
 	.editor-container :global(.ProseMirror li[data-item-type="task"] .task-checkbox) {
 		flex-shrink: 0;
-		margin-top: 0.25em;
-		width: 0.875em;
-		height: 0.875em;
 		accent-color: var(--accent);
 		cursor: pointer;
 	}

--- a/frontend/src/lib/components/Editor.svelte
+++ b/frontend/src/lib/components/Editor.svelte
@@ -4,11 +4,13 @@
 	import {
 		commonmark,
 	} from '@milkdown/kit/preset/commonmark';
+	import { gfm } from '@milkdown/kit/preset/gfm';
 	import { history } from '@milkdown/kit/plugin/history';
 	import { listener, listenerCtx } from '@milkdown/kit/plugin/listener';
 	import { underlinePlugin } from '$lib/milkdown/underline';
 	import { imagePlugin } from '$lib/milkdown/image';
 	import { linkPlugin } from '$lib/milkdown/link';
+	import { taskListPlugin } from '$lib/milkdown/tasklist';
 
 	export interface EditorRef {
 		call: (key: string | CmdKey<unknown>, payload?: unknown) => void;
@@ -36,6 +38,8 @@
 				});
 			})
 			.use(commonmark)
+			.use(gfm)
+			.use(taskListPlugin as Parameters<typeof Editor.prototype.use>[0])
 			.use(underlinePlugin as Parameters<typeof Editor.prototype.use>[0])
 			.use(imagePlugin as Parameters<typeof Editor.prototype.use>[0])
 			.use(linkPlugin as Parameters<typeof Editor.prototype.use>[0])

--- a/frontend/src/lib/milkdown/tasklist.ts
+++ b/frontend/src/lib/milkdown/tasklist.ts
@@ -1,0 +1,51 @@
+import { $command } from '@milkdown/kit/utils';
+import { wrapIn } from '@milkdown/kit/prose/commands';
+import { bulletListSchema } from '@milkdown/kit/preset/commonmark';
+import { extendListItemSchemaForTask } from '@milkdown/kit/preset/gfm';
+import type { Transaction } from '@milkdown/kit/prose/state';
+
+export const wrapInTaskListCommand = $command('WrapInTaskList', (ctx) => () => {
+	return (state, dispatch) => {
+		const bulletListType = bulletListSchema.type(ctx);
+		const listItemType = extendListItemSchemaForTask.type(ctx);
+
+		// If already in a regular list item, convert it to a task item
+		const { $from } = state.selection;
+		for (let d = $from.depth; d > 0; d--) {
+			const node = $from.node(d);
+			if (node.type === listItemType) {
+				if (node.attrs.checked != null) return false; // already a task item
+				if (dispatch) {
+					const pos = $from.before(d);
+					dispatch(state.tr.setNodeMarkup(pos, null, { ...node.attrs, checked: false }));
+				}
+				return true;
+			}
+		}
+
+		// Not in a list — wrap in bullet list, then mark new items as task items
+		if (!wrapIn(bulletListType)(state)) return false;
+
+		if (dispatch) {
+			let innerTr: Transaction | null = null;
+			wrapIn(bulletListType)(state, (tr) => { innerTr = tr; });
+			if (!innerTr) return false;
+
+			// Walk up from the post-wrap selection to find and mark the new list item
+			const $newFrom = innerTr.selection.$from;
+			for (let d = $newFrom.depth; d > 0; d--) {
+				const node = $newFrom.node(d);
+				if (node.type === listItemType && node.attrs.checked == null) {
+					const pos = $newFrom.before(d);
+					innerTr.setNodeMarkup(pos, null, { ...node.attrs, checked: false });
+					break;
+				}
+			}
+
+			dispatch(innerTr);
+		}
+		return true;
+	};
+});
+
+export const taskListPlugin = [wrapInTaskListCommand];

--- a/frontend/src/lib/milkdown/tasklist.ts
+++ b/frontend/src/lib/milkdown/tasklist.ts
@@ -29,7 +29,8 @@ export const wrapInTaskListCommand = $command('WrapInTaskList', (ctx) => () => {
 		if (!wrapIn(bulletListType)(state)) return false;
 
 		if (dispatch) {
-			let innerTr: Transaction | null = null;
+			// Use definite-assignment assertion — TypeScript loses narrowing through the callback
+			let innerTr!: Transaction;
 			wrapIn(bulletListType)(state, (tr) => { innerTr = tr; });
 			if (!innerTr) return false;
 

--- a/frontend/src/lib/milkdown/tasklist.ts
+++ b/frontend/src/lib/milkdown/tasklist.ts
@@ -1,7 +1,9 @@
-import { $command } from '@milkdown/kit/utils';
+import { $command, $view } from '@milkdown/kit/utils';
 import { wrapIn } from '@milkdown/kit/prose/commands';
 import { bulletListSchema } from '@milkdown/kit/preset/commonmark';
 import { extendListItemSchemaForTask } from '@milkdown/kit/preset/gfm';
+import type { Node as ProseMirrorNode } from '@milkdown/kit/prose/model';
+import type { EditorView } from '@milkdown/kit/prose/view';
 import type { Transaction } from '@milkdown/kit/prose/state';
 
 export const wrapInTaskListCommand = $command('WrapInTaskList', (ctx) => () => {
@@ -31,7 +33,6 @@ export const wrapInTaskListCommand = $command('WrapInTaskList', (ctx) => () => {
 			wrapIn(bulletListType)(state, (tr) => { innerTr = tr; });
 			if (!innerTr) return false;
 
-			// Walk up from the post-wrap selection to find and mark the new list item
 			const $newFrom = innerTr.selection.$from;
 			for (let d = $newFrom.depth; d > 0; d--) {
 				const node = $newFrom.node(d);
@@ -48,4 +49,67 @@ export const wrapInTaskListCommand = $command('WrapInTaskList', (ctx) => () => {
 	};
 });
 
-export const taskListPlugin = [wrapInTaskListCommand];
+export const taskListItemView = $view(
+	extendListItemSchemaForTask.node,
+	() =>
+		(
+			initialNode: ProseMirrorNode,
+			view: EditorView,
+			getPos: (() => number | undefined) | boolean,
+		) => {
+			const isTaskItem = initialNode.attrs.checked != null;
+			const dom = document.createElement('li');
+			const contentDOM = document.createElement('div');
+			contentDOM.className = 'task-content';
+
+			let checkbox: HTMLInputElement | null = null;
+
+			if (isTaskItem) {
+				dom.setAttribute('data-item-type', 'task');
+				dom.setAttribute('data-checked', String(initialNode.attrs.checked));
+
+				checkbox = document.createElement('input');
+				checkbox.type = 'checkbox';
+				checkbox.checked = initialNode.attrs.checked === true;
+				checkbox.className = 'task-checkbox';
+
+				checkbox.addEventListener('mousedown', (e) => {
+					e.preventDefault(); // keep ProseMirror focused
+				});
+				checkbox.addEventListener('click', () => {
+					const pos = typeof getPos === 'function' ? getPos() : undefined;
+					if (pos == null) return;
+					const node = view.state.doc.nodeAt(pos);
+					if (!node) return;
+					view.dispatch(
+						view.state.tr.setNodeMarkup(pos, null, {
+							...node.attrs,
+							checked: !node.attrs.checked,
+						}),
+					);
+				});
+
+				dom.appendChild(checkbox);
+			}
+
+			dom.appendChild(contentDOM);
+
+			return {
+				dom,
+				contentDOM,
+				update(updatedNode: ProseMirrorNode) {
+					if (updatedNode.type !== initialNode.type) return false;
+					// If task-ness changed, let ProseMirror recreate the NodeView
+					if ((updatedNode.attrs.checked != null) !== isTaskItem) return false;
+					if (isTaskItem && checkbox) {
+						checkbox.checked = updatedNode.attrs.checked === true;
+						dom.setAttribute('data-checked', String(updatedNode.attrs.checked));
+					}
+					return true;
+				},
+				destroy() {},
+			};
+		},
+);
+
+export const taskListPlugin = [wrapInTaskListCommand, taskListItemView];

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -8,14 +8,16 @@
 
 	let { children } = $props();
 
-	const PUBLIC_PATHS = ['/login'];
+	function isPublicPath(path: string): boolean {
+		return path === '/login' || path.startsWith('/setup/');
+	}
 
 	onMount(async () => {
 		registerSW();
 		theme.init();
 		await auth.init();
 		const currentPath = $page.url.pathname;
-		if (!auth.user && !PUBLIC_PATHS.includes(currentPath)) {
+		if (!auth.user && !isPublicPath(currentPath)) {
 			// Replace the current history entry so "back" doesn't return to the
 			// protected page after being redirected to login.
 			goto('/login', { replaceState: true });

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -77,9 +77,10 @@
 	let showTagsPanel = $state(false);
 	// Note action menu
 	let showNoteMenu = $state(false);
-	// Editor focus / toolbar visibility
+	// Editor focus state (used for Enter/Escape shortcuts)
 	let editorFocused = $state(false);
 	let showHeadingsMenu = $state(false);
+	let noteListEl = $state<HTMLUListElement | null>(null);
 
 	const PALETTE = [
 		// Reds / Pinks / Rose
@@ -373,28 +374,53 @@
 			void refreshSyncStatus();
 		};
 		const handleKeydown = (e: KeyboardEvent) => {
+			const target = e.target as Element;
+			const inInput = !!target.closest('input, textarea, [contenteditable]');
+
 			if (e.key === 'Escape') {
-				// Priority order: link dialog → editor focus → filter → tag popover
+				// Priority: link dialog → tag popover → editor blur → filter tabs
 				if (showLinkDialog) { showLinkDialog = false; return; }
-				if (showTagPopover) { showTagPopover = false; return; }
-				if (editorFocused) { editorRef?.blur(); return; }
-				if (starredOnly || activeTagId !== null) {
+				if (showTagPopover) { showTagPopover = false; (document.activeElement as HTMLElement)?.blur(); return; }
+				if (editorFocused) {
+					editorRef?.blur();
+					void tick().then(() => {
+						noteListEl?.querySelector<HTMLElement>('.note-item.selected .note-btn')?.focus();
+					});
+					return;
+				}
+				if (showTagsPanel || starredOnly || activeTagId !== null) {
+					showTagsPanel = false;
 					starredOnly = false;
 					activeTagId = null;
 					void loadNotes();
+					(document.activeElement as HTMLElement)?.blur();
 					return;
 				}
 				return;
 			}
-			// Enter focuses the editor at end when the editor is not focused
-			if (e.key === 'Enter' && !editorFocused && selectedId !== null) {
-				const target = e.target as Element;
-				if (!target.closest('input, textarea, [contenteditable]')) {
-					e.preventDefault();
-					editorRef?.focusEnd();
-					return;
+
+			// Arrow Up/Down: navigate note list when editor is not focused
+			if ((e.key === 'ArrowUp' || e.key === 'ArrowDown') && !editorFocused && !inInput && selectedId !== null) {
+				e.preventDefault();
+				const idx = notes.findIndex(n => n.id === selectedId);
+				if (idx === -1) return;
+				const next = e.key === 'ArrowUp' ? Math.max(0, idx - 1) : Math.min(notes.length - 1, idx + 1);
+				if (next !== idx) {
+					void selectNote(notes[next].id);
+					void tick().then(() => {
+						noteListEl?.querySelector<HTMLElement>('.note-item.selected')?.scrollIntoView({ block: 'nearest' });
+					});
 				}
+				return;
 			}
+
+			// Enter: focus editor at end when a note is selected and editor is not active
+			if (e.key === 'Enter' && !editorFocused && !inInput && selectedId !== null) {
+				e.preventDefault();
+				editorRef?.focusEnd();
+				return;
+			}
+
 			const id = matchShortcut(e, { skipInInputs: true });
 			if (!id) return;
 			runShortcut(id, e);
@@ -547,6 +573,7 @@
 		selectedId = id;
 		showTagPopover = false;
 		showNoteMenu = false;
+		showHeadingsMenu = false;
 		noteTags = await api.tags.listForNote(id);
 	}
 
@@ -918,7 +945,7 @@
 			</div>
 		{:else}
 
-		<ul class="note-list" role="list" class:note-list-filtered={tagsTabActive}>
+		<ul bind:this={noteListEl} class="note-list" role="list" class:note-list-filtered={tagsTabActive}>
 			{#each notes as note (note.id)}
 				<li class="note-item" class:selected={note.id === selectedId}>
 					<div class="note-btn" role="button" tabindex="0" onclick={() => selectNote(note.id)} onkeydown={(e) => (e.key === 'Enter' || e.key === ' ') && selectNote(note.id)}>
@@ -989,10 +1016,9 @@
 				onfocusin={() => (editorFocused = true)}
 				onfocusout={(e) => { if (!e.currentTarget.contains(e.relatedTarget as Node | null)) { editorFocused = false; showHeadingsMenu = false; } }}
 			>
-				{#if editorFocused}
 					<div class="toolbar" role="toolbar" aria-label="Formatting"
-						onmousedown={(e) => { if (!(e.target as Element).closest('input, textarea')) e.preventDefault(); }}
-					>
+					onmousedown={(e) => { if (!(e.target as Element).closest('input, textarea')) e.preventDefault(); }}
+				>
 						<!-- Headings expanding group -->
 						<div class="tb-heading-wrap">
 							<button class="tb-btn tb-h-toggle" onclick={() => (showHeadingsMenu = !showHeadingsMenu)} title="Headings" aria-label="Headings" aria-expanded={showHeadingsMenu}>H</button>
@@ -1053,7 +1079,6 @@
 							{/if}
 						</div>
 					</div>
-				{/if}
 
 				<div class="editor-header">
 					<div class="editor-header-inner">

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1016,7 +1016,7 @@
 				onfocusin={() => (editorFocused = true)}
 				onfocusout={(e) => { if (!e.currentTarget.contains(e.relatedTarget as Node | null)) { editorFocused = false; showHeadingsMenu = false; } }}
 			>
-					<div class="toolbar" role="toolbar" aria-label="Formatting"
+					<div class="toolbar" role="toolbar" aria-label="Formatting" tabindex="-1"
 					onmousedown={(e) => { if (!(e.target as Element).closest('input, textarea')) e.preventDefault(); }}
 				>
 						<!-- Headings expanding group -->
@@ -1025,9 +1025,9 @@
 							{#if showHeadingsMenu}
 								<div class="heading-menu-backdrop" onclick={() => (showHeadingsMenu = false)} role="presentation"></div>
 								<div class="heading-menu">
-									<button class="tb-btn tb-h-btn" onclick={() => { cmd(wrapInHeadingCommand.key, 1); showHeadingsMenu = false; }} title="Heading 1">H1</button>
-									<button class="tb-btn tb-h-btn" onclick={() => { cmd(wrapInHeadingCommand.key, 2); showHeadingsMenu = false; }} title="Heading 2">H2</button>
-									<button class="tb-btn tb-h-btn" onclick={() => { cmd(wrapInHeadingCommand.key, 3); showHeadingsMenu = false; }} title="Heading 3">H3</button>
+									<button class="tb-btn tb-h-btn" onclick={() => { cmd(wrapInHeadingCommand.key as CmdKey<unknown>, 1); showHeadingsMenu = false; }} title="Heading 1">H1</button>
+									<button class="tb-btn tb-h-btn" onclick={() => { cmd(wrapInHeadingCommand.key as CmdKey<unknown>, 2); showHeadingsMenu = false; }} title="Heading 2">H2</button>
+									<button class="tb-btn tb-h-btn" onclick={() => { cmd(wrapInHeadingCommand.key as CmdKey<unknown>, 3); showHeadingsMenu = false; }} title="Heading 3">H3</button>
 								</div>
 							{/if}
 						</div>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -16,6 +16,7 @@
 	import { undoCommand, redoCommand } from '@milkdown/kit/plugin/history';
 	import { toggleUnderlineCommand } from '$lib/milkdown/underline';
 	import { insertImageCommand } from '$lib/milkdown/image';
+	import { wrapInTaskListCommand } from '$lib/milkdown/tasklist';
 	import type { CmdKey } from '@milkdown/kit/core';
 	import { api, type Note, type Tag } from '$lib/api';
 	import { auth } from '$lib/stores/auth.svelte';
@@ -38,7 +39,7 @@
 	// Lucide icons
 	import {
 		Bold, Italic, Underline, Quote, Code, FileCode2,
-		List, ListOrdered, Minus, Undo2, Redo2, Image, Link,
+		List, ListOrdered, ListTodo, Minus, Undo2, Redo2, Image, Link,
 		Plus, Star, Pin, Archive, Trash2, Settings, LogOut,
 		ChevronRight, Search,
 		CloudUpload, CheckCircle2, Lock, MoreHorizontal,
@@ -1004,6 +1005,7 @@
 						<span class="tb-sep"></span>
 						<button class="tb-btn" onclick={() => cmd(wrapInBulletListCommand.key)} title="Bullet list"><List size={13} /></button>
 						<button class="tb-btn" onclick={() => cmd(wrapInOrderedListCommand.key)} title="Numbered list"><ListOrdered size={13} /></button>
+						<button class="tb-btn" onclick={() => cmd(wrapInTaskListCommand.key)} title="Task list"><ListTodo size={13} /></button>
 						<button class="tb-btn" onclick={() => cmd(insertHrCommand.key)} title="Horizontal rule"><Minus size={13} /></button>
 						<span class="tb-sep"></span>
 						<button class="tb-btn" onclick={() => cmd(undoCommand.key)} title="Undo"><Undo2 size={13} /></button>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -373,7 +373,28 @@
 			void refreshSyncStatus();
 		};
 		const handleKeydown = (e: KeyboardEvent) => {
-			if (e.key === 'Escape') { showTagPopover = false; }
+			if (e.key === 'Escape') {
+				// Priority order: link dialog → editor focus → filter → tag popover
+				if (showLinkDialog) { showLinkDialog = false; return; }
+				if (showTagPopover) { showTagPopover = false; return; }
+				if (editorFocused) { editorRef?.blur(); return; }
+				if (starredOnly || activeTagId !== null) {
+					starredOnly = false;
+					activeTagId = null;
+					void loadNotes();
+					return;
+				}
+				return;
+			}
+			// Enter focuses the editor at end when the editor is not focused
+			if (e.key === 'Enter' && !editorFocused && selectedId !== null) {
+				const target = e.target as Element;
+				if (!target.closest('input, textarea, [contenteditable]')) {
+					e.preventDefault();
+					editorRef?.focusEnd();
+					return;
+				}
+			}
 			const id = matchShortcut(e, { skipInInputs: true });
 			if (!id) return;
 			runShortcut(id, e);

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -384,7 +384,7 @@
 				if (editorFocused) {
 					editorRef?.blur();
 					void tick().then(() => {
-						noteListEl?.querySelector<HTMLElement>('.note-item.selected .note-btn')?.focus();
+						noteListEl?.focus();
 					});
 					return;
 				}
@@ -945,7 +945,7 @@
 			</div>
 		{:else}
 
-		<ul bind:this={noteListEl} class="note-list" role="list" class:note-list-filtered={tagsTabActive}>
+		<ul bind:this={noteListEl} class="note-list" role="list" class:note-list-filtered={tagsTabActive} tabindex="-1">
 			{#each notes as note (note.id)}
 				<li class="note-item" class:selected={note.id === selectedId}>
 					<div class="note-btn" role="button" tabindex="0" onclick={() => selectNote(note.id)} onkeydown={(e) => (e.key === 'Enter' || e.key === ' ') && selectNote(note.id)}>
@@ -1436,6 +1436,7 @@
 	.note-list::-webkit-scrollbar-track { background: transparent; }
 	.note-list:hover { scrollbar-color: var(--border-md) transparent; }
 	.note-list:hover::-webkit-scrollbar-thumb { background: var(--border-md); }
+	.note-list:focus { outline: none; }
 
 	.note-item {
 		position: relative;

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -10,11 +10,12 @@
 		wrapInOrderedListCommand,
 		insertHrCommand,
 		createCodeBlockCommand,
+		wrapInHeadingCommand,
+		toggleLinkCommand,
 	} from '@milkdown/kit/preset/commonmark';
 	import { undoCommand, redoCommand } from '@milkdown/kit/plugin/history';
 	import { toggleUnderlineCommand } from '$lib/milkdown/underline';
 	import { insertImageCommand } from '$lib/milkdown/image';
-	import { toggleLinkCommand } from '@milkdown/kit/preset/commonmark';
 	import type { CmdKey } from '@milkdown/kit/core';
 	import { api, type Note, type Tag } from '$lib/api';
 	import { auth } from '$lib/stores/auth.svelte';
@@ -75,6 +76,9 @@
 	let showTagsPanel = $state(false);
 	// Note action menu
 	let showNoteMenu = $state(false);
+	// Editor focus / toolbar visibility
+	let editorFocused = $state(false);
+	let showHeadingsMenu = $state(false);
 
 	const PALETTE = [
 		// Reds / Pinks / Rose
@@ -563,6 +567,22 @@
 		return applyFilter(activeTagId, !starredOnly);
 	}
 
+	async function goHome() {
+		search = '';
+		activeTagId = null;
+		starredOnly = false;
+		showTagsPanel = false;
+		editorFocused = false;
+		showHeadingsMenu = false;
+		selectedId = null;
+		await loadNotes();
+		if (!isMobile() && notes.length > 0) {
+			const initId = notes[0].id;
+			selectedId = initId;
+			noteTags = await api.tags.listForNote(initId).catch(() => []);
+		}
+	}
+
 	async function toggleTag(tag: Tag) {
 		if (!selectedId) return;
 		const has = noteTags.find(t => t.id === tag.id);
@@ -788,7 +808,7 @@
 	<!-- ── Sidebar ── -->
 	<aside class="sidebar">
 		<header class="sidebar-header">
-			<a href="/" class="wordmark app-name">Crapnote<span class="wordmark-dot" aria-hidden="true"></span></a>
+			<a href="/" class="wordmark app-name" onclick={(e) => { e.preventDefault(); void goHome(); }}>Crapnote<span class="wordmark-dot" aria-hidden="true"></span></a>
 			{#if !isOnline}
 				<span class="offline-badge" title="You are offline — changes will sync when reconnected">Offline</span>
 			{/if}
@@ -941,70 +961,94 @@
 	<!-- ── Editor pane ── -->
 	<main class="editor-pane">
 		{#if selectedNote}
-			<div class="toolbar" role="toolbar" aria-label="Formatting">
-				<button class="tb-btn" onclick={() => cmd(toggleStrongCommand.key)} title="Bold"><Bold size={13} /></button>
-				<button class="tb-btn" onclick={() => cmd(toggleEmphasisCommand.key)} title="Italic"><Italic size={13} /></button>
-				<button class="tb-btn" onclick={() => cmd(toggleUnderlineCommand.key)} title="Underline"><Underline size={13} /></button>
-				<div class="link-btn-wrap">
-					<button class="tb-btn" onclick={openLinkDialog} title="Insert link (Ctrl+K)"><Link size={13} /></button>
-					{#if showLinkDialog}
-						<div class="link-dialog-backdrop" onclick={() => (showLinkDialog = false)} role="presentation"></div>
-						<div class="link-dialog" role="dialog" aria-label="Insert link">
-							<input class="link-dialog-input" type="url" placeholder="https://…" bind:value={linkDialogHref} onkeydown={linkInputKeydown} use:focusInput />
-							<button class="link-dialog-btn" onclick={applyLink}>Apply</button>
+			<div
+				class="editor-focus-zone"
+				data-testid="editor-focus-zone"
+				onfocusin={() => (editorFocused = true)}
+				onfocusout={(e) => { if (!e.currentTarget.contains(e.relatedTarget as Node | null)) { editorFocused = false; showHeadingsMenu = false; } }}
+			>
+				{#if editorFocused}
+					<div class="toolbar" role="toolbar" aria-label="Formatting"
+						onmousedown={(e) => { if (!(e.target as Element).closest('input, textarea')) e.preventDefault(); }}
+					>
+						<!-- Headings expanding group -->
+						<div class="tb-heading-wrap">
+							<button class="tb-btn tb-h-toggle" onclick={() => (showHeadingsMenu = !showHeadingsMenu)} title="Headings" aria-label="Headings" aria-expanded={showHeadingsMenu}>H</button>
+							{#if showHeadingsMenu}
+								<div class="heading-menu-backdrop" onclick={() => (showHeadingsMenu = false)} role="presentation"></div>
+								<div class="heading-menu">
+									<button class="tb-btn tb-h-btn" onclick={() => { cmd(wrapInHeadingCommand.key, 1); showHeadingsMenu = false; }} title="Heading 1">H1</button>
+									<button class="tb-btn tb-h-btn" onclick={() => { cmd(wrapInHeadingCommand.key, 2); showHeadingsMenu = false; }} title="Heading 2">H2</button>
+									<button class="tb-btn tb-h-btn" onclick={() => { cmd(wrapInHeadingCommand.key, 3); showHeadingsMenu = false; }} title="Heading 3">H3</button>
+								</div>
+							{/if}
 						</div>
-					{/if}
-				</div>
-				<span class="tb-sep"></span>
-				<button class="tb-btn" onclick={() => cmd(wrapInBlockquoteCommand.key)} title="Quote"><Quote size={13} /></button>
-				<button class="tb-btn" onclick={() => cmd(toggleInlineCodeCommand.key)} title="Inline code"><Code size={13} /></button>
-				<button class="tb-btn" onclick={() => cmd(createCodeBlockCommand.key)} title="Code block"><FileCode2 size={13} /></button>
-				<span class="tb-sep"></span>
-				<button class="tb-btn" onclick={() => cmd(wrapInBulletListCommand.key)} title="Bullet list"><List size={13} /></button>
-				<button class="tb-btn" onclick={() => cmd(wrapInOrderedListCommand.key)} title="Numbered list"><ListOrdered size={13} /></button>
-				<button class="tb-btn" onclick={() => cmd(insertHrCommand.key)} title="Horizontal rule"><Minus size={13} /></button>
-				<span class="tb-sep"></span>
-				<button class="tb-btn" onclick={() => cmd(undoCommand.key)} title="Undo"><Undo2 size={13} /></button>
-				<button class="tb-btn" onclick={() => cmd(redoCommand.key)} title="Redo"><Redo2 size={13} /></button>
-				<span class="tb-sep"></span>
-				<button class="tb-btn" onclick={() => cmd(insertImageCommand.key)} title="Insert image"><Image size={13} /></button>
-				<span class="tb-spacer"></span>
-				<button class="tb-btn tb-star" class:tb-star-on={selectedNote.starred} onclick={() => toggleStar(selectedNote.id)} title={selectedNote.starred ? 'Unstar' : 'Star'}><Star size={13} /></button>
-				<div class="note-menu-wrap">
-					<button class="tb-btn" onclick={() => (showNoteMenu = !showNoteMenu)} title="More actions" aria-label="More actions"><MoreHorizontal size={13} /></button>
-					{#if showNoteMenu}
-						<div class="note-menu-backdrop" onclick={() => (showNoteMenu = false)} role="presentation"></div>
-						<div class="note-menu" role="menu">
-							<button class="note-menu-item" role="menuitem" onclick={() => { togglePin(selectedNote.id); showNoteMenu = false; }}>
-								<Pin size={13} />{selectedNote.pinned ? 'Unpin note' : 'Pin note'}
-							</button>
-							<button class="note-menu-item" role="menuitem" onclick={() => duplicateNote(selectedNote.id)}>
-								<Plus size={13} />Duplicate note
-							</button>
-							<button class="note-menu-item danger" role="menuitem" onclick={() => { deleteNote(selectedNote.id); showNoteMenu = false; }}>
-								<Trash2 size={13} />Move to trash
-							</button>
+						<span class="tb-sep"></span>
+						<button class="tb-btn" onclick={() => cmd(toggleStrongCommand.key)} title="Bold"><Bold size={13} /></button>
+						<button class="tb-btn" onclick={() => cmd(toggleEmphasisCommand.key)} title="Italic"><Italic size={13} /></button>
+						<button class="tb-btn" onclick={() => cmd(toggleUnderlineCommand.key)} title="Underline"><Underline size={13} /></button>
+						<div class="link-btn-wrap">
+							<button class="tb-btn" onclick={openLinkDialog} title="Insert link (Ctrl+K)"><Link size={13} /></button>
+							{#if showLinkDialog}
+								<div class="link-dialog-backdrop" onclick={() => (showLinkDialog = false)} role="presentation"></div>
+								<div class="link-dialog" role="dialog" aria-label="Insert link">
+									<input class="link-dialog-input" type="url" placeholder="https://…" bind:value={linkDialogHref} onkeydown={linkInputKeydown} use:focusInput />
+									<button class="link-dialog-btn" onclick={applyLink}>Apply</button>
+								</div>
+							{/if}
 						</div>
-					{/if}
-				</div>
-			</div>
+						<span class="tb-sep"></span>
+						<button class="tb-btn" onclick={() => cmd(wrapInBlockquoteCommand.key)} title="Quote"><Quote size={13} /></button>
+						<button class="tb-btn" onclick={() => cmd(toggleInlineCodeCommand.key)} title="Inline code"><Code size={13} /></button>
+						<button class="tb-btn" onclick={() => cmd(createCodeBlockCommand.key)} title="Code block"><FileCode2 size={13} /></button>
+						<span class="tb-sep"></span>
+						<button class="tb-btn" onclick={() => cmd(wrapInBulletListCommand.key)} title="Bullet list"><List size={13} /></button>
+						<button class="tb-btn" onclick={() => cmd(wrapInOrderedListCommand.key)} title="Numbered list"><ListOrdered size={13} /></button>
+						<button class="tb-btn" onclick={() => cmd(insertHrCommand.key)} title="Horizontal rule"><Minus size={13} /></button>
+						<span class="tb-sep"></span>
+						<button class="tb-btn" onclick={() => cmd(undoCommand.key)} title="Undo"><Undo2 size={13} /></button>
+						<button class="tb-btn" onclick={() => cmd(redoCommand.key)} title="Redo"><Redo2 size={13} /></button>
+						<span class="tb-sep"></span>
+						<button class="tb-btn" onclick={() => cmd(insertImageCommand.key)} title="Insert image"><Image size={13} /></button>
+						<span class="tb-spacer"></span>
+						<button class="tb-btn tb-star" class:tb-star-on={selectedNote.starred} onclick={() => toggleStar(selectedNote.id)} title={selectedNote.starred ? 'Unstar' : 'Star'}><Star size={13} /></button>
+						<div class="note-menu-wrap">
+							<button class="tb-btn" onclick={() => (showNoteMenu = !showNoteMenu)} title="More actions" aria-label="More actions"><MoreHorizontal size={13} /></button>
+							{#if showNoteMenu}
+								<div class="note-menu-backdrop" onclick={() => (showNoteMenu = false)} role="presentation"></div>
+								<div class="note-menu" role="menu">
+									<button class="note-menu-item" role="menuitem" onclick={() => { togglePin(selectedNote.id); showNoteMenu = false; }}>
+										<Pin size={13} />{selectedNote.pinned ? 'Unpin note' : 'Pin note'}
+									</button>
+									<button class="note-menu-item" role="menuitem" onclick={() => duplicateNote(selectedNote.id)}>
+										<Plus size={13} />Duplicate note
+									</button>
+									<button class="note-menu-item danger" role="menuitem" onclick={() => { deleteNote(selectedNote.id); showNoteMenu = false; }}>
+										<Trash2 size={13} />Move to trash
+									</button>
+								</div>
+							{/if}
+						</div>
+					</div>
+				{/if}
 
-			<div class="editor-header">
-				<div class="editor-header-inner">
-					<input
-						bind:this={titleInput}
-						class="title-input"
-						type="text"
-						value={selectedNote.title}
-						oninput={(e) => scheduleAutoSave('title', (e.target as HTMLInputElement).value)}
-						placeholder="Note title"
-					/>
+				<div class="editor-header">
+					<div class="editor-header-inner">
+						<input
+							bind:this={titleInput}
+							class="title-input"
+							type="text"
+							value={selectedNote.title}
+							oninput={(e) => scheduleAutoSave('title', (e.target as HTMLInputElement).value)}
+							placeholder="Note title"
+						/>
+					</div>
 				</div>
-			</div>
 
-			{#key selectedId}
-				<Editor value={selectedNote.body} onchange={(md) => scheduleAutoSave('body', md)} bind:ref={editorRef} oninsertlink={openLinkDialog} />
-			{/key}
+				{#key selectedId}
+					<Editor value={selectedNote.body} onchange={(md) => scheduleAutoSave('body', md)} bind:ref={editorRef} oninsertlink={openLinkDialog} />
+				{/key}
+			</div>
 			{#if !isOnline && noteHasImages(selectedNote.body)}
 				<div class="offline-image-notice"><Lock size={13} /> Images aren't available offline</div>
 			{/if}
@@ -1484,6 +1528,15 @@
 		background: var(--bg);
 	}
 
+	/* ─── Editor focus zone ────────────────────────────── */
+	.editor-focus-zone {
+		display: flex;
+		flex-direction: column;
+		flex: 1;
+		min-height: 0;
+		overflow: hidden;
+	}
+
 	/* ─── Toolbar ────────────────────────────────────────── */
 	.toolbar {
 		display: flex;
@@ -1518,6 +1571,40 @@
 		flex-shrink: 0;
 	}
 	.tb-spacer { flex: 1; }
+
+	/* ─── Headings group ─────────────────────────────────── */
+	.tb-heading-wrap { position: relative; display: inline-flex; }
+
+	.tb-h-toggle {
+		font-family: var(--serif);
+		font-weight: 700;
+		font-size: 0.8rem;
+		letter-spacing: -0.02em;
+		min-width: 1.6rem;
+	}
+
+	.heading-menu-backdrop { position: fixed; inset: 0; z-index: 49; }
+
+	.heading-menu {
+		position: absolute;
+		top: calc(100% + 4px);
+		left: 0;
+		background: var(--bg);
+		border: 1px solid var(--border);
+		box-shadow: var(--shadow);
+		display: flex;
+		gap: 1px;
+		z-index: 50;
+		padding: 0.2rem;
+	}
+
+	.tb-h-btn {
+		font-family: var(--serif);
+		font-weight: 700;
+		font-size: 0.75rem;
+		letter-spacing: -0.02em;
+		min-width: 1.8rem;
+	}
 
 	.link-btn-wrap { position: relative; display: inline-flex; }
 

--- a/frontend/src/routes/admin/+page.svelte
+++ b/frontend/src/routes/admin/+page.svelte
@@ -203,11 +203,11 @@
 <div class="admin-page">
 	<div class="admin-inner">
 		<header class="page-header">
+			<a href="/" class="wordmark">Crapnote<span class="wordmark-dot" aria-hidden="true"></span></a>
 			<a href="/settings" class="back-btn" title="Back to settings" aria-label="Back to settings">
 				<ChevronLeft size={20} />
 			</a>
 			<h1 class="page-title">User management<span class="accent-dot" aria-hidden="true">.</span></h1>
-			<span class="wm-small">Crapnote<span class="wm-dot" aria-hidden="true"></span></span>
 		</header>
 
 		<!-- Create user -->
@@ -450,22 +450,26 @@
 	}
 	.accent-dot { color: var(--accent); }
 
-	.wm-small {
+	.wordmark {
 		font-family: var(--serif);
 		font-weight: 800;
-		font-size: 1.2rem;
-		letter-spacing: -0.02em;
-		color: rgb(122, 114, 103);
+		font-size: 1.5rem;
+		letter-spacing: -0.04em;
+		line-height: 1;
+		color: var(--text);
+		text-decoration: none;
 		display: inline-flex;
 		align-items: baseline;
+		flex-shrink: 0;
 	}
-	.wm-dot {
+	.wordmark:hover { opacity: 0.8; }
+	.wordmark-dot {
 		display: inline-block;
-		width: 5px;
-		height: 5px;
+		width: 7px;
+		height: 7px;
 		border-radius: 50%;
 		background: var(--accent);
-		margin-left: 2px;
+		margin-left: 3px;
 		margin-bottom: 1px;
 	}
 

--- a/frontend/src/routes/admin/+page.svelte
+++ b/frontend/src/routes/admin/+page.svelte
@@ -7,6 +7,15 @@
 	import PasswordPromptModal from '$lib/components/PasswordPromptModal.svelte';
 	import { api, ApiError, type InviteResult } from '$lib/api';
 
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') {
+			const target = e.target as Element;
+			if (!target.closest('input, textarea, [contenteditable]')) {
+				void goto('/settings');
+			}
+		}
+	}
+
 	interface AdminUser {
 		id: number;
 		username: string;
@@ -199,6 +208,8 @@
 <svelte:head>
 	<title>User Management — Crapnote</title>
 </svelte:head>
+
+<svelte:window onkeydown={handleKeydown} />
 
 <div class="admin-page">
 	<a href="/" class="wordmark">Crapnote<span class="wordmark-dot" aria-hidden="true"></span></a>

--- a/frontend/src/routes/admin/+page.svelte
+++ b/frontend/src/routes/admin/+page.svelte
@@ -201,9 +201,9 @@
 </svelte:head>
 
 <div class="admin-page">
+	<a href="/" class="wordmark">Crapnote<span class="wordmark-dot" aria-hidden="true"></span></a>
 	<div class="admin-inner">
 		<header class="page-header">
-			<a href="/" class="wordmark">Crapnote<span class="wordmark-dot" aria-hidden="true"></span></a>
 			<a href="/settings" class="back-btn" title="Back to settings" aria-label="Back to settings">
 				<ChevronLeft size={20} />
 			</a>
@@ -451,6 +451,10 @@
 	.accent-dot { color: var(--accent); }
 
 	.wordmark {
+		position: fixed;
+		top: 1.25rem;
+		left: 1.25rem;
+		z-index: 10;
 		font-family: var(--serif);
 		font-weight: 800;
 		font-size: 1.5rem;
@@ -460,7 +464,6 @@
 		text-decoration: none;
 		display: inline-flex;
 		align-items: baseline;
-		flex-shrink: 0;
 	}
 	.wordmark:hover { opacity: 0.8; }
 	.wordmark-dot {

--- a/frontend/src/routes/admin/page.test.ts
+++ b/frontend/src/routes/admin/page.test.ts
@@ -226,3 +226,12 @@ describe('Admin page', () => {
 		).toBeFalsy();
 	});
 });
+
+describe('Admin — Typemark', () => {
+	it('typemark is a link to the home page', async () => {
+		render(AdminPage);
+		await waitFor(() => screen.getByRole('heading', { name: /user management/i }));
+		const link = screen.getByRole('link', { name: /^crapnote/i });
+		expect(link).toHaveAttribute('href', '/');
+	});
+});

--- a/frontend/src/routes/archive/+page.svelte
+++ b/frontend/src/routes/archive/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
 	import { ArchiveRestore, Trash2, ChevronLeft } from 'lucide-svelte';
 	import { api, type Note } from '$lib/api';
 
@@ -11,6 +12,15 @@
 		notes = await api.notes.listArchived();
 		loading = false;
 	});
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') {
+			const target = e.target instanceof Element ? e.target : null;
+			if (!target?.closest('input, textarea, [contenteditable]')) {
+				void goto('/');
+			}
+		}
+	}
 
 	async function unarchive(id: number) {
 		await api.notes.unarchive(id);
@@ -33,65 +43,112 @@
 	<title>Archive — Crapnote</title>
 </svelte:head>
 
-<div class="page">
-	<header class="page-header">
-		<a href="/" class="back-btn" title="Back to notes" aria-label="Back to notes">
-			<ChevronLeft size={20} />
-		</a>
-		<h1>Archive</h1>
-	</header>
+<svelte:window onkeydown={handleKeydown} />
 
-	{#if loading}
-		<p class="status">Loading…</p>
-	{:else if notes.length === 0}
-		<p class="status">Archive is empty.</p>
-	{:else}
-		<ul class="note-list">
-			{#each notes as note (note.id)}
-				<li class="note-item" class:expanded={expandedId === note.id}>
-					<div class="note-row">
-						<button class="note-title-btn" onclick={() => toggleExpand(note.id)}>
-							<span class="note-title">{note.title}</span>
-							<span class="note-meta">{new Date(note.updated_at).toLocaleDateString()}</span>
-						</button>
-						<div class="note-actions">
-							<button
-								class="act-btn"
-								onclick={() => unarchive(note.id)}
-								title="Restore from archive"
-								aria-label="Restore from archive"
-							>
-								<ArchiveRestore size={15} />
+<div class="archive-page">
+	<a href="/" class="wordmark">Crapnote<span class="wordmark-dot" aria-hidden="true"></span></a>
+	<div class="archive-inner">
+		<header class="page-header">
+			<a href="/" class="back-btn" title="Back to notes" aria-label="Back to notes">
+				<ChevronLeft size={20} />
+			</a>
+			<h1 class="page-title">Archive<span class="accent-dot" aria-hidden="true">.</span></h1>
+		</header>
+
+		{#if loading}
+			<p class="status">Loading…</p>
+		{:else if notes.length === 0}
+			<p class="status">Archive is empty.</p>
+		{:else}
+			<ul class="note-list">
+				{#each notes as note (note.id)}
+					<li class="note-item" class:expanded={expandedId === note.id}>
+						<div class="note-row">
+							<button class="note-title-btn" onclick={() => toggleExpand(note.id)}>
+								<span class="note-title">{note.title || 'Untitled'}</span>
+								<span class="note-meta">
+									{new Date(note.updated_at).toLocaleDateString('en-GB', { day: 'numeric', month: 'short' })}
+									· {new Date(note.updated_at).toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' })}
+								</span>
 							</button>
-							<button
-								class="act-btn danger"
-								onclick={() => deleteNote(note.id)}
-								title="Delete permanently"
-								aria-label="Delete permanently"
-							>
-								<Trash2 size={15} />
-							</button>
+							<div class="note-actions">
+								<button
+									class="act-btn"
+									onclick={() => unarchive(note.id)}
+									title="Restore from archive"
+									aria-label="Restore from archive"
+								>
+									<ArchiveRestore size={14} />
+								</button>
+								<button
+									class="act-btn danger"
+									onclick={() => deleteNote(note.id)}
+									title="Delete permanently"
+									aria-label="Delete permanently"
+								>
+									<Trash2 size={14} />
+								</button>
+							</div>
 						</div>
-					</div>
-					{#if expandedId === note.id}
-						<div class="note-body">
-							<pre class="body-text">{note.body || '(empty)'}</pre>
-						</div>
-					{/if}
-				</li>
-			{/each}
-		</ul>
-	{/if}
+						{#if expandedId === note.id}
+							<div class="note-body">
+								<pre class="body-text">{note.body || '(empty)'}</pre>
+							</div>
+						{/if}
+					</li>
+				{/each}
+			</ul>
+		{/if}
+	</div>
 </div>
 
 <style>
-	.page { max-width: 720px; margin: 0 auto; padding: 2rem 1rem; }
+	.archive-page {
+		height: 100dvh;
+		overflow-y: auto;
+		background: var(--bg);
+		font-family: var(--sans);
+	}
+
+	.archive-inner {
+		max-width: 1040px;
+		margin: 0 auto;
+		padding: 0 3rem;
+	}
+
+	.wordmark {
+		position: fixed;
+		top: 1.25rem;
+		left: 1.25rem;
+		z-index: 10;
+		font-family: var(--serif);
+		font-weight: 800;
+		font-size: 1.5rem;
+		letter-spacing: -0.04em;
+		line-height: 1;
+		color: var(--text);
+		text-decoration: none;
+		display: inline-flex;
+		align-items: baseline;
+	}
+	.wordmark:hover { opacity: 0.8; }
+	.wordmark-dot {
+		display: inline-block;
+		width: 7px;
+		height: 7px;
+		border-radius: 50%;
+		background: var(--accent);
+		margin-left: 3px;
+		margin-bottom: 1px;
+	}
 
 	.page-header {
 		display: flex;
 		align-items: center;
-		gap: 0.5rem;
-		margin-bottom: 1.5rem;
+		gap: 0.75rem;
+		padding: 2rem 0 1.5rem;
+		border-bottom: 1px solid var(--border);
+		margin-bottom: 0;
 	}
 
 	.back-btn {
@@ -99,31 +156,49 @@
 		align-items: center;
 		justify-content: center;
 		padding: 0.25rem;
-		border-radius: 0.375rem;
 		color: var(--text-3);
 		text-decoration: none;
 		flex-shrink: 0;
 	}
-	.back-btn:hover { background: var(--bg-hover); color: var(--text); }
+	.back-btn:hover { color: var(--text); }
 
-	h1 { font-size: 1.5rem; margin: 0; }
+	.page-title {
+		font-family: var(--serif);
+		font-weight: 700;
+		font-size: 2.125rem;
+		letter-spacing: -0.04em;
+		line-height: 1;
+		color: var(--text);
+		margin: 0;
+		flex: 1;
+	}
+	.accent-dot { color: var(--accent); }
 
-	.status { color: var(--text-4); text-align: center; padding: 2rem; }
+	.status {
+		color: var(--text-4);
+		padding: 2rem 0;
+		font-size: 0.875rem;
+		font-family: var(--sans);
+	}
 
-	.note-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.375rem; }
+	.note-list {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+	}
 
 	.note-item {
-		border: 1px solid var(--border);
-		border-radius: 0.5rem;
-		overflow: hidden;
+		border-bottom: 1px solid var(--border);
 	}
-	.note-item.expanded { border-color: var(--border-hi); }
+	.note-item:first-child {
+		border-top: 1px solid var(--border);
+	}
 
 	.note-row {
 		display: flex;
 		align-items: center;
 		gap: 0.5rem;
-		padding: 0.5rem 0.75rem;
+		padding: 0.75rem 0;
 	}
 
 	.note-title-btn {
@@ -135,21 +210,35 @@
 		border: none;
 		cursor: pointer;
 		text-align: left;
-		padding: 0.25rem 0;
+		padding: 0;
+		font-family: var(--sans);
+	}
+	.note-title-btn:hover .note-title { color: var(--accent); }
+
+	.note-title {
+		font-family: var(--serif);
+		font-weight: 600;
+		font-size: 1rem;
+		color: var(--text);
 	}
 
-	.note-title { font-weight: 600; font-size: 0.9rem; color: var(--text); }
-	.note-meta { font-size: 0.75rem; color: var(--text-4); white-space: nowrap; }
+	.note-meta {
+		font-size: 0.6875rem;
+		color: var(--text-4);
+		white-space: nowrap;
+		font-family: var(--sans);
+		font-variant-numeric: tabular-nums;
+	}
 
-	.note-actions { display: flex; gap: 0.25rem; flex-shrink: 0; }
+	.note-actions { display: flex; gap: 1px; flex-shrink: 0; }
 
 	.act-btn {
 		display: flex;
 		align-items: center;
-		padding: 0.3rem 0.4rem;
+		padding: 0.3rem 0.35rem;
 		background: none;
-		border: none;
-		border-radius: 0.25rem;
+		border: 1px solid transparent;
+		border-radius: 2px;
 		cursor: pointer;
 		color: var(--text-3);
 	}
@@ -159,16 +248,20 @@
 	.note-body {
 		border-top: 1px solid var(--border);
 		background: var(--bg-alt);
-		padding: 0.75rem 1rem;
+		padding: 0.75rem 0 1rem;
 	}
 
 	.body-text {
 		margin: 0;
-		font-family: system-ui, -apple-system, sans-serif;
-		font-size: 0.875rem;
-		color: var(--text-2);
+		font-family: var(--mono);
+		font-size: 0.8125rem;
+		color: var(--text-3);
 		white-space: pre-wrap;
 		word-break: break-word;
 		line-height: 1.5;
+	}
+
+	@media (max-width: 640px) {
+		.archive-inner { padding: 0 1rem; }
 	}
 </style>

--- a/frontend/src/routes/archive/page.test.ts
+++ b/frontend/src/routes/archive/page.test.ts
@@ -33,6 +33,20 @@ describe('Archive page', () => {
 		await waitFor(() => expect(screen.getByRole('heading', { name: /archive/i })).toBeInTheDocument());
 	});
 
+	it('renders the Crapnote wordmark linking to home', async () => {
+		render(ArchivePage);
+		const wordmark = screen.getByRole('link', { name: /crapnote/i });
+		expect(wordmark).toBeInTheDocument();
+		expect(wordmark).toHaveAttribute('href', '/');
+	});
+
+	it('navigates home on Escape key', async () => {
+		const { goto } = await import('$app/navigation');
+		render(ArchivePage);
+		await fireEvent.keyDown(window, { key: 'Escape' });
+		expect(goto).toHaveBeenCalledWith('/');
+	});
+
 	it('shows archived note titles', async () => {
 		render(ArchivePage);
 		await waitFor(() => expect(screen.getByText('Archived Note')).toBeInTheDocument());

--- a/frontend/src/routes/layout.test.ts
+++ b/frontend/src/routes/layout.test.ts
@@ -1,0 +1,70 @@
+import { render } from '@testing-library/svelte';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Layout from './+layout.svelte';
+import { writable } from 'svelte/store';
+
+const goto = vi.hoisted(() => vi.fn());
+vi.mock('$app/navigation', () => ({ goto }));
+
+const pageStore = writable({
+	url: new URL('http://localhost/'),
+	params: {}, route: { id: null }, status: 200,
+	error: null, data: {}, form: undefined, state: {},
+});
+
+vi.mock('$app/stores', () => ({
+	page: { subscribe: (fn: Parameters<ReturnType<typeof writable>['subscribe']>[0]) => pageStore.subscribe(fn) },
+	navigating: { subscribe: () => () => {} },
+	updated: { subscribe: () => () => {} },
+}));
+
+const mockAuth = vi.hoisted(() => ({ user: null as object | null, loading: false, init: vi.fn() }));
+vi.mock('$lib/stores/auth.svelte', () => ({ auth: mockAuth }));
+
+vi.mock('$lib/stores/theme.svelte', () => ({ theme: { init: vi.fn(), current: 'light', toggle: vi.fn() } }));
+vi.mock('$lib/sw-register', () => ({ registerSW: vi.fn() }));
+
+function setPath(pathname: string) {
+	pageStore.set({
+		url: new URL(`http://localhost${pathname}`),
+		params: {}, route: { id: null }, status: 200,
+		error: null, data: {}, form: undefined, state: {},
+	});
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mockAuth.user = null;
+	mockAuth.init.mockResolvedValue(undefined);
+	setPath('/');
+});
+
+describe('Layout auth guard', () => {
+	it('redirects unauthenticated users from protected routes to login', async () => {
+		setPath('/');
+		render(Layout, { children: () => null });
+		await vi.waitFor(() => expect(goto).toHaveBeenCalledWith('/login', { replaceState: true }));
+	});
+
+	it('does not redirect unauthenticated users on /login', async () => {
+		setPath('/login');
+		render(Layout, { children: () => null });
+		// Wait for onMount to run
+		await new Promise(r => setTimeout(r, 50));
+		expect(goto).not.toHaveBeenCalledWith('/login', { replaceState: true });
+	});
+
+	it('does not redirect unauthenticated users on /setup/* routes', async () => {
+		setPath('/setup/abc123token');
+		render(Layout, { children: () => null });
+		await new Promise(r => setTimeout(r, 50));
+		expect(goto).not.toHaveBeenCalledWith('/login', { replaceState: true });
+	});
+
+	it('redirects authenticated users away from /login to home', async () => {
+		mockAuth.user = { id: 1, username: 'alice', is_admin: false };
+		setPath('/login');
+		render(Layout, { children: () => null });
+		await vi.waitFor(() => expect(goto).toHaveBeenCalledWith('/', { replaceState: true }));
+	});
+});

--- a/frontend/src/routes/layout.test.ts
+++ b/frontend/src/routes/layout.test.ts
@@ -1,7 +1,12 @@
 import { render } from '@testing-library/svelte';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Snippet } from 'svelte';
 import Layout from './+layout.svelte';
 import { writable } from 'svelte/store';
+
+// Svelte 5 Snippet is a branded type — cast a no-op fn for tests that only
+// exercise redirect logic and never actually render children.
+const noopSnippet = (() => {}) as unknown as Snippet;
 
 const goto = vi.hoisted(() => vi.fn());
 vi.mock('$app/navigation', () => ({ goto }));
@@ -42,13 +47,13 @@ beforeEach(() => {
 describe('Layout auth guard', () => {
 	it('redirects unauthenticated users from protected routes to login', async () => {
 		setPath('/');
-		render(Layout, { children: () => null });
+		render(Layout, { children: noopSnippet });
 		await vi.waitFor(() => expect(goto).toHaveBeenCalledWith('/login', { replaceState: true }));
 	});
 
 	it('does not redirect unauthenticated users on /login', async () => {
 		setPath('/login');
-		render(Layout, { children: () => null });
+		render(Layout, { children: noopSnippet });
 		// Wait for onMount to run
 		await new Promise(r => setTimeout(r, 50));
 		expect(goto).not.toHaveBeenCalledWith('/login', { replaceState: true });
@@ -56,7 +61,7 @@ describe('Layout auth guard', () => {
 
 	it('does not redirect unauthenticated users on /setup/* routes', async () => {
 		setPath('/setup/abc123token');
-		render(Layout, { children: () => null });
+		render(Layout, { children: noopSnippet });
 		await new Promise(r => setTimeout(r, 50));
 		expect(goto).not.toHaveBeenCalledWith('/login', { replaceState: true });
 	});
@@ -64,7 +69,7 @@ describe('Layout auth guard', () => {
 	it('redirects authenticated users away from /login to home', async () => {
 		mockAuth.user = { id: 1, username: 'alice', is_admin: false };
 		setPath('/login');
-		render(Layout, { children: () => null });
+		render(Layout, { children: noopSnippet });
 		await vi.waitFor(() => expect(goto).toHaveBeenCalledWith('/', { replaceState: true }));
 	});
 });

--- a/frontend/src/routes/page.test.ts
+++ b/frontend/src/routes/page.test.ts
@@ -19,6 +19,7 @@ vi.mock('@milkdown/kit/preset/commonmark', () => ({
 vi.mock('$lib/milkdown/link', () => ({ linkPlugin: [] }));
 vi.mock('$lib/milkdown/tasklist', () => ({
 	wrapInTaskListCommand: { key: 'WrapInTaskList' },
+	taskListItemView: {},
 	taskListPlugin: [],
 }));
 vi.mock('@milkdown/kit/preset/gfm', () => ({ gfm: [] }));

--- a/frontend/src/routes/page.test.ts
+++ b/frontend/src/routes/page.test.ts
@@ -13,6 +13,7 @@ vi.mock('@milkdown/kit/preset/commonmark', () => ({
 	insertHrCommand: { key: 'InsertHr' },
 	createCodeBlockCommand: { key: 'CreateCodeBlock' },
 	toggleLinkCommand: { key: 'ToggleLink' },
+	wrapInHeadingCommand: { key: 'WrapInHeading' },
 }));
 
 vi.mock('$lib/milkdown/link', () => ({ linkPlugin: [] }));
@@ -118,6 +119,14 @@ beforeEach(() => {
 	vi.mocked(api.tags.list).mockResolvedValue([]);
 });
 
+async function focusEditor() {
+	// Wait for the title input — it's inside the focus zone and only rendered when a note is selected
+	const titleInput = await waitFor(() => screen.getByPlaceholderText(/note title/i));
+	// focusin on the title input bubbles up to the .editor-focus-zone parent
+	await fireEvent.focusIn(titleInput);
+	await waitFor(() => expect(screen.getByRole('toolbar', { name: /formatting/i })).toBeInTheDocument());
+}
+
 describe('Notes page', () => {
 	it('renders the app title', async () => {
 		render(Page);
@@ -175,9 +184,16 @@ describe('Notes page', () => {
 		await waitFor(() => expect(api.notes.archive).toHaveBeenCalledWith(1));
 	});
 
-	it('renders formatting toolbar', async () => {
+	it('toolbar is hidden when editor is not focused', async () => {
 		render(Page);
-		await waitFor(() => expect(screen.getByRole('toolbar', { name: /formatting/i })).toBeInTheDocument());
+		await waitFor(() => screen.getByText('Test Note'));
+		expect(screen.queryByRole('toolbar', { name: /formatting/i })).not.toBeInTheDocument();
+	});
+
+	it('toolbar appears when editor focus zone receives focus', async () => {
+		render(Page);
+		await focusEditor();
+		expect(screen.getByRole('toolbar', { name: /formatting/i })).toBeInTheDocument();
 	});
 });
 
@@ -241,14 +257,13 @@ describe('Mobile navigation', () => {
 describe('Link toolbar', () => {
 	it('shows the Insert link button in the toolbar', async () => {
 		render(Page);
-		await waitFor(() =>
-			expect(screen.getByTitle('Insert link (Ctrl+K)')).toBeInTheDocument()
-		);
+		await focusEditor();
+		expect(screen.getByTitle('Insert link (Ctrl+K)')).toBeInTheDocument();
 	});
 
 	it('clicking the link button shows the URL input dialog', async () => {
 		render(Page);
-		await waitFor(() => screen.getByTitle('Insert link (Ctrl+K)'));
+		await focusEditor();
 
 		await fireEvent.click(screen.getByTitle('Insert link (Ctrl+K)'));
 
@@ -258,7 +273,7 @@ describe('Link toolbar', () => {
 
 	it('pressing Escape closes the dialog', async () => {
 		render(Page);
-		await waitFor(() => screen.getByTitle('Insert link (Ctrl+K)'));
+		await focusEditor();
 
 		await fireEvent.click(screen.getByTitle('Insert link (Ctrl+K)'));
 		const input = screen.getByPlaceholderText(/https/i);
@@ -270,7 +285,7 @@ describe('Link toolbar', () => {
 
 	it('clicking the backdrop closes the dialog', async () => {
 		render(Page);
-		await waitFor(() => screen.getByTitle('Insert link (Ctrl+K)'));
+		await focusEditor();
 
 		await fireEvent.click(screen.getByTitle('Insert link (Ctrl+K)'));
 		expect(screen.getByPlaceholderText(/https/i)).toBeInTheDocument();
@@ -282,7 +297,7 @@ describe('Link toolbar', () => {
 
 	it('pressing Enter in the URL input closes the dialog', async () => {
 		render(Page);
-		await waitFor(() => screen.getByTitle('Insert link (Ctrl+K)'));
+		await focusEditor();
 
 		await fireEvent.click(screen.getByTitle('Insert link (Ctrl+K)'));
 		const input = screen.getByPlaceholderText(/https/i);
@@ -295,12 +310,56 @@ describe('Link toolbar', () => {
 
 	it('clicking Apply closes the dialog', async () => {
 		render(Page);
-		await waitFor(() => screen.getByTitle('Insert link (Ctrl+K)'));
+		await focusEditor();
 
 		await fireEvent.click(screen.getByTitle('Insert link (Ctrl+K)'));
 		await fireEvent.click(screen.getByRole('button', { name: /apply/i }));
 
 		expect(screen.queryByPlaceholderText(/https/i)).not.toBeInTheDocument();
+	});
+});
+
+describe('Headings toolbar group', () => {
+	it('shows a Headings toggle button when editor is focused', async () => {
+		render(Page);
+		await focusEditor();
+		expect(screen.getByTitle('Headings')).toBeInTheDocument();
+	});
+
+	it('H1/H2/H3 buttons are hidden before toggling', async () => {
+		render(Page);
+		await focusEditor();
+		expect(screen.queryByTitle('Heading 1')).not.toBeInTheDocument();
+		expect(screen.queryByTitle('Heading 2')).not.toBeInTheDocument();
+		expect(screen.queryByTitle('Heading 3')).not.toBeInTheDocument();
+	});
+
+	it('clicking Headings toggle reveals H1, H2, H3 buttons', async () => {
+		render(Page);
+		await focusEditor();
+		await fireEvent.click(screen.getByTitle('Headings'));
+		expect(screen.getByTitle('Heading 1')).toBeInTheDocument();
+		expect(screen.getByTitle('Heading 2')).toBeInTheDocument();
+		expect(screen.getByTitle('Heading 3')).toBeInTheDocument();
+	});
+
+	it('clicking H1 closes the heading group', async () => {
+		render(Page);
+		await focusEditor();
+		await fireEvent.click(screen.getByTitle('Headings'));
+		await fireEvent.click(screen.getByTitle('Heading 1'));
+		await waitFor(() => expect(screen.queryByTitle('Heading 1')).not.toBeInTheDocument());
+	});
+});
+
+describe('Typemark (home link)', () => {
+	it('clicking the typemark resets the search term', async () => {
+		render(Page);
+		await waitFor(() => screen.getByText('Test Note'));
+		const searchInput = screen.getByPlaceholderText(/search/i);
+		await fireEvent.input(searchInput, { target: { value: 'my search' } });
+		await fireEvent.click(screen.getByRole('link', { name: /crapnote/i }));
+		await waitFor(() => expect((searchInput as HTMLInputElement).value).toBe(''));
 	});
 });
 

--- a/frontend/src/routes/page.test.ts
+++ b/frontend/src/routes/page.test.ts
@@ -17,6 +17,11 @@ vi.mock('@milkdown/kit/preset/commonmark', () => ({
 }));
 
 vi.mock('$lib/milkdown/link', () => ({ linkPlugin: [] }));
+vi.mock('$lib/milkdown/tasklist', () => ({
+	wrapInTaskListCommand: { key: 'WrapInTaskList' },
+	taskListPlugin: [],
+}));
+vi.mock('@milkdown/kit/preset/gfm', () => ({ gfm: [] }));
 vi.mock('@milkdown/kit/plugin/history', () => ({
 	undoCommand: { key: 'Undo' },
 	redoCommand: { key: 'Redo' },
@@ -349,6 +354,20 @@ describe('Headings toolbar group', () => {
 		await fireEvent.click(screen.getByTitle('Headings'));
 		await fireEvent.click(screen.getByTitle('Heading 1'));
 		await waitFor(() => expect(screen.queryByTitle('Heading 1')).not.toBeInTheDocument());
+	});
+});
+
+describe('Checklist toolbar button', () => {
+	it('shows a Task list button in the toolbar when editor is focused', async () => {
+		render(Page);
+		await focusEditor();
+		expect(screen.getByTitle('Task list')).toBeInTheDocument();
+	});
+
+	it('Task list button is clickable without error', async () => {
+		render(Page);
+		await focusEditor();
+		await fireEvent.click(screen.getByTitle('Task list'));
 	});
 });
 

--- a/frontend/src/routes/page.test.ts
+++ b/frontend/src/routes/page.test.ts
@@ -190,16 +190,10 @@ describe('Notes page', () => {
 		await waitFor(() => expect(api.notes.archive).toHaveBeenCalledWith(1));
 	});
 
-	it('toolbar is hidden when editor is not focused', async () => {
+	it('toolbar is visible when a note is selected', async () => {
 		render(Page);
 		await waitFor(() => screen.getByText('Test Note'));
-		expect(screen.queryByRole('toolbar', { name: /formatting/i })).not.toBeInTheDocument();
-	});
-
-	it('toolbar appears when editor focus zone receives focus', async () => {
-		render(Page);
-		await focusEditor();
-		expect(screen.getByRole('toolbar', { name: /formatting/i })).toBeInTheDocument();
+		await waitFor(() => expect(screen.getByRole('toolbar', { name: /formatting/i })).toBeInTheDocument());
 	});
 });
 

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -1,11 +1,21 @@
 <script lang="ts">
 	import { ChevronLeft } from 'lucide-svelte';
+	import { goto } from '$app/navigation';
 	import { auth } from '$lib/stores/auth.svelte';
 	import { theme } from '$lib/stores/theme.svelte';
 	import ApiTokens from '$lib/components/ApiTokens.svelte';
 	import PasswordInput from '$lib/components/PasswordInput.svelte';
 	import ShortcutEditor from '$lib/components/ShortcutEditor.svelte';
 	import { api, ApiError } from '$lib/api';
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') {
+			const target = e.target as Element;
+			if (!target.closest('input, textarea, [contenteditable]')) {
+				void goto('/');
+			}
+		}
+	}
 
 	let exportPassword = $state('');
 
@@ -67,6 +77,8 @@
 <svelte:head>
 	<title>Settings — Crapnote</title>
 </svelte:head>
+
+<svelte:window onkeydown={handleKeydown} />
 
 <div class="settings-page">
 	<a href="/" class="wordmark">Crapnote<span class="wordmark-dot" aria-hidden="true"></span></a>

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -71,11 +71,11 @@
 <div class="settings-page">
 	<div class="settings-inner">
 		<header class="page-header">
+			<a href="/" class="wordmark">Crapnote<span class="wordmark-dot" aria-hidden="true"></span></a>
 			<a href="/" class="back-btn" title="Back to notes" aria-label="Back to notes">
 				<ChevronLeft size={20} />
 			</a>
 			<h1 class="page-title">Settings<span class="accent-dot" aria-hidden="true">.</span></h1>
-			<span class="wm-small">Crapnote<span class="wm-dot" aria-hidden="true"></span></span>
 		</header>
 
 		<!-- Export -->
@@ -243,22 +243,26 @@
 	}
 	.accent-dot { color: var(--accent); }
 
-	.wm-small {
+	.wordmark {
 		font-family: var(--serif);
 		font-weight: 800;
-		font-size: 1.2rem;
-		letter-spacing: -0.02em;
-		color: rgb(122, 114, 103);
+		font-size: 1.5rem;
+		letter-spacing: -0.04em;
+		line-height: 1;
+		color: var(--text);
+		text-decoration: none;
 		display: inline-flex;
 		align-items: baseline;
+		flex-shrink: 0;
 	}
-	.wm-dot {
+	.wordmark:hover { opacity: 0.8; }
+	.wordmark-dot {
 		display: inline-block;
-		width: 5px;
-		height: 5px;
+		width: 7px;
+		height: 7px;
 		border-radius: 50%;
 		background: var(--accent);
-		margin-left: 2px;
+		margin-left: 3px;
 		margin-bottom: 1px;
 	}
 

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -69,9 +69,9 @@
 </svelte:head>
 
 <div class="settings-page">
+	<a href="/" class="wordmark">Crapnote<span class="wordmark-dot" aria-hidden="true"></span></a>
 	<div class="settings-inner">
 		<header class="page-header">
-			<a href="/" class="wordmark">Crapnote<span class="wordmark-dot" aria-hidden="true"></span></a>
 			<a href="/" class="back-btn" title="Back to notes" aria-label="Back to notes">
 				<ChevronLeft size={20} />
 			</a>
@@ -244,6 +244,10 @@
 	.accent-dot { color: var(--accent); }
 
 	.wordmark {
+		position: fixed;
+		top: 1.25rem;
+		left: 1.25rem;
+		z-index: 10;
 		font-family: var(--serif);
 		font-weight: 800;
 		font-size: 1.5rem;
@@ -253,7 +257,6 @@
 		text-decoration: none;
 		display: inline-flex;
 		align-items: baseline;
-		flex-shrink: 0;
 	}
 	.wordmark:hover { opacity: 0.8; }
 	.wordmark-dot {

--- a/frontend/src/routes/settings/page.test.ts
+++ b/frontend/src/routes/settings/page.test.ts
@@ -167,3 +167,11 @@ describe('Settings — Change password', () => {
 		expect(mockApi.auth.changePassword).not.toHaveBeenCalled();
 	});
 });
+
+describe('Settings — Typemark', () => {
+	it('typemark is a link to the home page', () => {
+		render(SettingsPage);
+		const link = screen.getByRole('link', { name: /^crapnote/i });
+		expect(link).toHaveAttribute('href', '/');
+	});
+});

--- a/frontend/src/routes/setup/[token]/+page.svelte
+++ b/frontend/src/routes/setup/[token]/+page.svelte
@@ -64,104 +64,254 @@
 	<title>Set your password — Crapnote</title>
 </svelte:head>
 
-<div class="setup-container">
-	<h1>Welcome to Crapnote</h1>
+<div class="setup-page">
+	<div class="corner-mark">
+		<a href="/" class="wm">Crapnote<span class="wm-dot" aria-hidden="true"></span></a>
+	</div>
 
-	{#if loading}
-		<p>Loading…</p>
-	{:else if username}
-		<p class="intro">
-			You're setting the password for <strong>{username}</strong>. Choose something at least
-			12 characters long. You'll use this password to log in from now on.
-		</p>
-		{#if expiresAt}
-			<p class="hint">This link expires on {new Date(expiresAt).toLocaleString()}.</p>
+	<div class="setup-box">
+		{#if loading}
+			<p class="loading">Loading…</p>
+		{:else if username}
+			<div class="hero">
+				<div class="hero-wordmark">
+					Crapnote<span class="hero-dot" aria-hidden="true"></span>
+				</div>
+				<p class="hero-sub">
+					You're setting up <strong class="hero-name">{username}</strong>. Choose a password at least 12 characters long.
+				</p>
+				{#if expiresAt}
+					<p class="hero-expiry">
+						Link expires {new Date(expiresAt).toLocaleString('en-GB', { dateStyle: 'medium', timeStyle: 'short' })}.
+					</p>
+				{/if}
+			</div>
+
+			<form onsubmit={handleSubmit} class="setup-form">
+				{#if error}
+					<p role="alert" class="error">{error}</p>
+				{/if}
+
+				<div class="field">
+					<label for="new-password">New password</label>
+					<PasswordInput
+						id="new-password"
+						autocomplete="new-password"
+						bind:value={newPassword}
+						disabled={submitting}
+						required
+					/>
+				</div>
+				<div class="field">
+					<label for="new-password-confirm">Confirm new password</label>
+					<PasswordInput
+						id="new-password-confirm"
+						autocomplete="new-password"
+						bind:value={newPasswordConfirm}
+						disabled={submitting}
+						required
+					/>
+				</div>
+				<button type="submit" class="submit-btn" disabled={submitting}>
+					{submitting ? 'Setting password…' : 'Set password'}<span class="btn-dot" aria-hidden="true">.</span>
+				</button>
+			</form>
+		{:else}
+			<p role="alert" class="error">{error || 'Setup link invalid.'}</p>
 		{/if}
+	</div>
 
-		<form onsubmit={handleSubmit}>
-			{#if error}
-				<p role="alert" class="error">{error}</p>
-			{/if}
-
-			<div class="field">
-				<label for="new-password">New password</label>
-				<PasswordInput
-					id="new-password"
-					autocomplete="new-password"
-					bind:value={newPassword}
-					disabled={submitting}
-					required
-				/>
-			</div>
-			<div class="field">
-				<label for="new-password-confirm">Confirm new password</label>
-				<PasswordInput
-					id="new-password-confirm"
-					autocomplete="new-password"
-					bind:value={newPasswordConfirm}
-					disabled={submitting}
-					required
-				/>
-			</div>
-			<button type="submit" disabled={submitting}>
-				{submitting ? 'Setting password…' : 'Set password'}
-			</button>
-		</form>
-	{:else}
-		<p role="alert" class="error">{error || 'Setup link invalid.'}</p>
-	{/if}
+	<div class="setup-footer">
+		<span>Notes, kept simple.</span>
+	</div>
 </div>
 
 <style>
-	.setup-container {
+	.setup-page {
+		min-height: 100dvh;
+		background: var(--bg);
 		display: flex;
-		flex-direction: column;
-		gap: 0.75rem;
-		max-width: 380px;
-		margin: 0 auto;
-		padding: 4rem 1rem 2rem;
+		align-items: center;
+		justify-content: center;
+		position: relative;
+		padding: 2rem 1rem;
+		box-sizing: border-box;
+		font-family: var(--sans);
 	}
 
-	h1 {
-		font-size: 1.5rem;
-		margin: 0;
+	/* Corner wordmark */
+	.corner-mark {
+		position: absolute;
+		top: 1.5rem;
+		left: 2rem;
 	}
-
-	.intro { color: var(--text-2); font-size: 0.9rem; margin: 0; }
-	.hint { color: var(--text-3); font-size: 0.8125rem; margin: 0; }
-
-	form {
-		display: flex;
-		flex-direction: column;
-		gap: 0.75rem;
-		margin-top: 0.5rem;
-	}
-
-	.field { display: flex; flex-direction: column; gap: 0.25rem; }
-	.field label { font-weight: 500; font-size: 0.875rem; color: var(--text-2); }
-
-	button[type='submit'] {
-		padding: 0.625rem;
-		background: var(--accent);
-		color: white;
-		border: none;
-		border-radius: 0.375rem;
+	.wm {
+		font-family: var(--serif);
+		font-weight: 800;
 		font-size: 1rem;
-		font-weight: 500;
+		letter-spacing: -0.02em;
+		color: var(--text-3);
+		text-decoration: none;
+		display: inline-flex;
+		align-items: baseline;
+	}
+	.wm:hover { color: var(--text); }
+	.wm-dot {
+		display: inline-block;
+		width: 5px;
+		height: 5px;
+		border-radius: 50%;
+		background: var(--accent);
+		margin-left: 2px;
+		margin-bottom: 1px;
+	}
+
+	.setup-box {
+		width: 100%;
+		max-width: 400px;
+	}
+
+	.loading {
+		font-family: var(--sans);
+		color: var(--text-4);
+		font-size: 0.875rem;
+	}
+
+	/* Hero */
+	.hero { margin-bottom: 2.5rem; }
+
+	.hero-wordmark {
+		font-family: var(--serif);
+		font-weight: 800;
+		font-size: 4.5rem;
+		letter-spacing: -0.04em;
+		line-height: 0.95;
+		color: var(--text);
+		display: inline-flex;
+		align-items: baseline;
+	}
+	.hero-dot {
+		display: inline-block;
+		width: 18px;
+		height: 18px;
+		border-radius: 50%;
+		background: var(--accent);
+		margin-left: 5px;
+		margin-bottom: 4px;
+	}
+
+	.hero-sub {
+		font-family: var(--serif);
+		font-style: italic;
+		font-size: 1.125rem;
+		color: var(--text-3);
+		margin: 0.75rem 0 0;
+		line-height: 1.5;
+	}
+	.hero-name {
+		font-style: normal;
+		font-weight: 700;
+		color: var(--text);
+	}
+
+	.hero-expiry {
+		font-family: var(--sans);
+		font-size: 0.75rem;
+		color: var(--text-4);
+		margin: 0.5rem 0 0;
+	}
+
+	/* Form */
+	.setup-form {
+		display: flex;
+		flex-direction: column;
+		gap: 1.25rem;
+	}
+
+	.field {
+		display: flex;
+		flex-direction: column;
+		gap: 0.4rem;
+	}
+
+	label {
+		font-family: var(--sans);
+		font-size: 0.6875rem;
+		color: var(--text-3);
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+	}
+
+	/* Style the PasswordInput component to match login's underline style */
+	:global(.setup-form .pw-wrap) { display: block; position: relative; }
+	:global(.setup-form .pw-wrap input) {
+		width: 100%;
+		box-sizing: border-box;
+		font-family: var(--serif);
+		font-size: 1.125rem;
+		color: var(--text);
+		background: transparent;
+		border: none;
+		border-radius: 0;
+		border-bottom: 1.5px solid var(--border);
+		outline: none;
+		padding: 0.375rem 1.75rem 0.625rem 0;
+		box-shadow: none;
+		transition: border-color 0.15s;
+	}
+	:global(.setup-form .pw-wrap input:focus) {
+		border-bottom-color: var(--accent);
+		box-shadow: none;
+	}
+	:global(.setup-form .pw-wrap .toggle) {
+		position: absolute;
+		right: 0;
+		bottom: 0.25rem;
+		top: auto;
+		transform: none;
+		background: transparent;
+	}
+
+	.submit-btn {
+		width: 100%;
+		margin-top: 0.5rem;
+		padding: 0.875rem 1rem;
+		background: var(--text);
+		color: var(--bg);
+		border: none;
 		cursor: pointer;
+		font-family: var(--serif);
+		font-weight: 600;
+		font-size: 1.125rem;
+		letter-spacing: -0.01em;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 0.5rem;
 	}
-	button[type='submit']:disabled {
-		opacity: 0.6;
-		cursor: not-allowed;
-	}
+	.submit-btn:disabled { opacity: 0.6; cursor: not-allowed; }
+	.btn-dot { color: var(--accent); font-size: 1.5rem; line-height: 0.8; }
 
 	.error {
 		color: var(--danger);
-		font-size: 0.875rem;
+		font-size: 0.8125rem;
+		font-family: var(--sans);
 		padding: 0.5rem 0.75rem;
 		background: var(--danger-bg);
 		border: 1px solid var(--danger-bd);
-		border-radius: 0.375rem;
 		margin: 0;
+	}
+
+	/* Footer */
+	.setup-footer {
+		position: absolute;
+		bottom: 1.5rem;
+		left: 2rem;
+		right: 2rem;
+		display: flex;
+		justify-content: space-between;
+		font-family: var(--sans);
+		font-size: 0.6875rem;
+		color: var(--text-4);
 	}
 </style>

--- a/frontend/src/routes/setup/[token]/page.test.ts
+++ b/frontend/src/routes/setup/[token]/page.test.ts
@@ -29,6 +29,14 @@ beforeEach(() => {
 });
 
 describe('Setup page', () => {
+	it('renders a Crapnote corner mark linking to home', async () => {
+		mockApi.setup.get.mockResolvedValueOnce({ username: 'mallory', expires_at: '2030-01-01T00:00:00Z' });
+		render(SetupPage);
+		const link = screen.getByRole('link', { name: /crapnote/i });
+		expect(link).toBeInTheDocument();
+		expect(link).toHaveAttribute('href', '/');
+	});
+
 	it('fetches the token metadata on load and shows the username', async () => {
 		mockApi.setup.get.mockResolvedValueOnce({
 			username: 'mallory',


### PR DESCRIPTION
## Summary
This PR significantly redesigns the Crapnote UI with a focus on improved visual hierarchy, better keyboard navigation, and enhanced editor focus management. The changes include a complete visual overhaul of the setup and archive pages, new keyboard shortcuts for note navigation, and better state management for editor focus.

## Key Changes

### Setup Page Redesign
- Complete visual redesign with a centered layout featuring a large hero wordmark
- Added corner wordmark linking to home
- Improved typography with serif fonts for headings and better spacing
- Enhanced form styling with underline-based input fields matching the login page aesthetic
- Added footer with tagline
- Better expiry date formatting using locale-specific date/time strings

### Archive Page Redesign
- Converted from card-based layout to a cleaner list-based design with borders
- Added fixed corner wordmark linking to home
- Improved typography and spacing throughout
- Better date/time formatting with tabular numbers
- Added Escape key handler to navigate back to home
- Responsive padding adjustments for mobile

### Editor Focus Management
- Added `editorFocused` state to track when the editor is actively being edited
- Implemented `editor-focus-zone` wrapper to manage focus state via `focusin`/`focusout` events
- Added keyboard shortcuts:
  - **Arrow Up/Down**: Navigate between notes when editor is not focused
  - **Enter**: Focus editor at end when a note is selected
  - **Escape**: Hierarchical handling (link dialog → tag popover → editor blur → filter tabs)
- Added `focusEnd()` and `blur()` methods to Editor component for programmatic focus control

### Toolbar Enhancements
- Added expandable headings menu (H1, H2, H3) with toggle button
- Reorganized toolbar layout with better visual grouping
- Improved button styling with accent dots
- Added task list support via new `wrapInTaskListCommand`

### Navigation Improvements
- Clicking the home wordmark now calls `goHome()` function instead of navigating away
- `goHome()` resets all filters, clears selection, and reloads notes
- Added Escape key handlers to settings and admin pages to navigate back
- Better keyboard navigation flow across the application

### New Task List Support
- Created `$lib/milkdown/tasklist.ts` with task list command and custom NodeView
- Integrated GFM (GitHub Flavored Markdown) preset for task list support
- Task items render with checkboxes that toggle the `checked` attribute
- Proper focus management to keep editor focused when toggling checkboxes

### Testing Updates
- Added `layout.test.ts` for auth guard testing
- Updated existing tests to use new `focusEditor()` helper function
- Added tests for wordmark links on archive and admin pages
- Updated toolbar visibility tests to account for editor focus requirements

### Settings & Admin Pages
- Added fixed corner wordmark linking to home
- Added Escape key handlers for navigation
- Removed redundant inline wordmarks from headers
- Improved page header styling with borders

## Notable Implementation Details

- The editor focus zone uses event bubbling to detect when focus enters/leaves the editor area, allowing proper state management without explicit focus tracking on every input
- Keyboard navigation respects input context—shortcuts are disabled when typing in inputs or contenteditable areas
- The `goHome()` function provides a clean reset of all UI state rather than just navigating
- Task list implementation uses ProseMirror NodeViews for proper checkbox rendering and interaction
- All date/time formatting now uses locale-specific formatting with `toLocaleString()` for better internationalization

https://claude.ai/code/session_016M9DJ8349jiEpqY5KxMB7U