### PR TITLE
[backend/httpx] Ignore spoofable forwarded headers unless TRUST_PROXY is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ npm run lint      # eslint
 | `LOGIN_RATE_BURST` | `5` | Burst allowance for the login limiter |
 | `BEARER_RATE_PER_MINUTE` | `600` | Per-IP rate limit applied only to requests carrying an `Authorization` header |
 | `BEARER_RATE_BURST` | `300` | Burst allowance for the bearer-auth limiter |
+| `TRUST_PROXY` | `false` | Set to `1` only when the app sits behind exactly one trusted reverse proxy. When on, the client IP for rate limiting and audit logs is taken from the rightmost `X-Forwarded-For` entry (appended by the proxy; `X-Real-IP` as fallback) and `X-Forwarded-Proto: https` marks session cookies `Secure`. When off (the default), these headers are ignored — they are client-controlled — and the TCP peer address is used. |
 
 ### Frontend build-time variables
 

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/danpicton/crapnote/internal/auth"
 	"github.com/danpicton/crapnote/internal/db"
 	"github.com/danpicton/crapnote/internal/export"
+	"github.com/danpicton/crapnote/internal/httpx"
 	"github.com/danpicton/crapnote/internal/images"
 	"github.com/danpicton/crapnote/internal/middleware"
 	"github.com/danpicton/crapnote/internal/notes"
@@ -149,6 +150,19 @@ func main() {
 
 	// Wrap with observability middleware (metrics outermost, then logging, then security headers).
 	handler := middleware.Metrics()(middleware.Logging(logger)(middleware.SecurityHeaders()(mux)))
+
+	// TRUST_PROXY: opt-in trust of reverse-proxy headers, default off. When
+	// off, the client IP used for the login/bearer rate limiters and audit
+	// logs is the connection's RemoteAddr, and X-Forwarded-For / X-Real-IP /
+	// X-Forwarded-Proto are ignored — they are client-controlled, and
+	// honouring them lets an attacker rotate rate-limit buckets and forge
+	// audit-log IPs. Set TRUST_PROXY=1 only when exactly one trusted reverse
+	// proxy sits in front of the app; the rightmost X-Forwarded-For entry
+	// (appended by that proxy) is then used. See httpx.TrustProxy.
+	if v, err := strconv.ParseBool(envOrDefault("TRUST_PROXY", "false")); err == nil && v {
+		handler = httpx.TrustProxy()(handler)
+		logger.Info("trusting reverse-proxy forwarded headers (TRUST_PROXY)")
+	}
 
 	addr := fmt.Sprintf(":%s", port)
 	logger.Info("server starting", "addr", addr)

--- a/backend/cmd/server/server_test.go
+++ b/backend/cmd/server/server_test.go
@@ -270,6 +270,58 @@ func TestLogin_RateLimited(t *testing.T) {
 	}
 }
 
+// Without TRUST_PROXY, the limiter must key on the connection's RemoteAddr —
+// an attacker rotating X-Forwarded-For per request must not get a fresh
+// rate-limit bucket each time.
+func TestLogin_RateLimited_SpoofedForwardedForDoesNotBypass(t *testing.T) {
+	database, err := db.Open(db.Config{SQLitePath: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	userRepo := auth.NewUserRepo(database)
+	sessRepo := auth.NewSessionRepo(database)
+	authSvc := auth.NewService(userRepo, sessRepo, 7*24*time.Hour)
+	notesSvc := notes.NewService(notes.NewRepo(database))
+	tightLimiter := ratelimit.New(0.01, 2)
+	authH := auth.NewHandler(authSvc)
+	tokensSvc := tokens.NewService(tokens.NewRepo(database), userRepo)
+	authH.SetBearerAuthenticator(tokens.NewBearerAuth(tokensSvc, nil))
+	mux := newMux(
+		authH,
+		auth.NewAdminHandler(userRepo, sessRepo),
+		auth.NewSetupHandler(authSvc),
+		notes.NewHandler(notesSvc),
+		tags.NewHandler(tags.NewService(tags.NewRepo(database))),
+		trash.NewHandler(trash.NewService(trash.NewRepo(database))),
+		export.NewHandler(notesSvc, database),
+		images.NewHandler(database),
+		tokens.NewHandler(tokensSvc),
+		tightLimiter,
+		permissiveBearerLimiter(),
+	)
+
+	send := func(spoofedIP string) int {
+		req := httptest.NewRequest(http.MethodPost, "/api/auth/login",
+			bytes.NewBufferString(`{"username":"u","password":"p"}`))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-Forwarded-For", spoofedIP)
+		req.RemoteAddr = "203.0.113.9:4444"
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	// Every request claims a different client IP, but they all arrive from
+	// the same connection — the third must still be throttled.
+	_ = send("10.0.0.1")
+	_ = send("10.0.0.2")
+	if code := send("10.0.0.3"); code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 despite rotating X-Forwarded-For, got %d", code)
+	}
+}
+
 func TestLogin_Endpoint(t *testing.T) {
 	mux := newTestMux(t)
 

--- a/backend/internal/auth/audit_test.go
+++ b/backend/internal/auth/audit_test.go
@@ -72,7 +72,10 @@ func TestAudit_SuccessfulLoginIsLogged(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/auth/login",
 		strings.NewReader(`{"username":"admin","password":"correct"}`))
 	req.Header.Set("Content-Type", "application/json")
+	// A spoofed forwarded header must not reach the audit log — without the
+	// TrustProxy middleware the connection's RemoteAddr is recorded.
 	req.Header.Set("X-Forwarded-For", "203.0.113.9")
+	req.RemoteAddr = "198.51.100.7:2222"
 	w := httptest.NewRecorder()
 	h.Login(w, req)
 
@@ -87,8 +90,8 @@ func TestAudit_SuccessfulLoginIsLogged(t *testing.T) {
 	if !strings.Contains(out, "user_id=1") {
 		t.Fatalf("expected user_id in audit log, got: %s", out)
 	}
-	if !strings.Contains(out, "ip=203.0.113.9") {
-		t.Fatalf("expected X-Forwarded-For IP in audit log, got: %s", out)
+	if !strings.Contains(out, "ip=198.51.100.7") {
+		t.Fatalf("expected RemoteAddr IP in audit log, got: %s", out)
 	}
 }
 

--- a/backend/internal/auth/handler.go
+++ b/backend/internal/auth/handler.go
@@ -21,12 +21,16 @@ func NewHandler(svc *Service) *Handler {
 }
 
 // isHTTPS reports whether the request arrived over HTTPS — either directly
-// (r.TLS != nil) or via a reverse proxy that signals it with X-Forwarded-Proto.
-// This is used to set the Secure flag on cookies: hardcoding Secure:true breaks
-// plain-HTTP deployments because browsers silently discard secure cookies sent
-// over HTTP, making every session immediately invalid after login.
+// (r.TLS != nil) or via a trusted reverse proxy that signals it with
+// X-Forwarded-Proto. The header is only honoured when the deployment has
+// opted in via httpx.TrustProxy (TRUST_PROXY env var), since any client can
+// set it otherwise. This is used to set the Secure flag on cookies:
+// hardcoding Secure:true breaks plain-HTTP deployments because browsers
+// silently discard secure cookies sent over HTTP, making every session
+// immediately invalid after login.
 func isHTTPS(r *http.Request) bool {
-	return r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https"
+	return r.TLS != nil ||
+		(httpx.ProxyTrusted(r) && r.Header.Get("X-Forwarded-Proto") == "https")
 }
 
 // Login handles POST /api/auth/login.

--- a/backend/internal/auth/handler_test.go
+++ b/backend/internal/auth/handler_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/danpicton/crapnote/internal/auth"
 	"github.com/danpicton/crapnote/internal/db"
+	"github.com/danpicton/crapnote/internal/httpx"
 )
 
 func newTestHandler(t *testing.T) (*auth.Handler, *auth.Service) {
@@ -105,7 +106,7 @@ func TestHandler_Login_Cookie_NotSecure_OverHTTP(t *testing.T) {
 	}
 }
 
-func TestHandler_Login_Cookie_Secure_WhenForwardedProtoIsHTTPS(t *testing.T) {
+func TestHandler_Login_Cookie_Secure_WhenTrustedProxySignalsHTTPS(t *testing.T) {
 	h, svc := newTestHandler(t)
 	svc.SeedAdmin(t.Context(), "admin", "pass") //nolint:errcheck
 
@@ -113,11 +114,29 @@ func TestHandler_Login_Cookie_Secure_WhenForwardedProtoIsHTTPS(t *testing.T) {
 		bytes.NewBufferString(`{"username":"admin","password":"pass"}`))
 	req.Header.Set("X-Forwarded-Proto", "https") // reverse proxy signals HTTPS
 	w := httptest.NewRecorder()
-	h.Login(w, req)
+	httpx.TrustProxy()(http.HandlerFunc(h.Login)).ServeHTTP(w, req)
 
 	cookie := findCookie(t, w.Result(), "session")
 	if !cookie.Secure {
-		t.Fatal("session cookie must be Secure when behind an HTTPS reverse proxy")
+		t.Fatal("session cookie must be Secure when behind a trusted HTTPS reverse proxy")
+	}
+}
+
+func TestHandler_Login_Cookie_IgnoresForwardedProtoWithoutTrust(t *testing.T) {
+	h, svc := newTestHandler(t)
+	svc.SeedAdmin(t.Context(), "admin", "pass") //nolint:errcheck
+
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/login",
+		bytes.NewBufferString(`{"username":"admin","password":"pass"}`))
+	// Client-supplied header with no trusted proxy configured: it must not
+	// influence the Secure flag.
+	req.Header.Set("X-Forwarded-Proto", "https")
+	w := httptest.NewRecorder()
+	h.Login(w, req)
+
+	cookie := findCookie(t, w.Result(), "session")
+	if cookie.Secure {
+		t.Fatal("X-Forwarded-Proto must be ignored when no trusted proxy is configured")
 	}
 }
 

--- a/backend/internal/httpx/clientip.go
+++ b/backend/internal/httpx/clientip.go
@@ -1,0 +1,83 @@
+package httpx
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"strings"
+)
+
+// clientIPKey carries the proxy-resolved client IP in the request context.
+type clientIPKey struct{}
+
+// proxyTrustedKey marks a request as having arrived via a trusted proxy, so
+// other forwarded headers (e.g. X-Forwarded-Proto) may be honoured too.
+type proxyTrustedKey struct{}
+
+// ClientIP returns a stable key identifying the requesting client.
+//
+// By default it is the host part of r.RemoteAddr — the connection's real
+// peer. X-Forwarded-For and X-Real-IP are deliberately ignored because any
+// client can set them: trusting them lets an attacker pick their own
+// rate-limit bucket and forge the IP recorded in audit logs.
+//
+// Deployments behind a trusted reverse proxy opt in by wrapping the handler
+// chain with TrustProxy (TRUST_PROXY env var); ClientIP then returns the IP
+// that middleware resolved from the forwarded headers.
+func ClientIP(r *http.Request) string {
+	if ip, ok := r.Context().Value(clientIPKey{}).(string); ok && ip != "" {
+		return ip
+	}
+	return remoteHost(r)
+}
+
+// ProxyTrusted reports whether the request passed through the TrustProxy
+// middleware, i.e. forwarded headers set by the proxy may be honoured.
+func ProxyTrusted(r *http.Request) bool {
+	trusted, _ := r.Context().Value(proxyTrustedKey{}).(bool)
+	return trusted
+}
+
+// TrustProxy returns middleware for deployments behind exactly one trusted
+// reverse proxy. It resolves the client IP that ClientIP will return for the
+// request, using the rightmost X-Forwarded-For entry — the one appended by
+// the trusted proxy itself, which a client cannot influence. Entries further
+// left may be attacker-supplied and are ignored. X-Real-IP is used when
+// X-Forwarded-For is absent, and the RemoteAddr host remains the fallback.
+//
+// Do not enable this without a proxy in front: the headers would be
+// client-controlled and spoofable again.
+func TrustProxy() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := context.WithValue(r.Context(), clientIPKey{}, forwardedIP(r))
+			ctx = context.WithValue(ctx, proxyTrustedKey{}, true)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+// forwardedIP picks the client IP from proxy-set headers, falling back to
+// the RemoteAddr host.
+func forwardedIP(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		entries := strings.Split(xff, ",")
+		if ip := strings.TrimSpace(entries[len(entries)-1]); ip != "" {
+			return ip
+		}
+	}
+	if xri := strings.TrimSpace(r.Header.Get("X-Real-IP")); xri != "" {
+		return xri
+	}
+	return remoteHost(r)
+}
+
+// remoteHost returns the host part of r.RemoteAddr, tolerating values
+// without a port.
+func remoteHost(r *http.Request) string {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}

--- a/backend/internal/httpx/clientip_test.go
+++ b/backend/internal/httpx/clientip_test.go
@@ -1,0 +1,112 @@
+package httpx_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/danpicton/crapnote/internal/httpx"
+)
+
+func TestClientIP_Default_IgnoresForwardedHeaders(t *testing.T) {
+	tests := []struct {
+		name string
+		set  map[string]string
+	}{
+		{name: "no headers", set: nil},
+		{name: "X-Forwarded-For", set: map[string]string{"X-Forwarded-For": "203.0.113.5"}},
+		{name: "X-Forwarded-For chain", set: map[string]string{"X-Forwarded-For": "203.0.113.5, 198.51.100.2"}},
+		{name: "X-Real-IP", set: map[string]string{"X-Real-IP": "203.0.113.6"}},
+		{name: "both headers", set: map[string]string{
+			"X-Forwarded-For": "203.0.113.5",
+			"X-Real-IP":       "203.0.113.6",
+		}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, "/", nil)
+			r.RemoteAddr = "10.0.0.1:1234"
+			for k, v := range tc.set {
+				r.Header.Set(k, v)
+			}
+			if got := httpx.ClientIP(r); got != "10.0.0.1" {
+				t.Fatalf("expected RemoteAddr host 10.0.0.1, got %q", got)
+			}
+		})
+	}
+}
+
+func TestClientIP_Default_RemoteAddrWithoutPort(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.RemoteAddr = "10.0.0.1"
+	if got := httpx.ClientIP(r); got != "10.0.0.1" {
+		t.Fatalf("expected 10.0.0.1, got %q", got)
+	}
+}
+
+// trustedClientIP runs a request through the TrustProxy middleware and
+// returns what ClientIP resolved inside the handler.
+func trustedClientIP(t *testing.T, configure func(r *http.Request)) string {
+	t.Helper()
+	var got string
+	h := httpx.TrustProxy()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = httpx.ClientIP(r)
+	}))
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.RemoteAddr = "10.0.0.1:1234"
+	configure(r)
+	h.ServeHTTP(httptest.NewRecorder(), r)
+	return got
+}
+
+func TestClientIP_TrustProxy_UsesRightmostForwardedFor(t *testing.T) {
+	// The rightmost entry is the one appended by the trusted proxy itself;
+	// anything to its left is attacker-suppliable.
+	got := trustedClientIP(t, func(r *http.Request) {
+		r.Header.Set("X-Forwarded-For", "6.6.6.6, 203.0.113.5")
+	})
+	if got != "203.0.113.5" {
+		t.Fatalf("expected rightmost XFF entry 203.0.113.5, got %q", got)
+	}
+}
+
+func TestClientIP_TrustProxy_SingleForwardedForEntry(t *testing.T) {
+	got := trustedClientIP(t, func(r *http.Request) {
+		r.Header.Set("X-Forwarded-For", "203.0.113.5")
+	})
+	if got != "203.0.113.5" {
+		t.Fatalf("expected 203.0.113.5, got %q", got)
+	}
+}
+
+func TestClientIP_TrustProxy_FallsBackToXRealIP(t *testing.T) {
+	got := trustedClientIP(t, func(r *http.Request) {
+		r.Header.Set("X-Real-IP", "203.0.113.6")
+	})
+	if got != "203.0.113.6" {
+		t.Fatalf("expected X-Real-IP 203.0.113.6, got %q", got)
+	}
+}
+
+func TestClientIP_TrustProxy_NoHeaders_UsesRemoteAddr(t *testing.T) {
+	got := trustedClientIP(t, func(r *http.Request) {})
+	if got != "10.0.0.1" {
+		t.Fatalf("expected RemoteAddr host 10.0.0.1, got %q", got)
+	}
+}
+
+func TestProxyTrusted(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	if httpx.ProxyTrusted(r) {
+		t.Fatal("expected ProxyTrusted false without middleware")
+	}
+
+	var inside bool
+	h := httpx.TrustProxy()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		inside = httpx.ProxyTrusted(r)
+	}))
+	h.ServeHTTP(httptest.NewRecorder(), r)
+	if !inside {
+		t.Fatal("expected ProxyTrusted true inside TrustProxy middleware")
+	}
+}

--- a/backend/internal/httpx/pagination.go
+++ b/backend/internal/httpx/pagination.go
@@ -2,33 +2,9 @@
 package httpx
 
 import (
-	"net"
 	"net/http"
 	"strconv"
-	"strings"
 )
-
-// ClientIP returns a stable key identifying the requesting client. It prefers
-// the first entry of X-Forwarded-For (set by a trusted reverse proxy), then
-// X-Real-IP, and falls back to r.RemoteAddr. Deployments that sit directly
-// on the public internet without a proxy should be aware that XFF is
-// spoofable.
-func ClientIP(r *http.Request) string {
-	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-		if i := strings.IndexByte(xff, ','); i >= 0 {
-			return strings.TrimSpace(xff[:i])
-		}
-		return strings.TrimSpace(xff)
-	}
-	if xri := r.Header.Get("X-Real-IP"); xri != "" {
-		return strings.TrimSpace(xri)
-	}
-	host, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		return r.RemoteAddr
-	}
-	return host
-}
 
 // Defaults used by ParsePage when the caller omits query parameters.
 const (

--- a/backend/internal/ratelimit/middleware_test.go
+++ b/backend/internal/ratelimit/middleware_test.go
@@ -34,13 +34,15 @@ func TestMiddleware_Returns429WhenExhausted(t *testing.T) {
 	}
 }
 
-func TestClientIP_PrefersXForwardedFor(t *testing.T) {
+// Forwarded headers are client-controlled and must not influence the
+// rate-limit key unless the deployment opts in via httpx.TrustProxy.
+func TestClientIP_IgnoresXForwardedForByDefault(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "/", nil)
 	r.RemoteAddr = "10.0.0.1:1234"
 	r.Header.Set("X-Forwarded-For", "203.0.113.5, 10.0.0.1")
 
-	if got := ratelimit.ClientIP(r); got != "203.0.113.5" {
-		t.Fatalf("expected 203.0.113.5, got %q", got)
+	if got := ratelimit.ClientIP(r); got != "10.0.0.1" {
+		t.Fatalf("expected RemoteAddr host 10.0.0.1, got %q", got)
 	}
 }
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -11,6 +11,11 @@ services:
       - ADMIN_USERNAME=${ADMIN_USERNAME:-admin}
       - ADMIN_PASSWORD=${ADMIN_PASSWORD:-changeme}
       - SESSION_TTL_DAYS=${SESSION_TTL_DAYS:-7}
+      # Set TRUST_PROXY=1 only when a trusted reverse proxy (e.g. nginx,
+      # Traefik) sits directly in front of the app; forwarded headers
+      # (X-Forwarded-For/-Proto) are ignored otherwise because clients can
+      # spoof them to bypass per-IP rate limits and forge audit-log IPs.
+      - TRUST_PROXY=${TRUST_PROXY:-false}
       # Set LOG_FORMAT=json for structured JSON logs (ingested by Loki via Alloy).
       - LOG_FORMAT=${LOG_FORMAT:-json}
       # Set LOG_LEVEL=debug|info|warn|error (default: info).


### PR DESCRIPTION
## What & why

`httpx.ClientIP` unconditionally trusted `X-Forwarded-For` / `X-Real-IP`, so any client could rotate the header to get a fresh rate-limit bucket per request — fully bypassing the login and bearer limiters (the only online brute-force protection for admin accounts, which are exempt from automatic lockout) — and forge the IP recorded in every audit-log line. Closes #43.

## How

Trust is now a request-scoped property with a secure default:

- `httpx.ClientIP(r)` returns the connection's `RemoteAddr` host by default, ignoring forwarded headers entirely. All ~20 existing call sites (limiter keys via `ratelimit.ClientIP`, every audit-log line) pick this up unchanged.
- New `httpx.TrustProxy()` middleware, enabled by `TRUST_PROXY=1` (default off, parsed next to the limiter env config in `main.go`), resolves the client IP once per request into the context. **Documented strategy:** the deployment declares exactly one trusted reverse proxy; the rightmost `X-Forwarded-For` entry — the one appended by that proxy, which a client cannot influence — is used, with `X-Real-IP` as fallback, then `RemoteAddr`.
- `isHTTPS` (cookie `Secure` flag) honours `X-Forwarded-Proto` only when the same trust is enabled, via `httpx.ProxyTrusted(r)`.
- `ClientIP` moved from `pagination.go` to a new `clientip.go`; behaviour documented there, in the README env-var table, and in `deploy/docker-compose.yml`.

Rejected alternatives: a trusted-CIDR list with rightmost-untrusted scanning (more flexible but more config surface than this single-proxy deployment needs — the boolean documents the common nginx/Traefik case and can grow into a CIDR list later), and changing the `ClientIP` signature to take a trust flag (would thread a parameter through ~20 call sites that the context already reaches).

Three pre-existing tests asserted the old spoofable contract (XFF preferred for the limiter key, XFF in the audit log, unconditional `X-Forwarded-Proto`); they were updated to assert the new default, with trust-on variants added alongside.

Out of scope, unchanged: the in-memory limiter store, new limiters, lockout-DoS.

## Test plan

Written test-first (red → green per behaviour):

- `httpx/clientip_test.go`: trust off → `RemoteAddr` host regardless of XFF/XRI (table-driven, including header combinations); trust on → rightmost XFF entry, X-Real-IP fallback, `RemoteAddr` fallback; `ProxyTrusted` flag behaviour.
- `cmd/server/server_test.go`: `TestLogin_RateLimited_SpoofedForwardedForDoesNotBypass` — with the real mux and a tight limiter, three logins rotating `X-Forwarded-For` from one `RemoteAddr` hit 429 on the third (failed with 401 before the fix).
- `auth/handler_test.go`: spoofed `X-Forwarded-Proto: https` no longer sets the `Secure` cookie flag without trust; behind `TrustProxy` it still does.
- `auth/audit_test.go`: audit log records `RemoteAddr`, not the spoofed XFF value.

`make test-backend` (full suite, `-race`) and `make lint-backend` pass.

## Risk & rollback

Deployments currently behind a reverse proxy must set `TRUST_PROXY=1` after upgrading; until they do, rate limiting keys on the proxy's IP (one shared bucket — potentially throttling legitimate users under load), audit logs record the proxy IP, and session cookies lose the `Secure` flag (they still function over HTTPS). This is the intended secure-by-default trade-off; the env var is documented in the README, `main.go`, and docker-compose. Rollback is a revert of this commit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L1LqJJ5EdDvPxkdvzb8tMW)_