### PR TITLE
Remove SESSION_SECRET requirement and reorganize Docker build

### DIFF
--- a/.claude/skills/crapnote/SKILL.md
+++ b/.claude/skills/crapnote/SKILL.md
@@ -278,7 +278,6 @@ DATABASE_PATH       # SQLite file path (default: /data/notes.db)
 DATABASE_URL        # PostgreSQL connection string (overrides SQLite if set)
 ADMIN_USERNAME      # Seeded on first run if no users exist
 ADMIN_PASSWORD      # Seeded on first run if no users exist
-SESSION_SECRET      # Secret for signing session tokens
 SESSION_TTL_DAYS    # Session lifetime (default: 7)
 PORT                # HTTP port (default: 8080)
 ```

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,12 @@ RUN npm run build
 FROM golang:1.24-bookworm AS backend-builder
 WORKDIR /app/backend
 RUN apt-get update && apt-get install -y --no-install-recommends gcc libc6-dev libsqlite3-dev && rm -rf /var/lib/apt/lists/*
-# Copy frontend build output into the go:embed target directory
-COPY --from=frontend-builder /app/frontend/build ./static/
 COPY backend/go.mod backend/go.sum ./
 RUN go mod download
 COPY backend/ ./
-RUN CGO_ENABLED=1 GOOS=linux go build -o /app/server ./cmd/server
+# Copy frontend build output into the go:embed target directory (must be after COPY backend/ to avoid .gitkeep overwrite)
+COPY --from=frontend-builder /app/frontend/build ./cmd/server/ui/build/
+RUN CGO_ENABLED=1 GOOS=linux go build -tags sqlite_fts5 -o /app/server ./cmd/server
 
 # Stage 3 — Final image (needs libc for CGO binary)
 FROM gcr.io/distroless/cc-debian12:nonroot

--- a/README.md
+++ b/README.md
@@ -255,7 +255,6 @@ docker build -t crapnote .
 docker run -p 8080:8080 \
   -e ADMIN_USERNAME=admin \
   -e ADMIN_PASSWORD=changeme \
-  -e SESSION_SECRET=change-this \
   -v $(pwd)/data:/data \
   crapnote
 ```

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -37,11 +37,6 @@ spec:
                 secretKeyRef:
                   name: crapnote-secrets
                   key: ADMIN_PASSWORD
-            - name: SESSION_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: crapnote-secrets
-                  key: SESSION_SECRET
           volumeMounts:
             - name: data
               mountPath: /data

--- a/deploy/k8s/secret.yaml
+++ b/deploy/k8s/secret.yaml
@@ -3,7 +3,6 @@
 #   kubectl create secret generic crapnote-secrets \
 #     --from-literal=ADMIN_USERNAME=<value> \
 #     --from-literal=ADMIN_PASSWORD=<value> \
-#     --from-literal=SESSION_SECRET=<32-byte-random-string> \
 #     -n crapnote
 apiVersion: v1
 kind: Secret
@@ -14,4 +13,3 @@ type: Opaque
 stringData:
   ADMIN_USERNAME: "REPLACE_ME"
   ADMIN_PASSWORD: "REPLACE_ME"
-  SESSION_SECRET: "REPLACE_ME"


### PR DESCRIPTION
## Summary
This PR removes the `SESSION_SECRET` environment variable requirement from the application and reorganizes the Docker build process to improve the build layer structure and add SQLite FTS5 support.

## Key Changes
- **Removed SESSION_SECRET requirement**: Eliminated the `SESSION_SECRET` environment variable from Kubernetes deployment, secret configuration, documentation, and Docker examples. The application now handles session token signing without requiring this external secret.
- **Reorganized Docker build stages**: Moved the frontend build output copy operation to occur after copying backend files to prevent `.gitkeep` files from being overwritten, ensuring proper directory structure initialization.
- **Updated frontend embed path**: Changed the frontend build output destination from `./static/` to `./cmd/server/ui/build/` to align with the application's go:embed directory structure.
- **Added SQLite FTS5 support**: Added `-tags sqlite_fts5` build flag to enable full-text search capabilities in SQLite.
- **Updated documentation**: Removed `SESSION_SECRET` references from SKILL.md, README.md, and Kubernetes deployment manifests.

## Implementation Details
The Docker build reorganization ensures that backend files are copied first, allowing the frontend build output to be placed in the correct location without interfering with backend directory initialization. The addition of the `sqlite_fts5` build tag enables advanced search functionality while maintaining the existing SQLite database backend.

https://claude.ai/code/session_017CDyAvpGHF4SBFnNypbkYV