### PR TITLE
auth: harden session-revocation failure handling and consolidate it in the service

### DIFF
--- a/backend/internal/auth/admin_handler.go
+++ b/backend/internal/auth/admin_handler.go
@@ -17,21 +17,20 @@ import (
 
 // AdminHandler holds HTTP handlers for admin user-management endpoints.
 type AdminHandler struct {
-	users    *UserRepo
-	sessions *SessionRepo
-	svc      *Service // optional — required for invite endpoints
+	users *UserRepo
+	svc   *Service // always present; carries session access and (optionally) invites
 }
 
 // NewAdminHandler creates a new AdminHandler for the admin CRUD endpoints.
 // Invite-based endpoints are unavailable; use NewAdminHandlerWithInvites.
 func NewAdminHandler(users *UserRepo, sessions *SessionRepo) *AdminHandler {
-	return &AdminHandler{users: users, sessions: sessions}
+	return &AdminHandler{users: users, svc: NewService(users, sessions, 0)}
 }
 
 // NewAdminHandlerWithInvites creates a new AdminHandler with access to the
 // auth Service, enabling the invite endpoints.
 func NewAdminHandlerWithInvites(users *UserRepo, sessions *SessionRepo, svc *Service) *AdminHandler {
-	return &AdminHandler{users: users, sessions: sessions, svc: svc}
+	return &AdminHandler{users: users, svc: svc}
 }
 
 // ListUsers handles GET /api/admin/users
@@ -118,7 +117,7 @@ func (h *AdminHandler) InviteUser(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusUnauthorized, "not authenticated")
 		return
 	}
-	if h.svc == nil {
+	if h.svc.invites == nil {
 		writeError(w, http.StatusInternalServerError, "invite flow not configured")
 		return
 	}
@@ -212,7 +211,7 @@ func (h *AdminHandler) RegenerateInvite(w http.ResponseWriter, r *http.Request) 
 		writeError(w, http.StatusUnauthorized, "not authenticated")
 		return
 	}
-	if h.svc == nil {
+	if h.svc.invites == nil {
 		writeError(w, http.StatusInternalServerError, "invite flow not configured")
 		return
 	}
@@ -360,8 +359,15 @@ func (h *AdminHandler) SetUserPassword(w http.ResponseWriter, r *http.Request) {
 	h.users.Unlock(r.Context(), id) //nolint:errcheck
 
 	// Revoke the user's existing sessions: a reset usually follows a
-	// compromise, and anyone holding an old cookie must be evicted.
-	h.sessions.DeleteForUser(r.Context(), id) //nolint:errcheck
+	// compromise, and anyone holding an old cookie must be evicted. The
+	// password is already reset, so a revocation failure is logged, not fatal.
+	if err := h.svc.RevokeUserSessions(r.Context(), id); err != nil {
+		slog.Warn("audit: session revocation failed after admin password reset",
+			"event", "session_revocation_failed",
+			"target_user_id", id,
+			"error", err,
+		)
+	}
 
 	slog.Info("audit: admin password reset",
 		"event", "admin_password_reset",
@@ -400,8 +406,15 @@ func (h *AdminHandler) LockUser(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Locking is meant to cut off access immediately — delete any established
-	// sessions rather than leaving them to expire naturally.
-	h.sessions.DeleteForUser(r.Context(), id) //nolint:errcheck
+	// sessions rather than leaving them to expire naturally. The lock itself
+	// already took effect, so a revocation failure is logged, not fatal.
+	if err := h.svc.RevokeUserSessions(r.Context(), id); err != nil {
+		slog.Warn("audit: session revocation failed after admin lock",
+			"event", "session_revocation_failed",
+			"target_user_id", id,
+			"error", err,
+		)
+	}
 
 	slog.Info("audit: admin lock",
 		"event", "admin_lock",
@@ -523,10 +536,8 @@ func toUserResponse(u *User) userResponse {
 
 func (h *AdminHandler) toUserResponseWithSetup(ctx context.Context, u *User) userResponse {
 	resp := toUserResponse(u)
-	if h.svc != nil {
-		if has, err := h.svc.HasActiveInvite(ctx, u.ID); err == nil {
-			resp.PendingSetup = has
-		}
+	if has, err := h.svc.HasActiveInvite(ctx, u.ID); err == nil {
+		resp.PendingSetup = has
 	}
 	return resp
 }

--- a/backend/internal/auth/middleware.go
+++ b/backend/internal/auth/middleware.go
@@ -112,6 +112,18 @@ func (h *Handler) RequireAuth(next http.Handler) http.Handler {
 		}
 
 		user, err := h.svc.ValidateSession(r.Context(), cookie.Value)
+		if errors.Is(err, ErrAccountLocked) {
+			// The session is valid but the account has since been locked. Keep
+			// the 401 so the SPA's existing re-auth/redirect flow still fires,
+			// but use a distinct "account locked" body and audit log so the
+			// reason is not conflated with an ordinary expired session.
+			slog.Warn("audit: session rejected — account locked",
+				"event", "session_rejected_locked",
+				"ip", httpx.ClientIP(r),
+			)
+			writeError(w, http.StatusUnauthorized, "account locked")
+			return
+		}
 		if errors.Is(err, ErrNotFound) {
 			writeError(w, http.StatusUnauthorized, "session expired or invalid")
 			return

--- a/backend/internal/auth/service.go
+++ b/backend/internal/auth/service.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"golang.org/x/crypto/bcrypt"
@@ -124,6 +125,15 @@ func (s *Service) Logout(ctx context.Context, sessionID string) error {
 	return s.sessions.Delete(ctx, sessionID)
 }
 
+// RevokeUserSessions deletes every session belonging to a user. It is the
+// single choke-point for session revocation so credential-change, account-lock
+// and admin-reset flows all share one path — any future audit entry,
+// revoked-reason column or rate limit can be added here rather than in each
+// caller.
+func (s *Service) RevokeUserSessions(ctx context.Context, userID int64) error {
+	return s.sessions.DeleteForUser(ctx, userID)
+}
+
 // CreateInvite issues a one-time setup token for a user. The raw token is
 // returned to the caller and must be shown to the admin exactly once — only
 // a SHA-256 hash is persisted. Any existing invites for the user are deleted
@@ -187,8 +197,16 @@ func (s *Service) CompleteSetup(ctx context.Context, rawToken, newPassword strin
 	s.invites.Delete(ctx, inv.ID) //nolint:errcheck
 	// Setting a new credential revokes any sessions established under the old
 	// one — an admin regenerating an invite is often resetting a compromised
-	// or offboarded account.
-	s.sessions.DeleteForUser(ctx, inv.UserID) //nolint:errcheck
+	// or offboarded account. The password is already set; a revocation failure
+	// is a degraded-security outcome, not a reason to fail the setup, so we log
+	// and continue.
+	if err := s.RevokeUserSessions(ctx, inv.UserID); err != nil {
+		slog.Error("audit: session revocation failed during setup completion",
+			"event", "session_revocation_failed",
+			"user_id", inv.UserID,
+			"error", err,
+		)
+	}
 
 	return s.users.FindByID(ctx, inv.UserID)
 }
@@ -241,16 +259,28 @@ func (s *Service) ChangePassword(ctx context.Context, userID int64, newPassword 
 	// Revoke every existing session so a credential change evicts anyone
 	// holding an old cookie (including a possible attacker). The caller is
 	// logged out too; the SPA simply re-authenticates.
-	if err := s.sessions.DeleteForUser(ctx, userID); err != nil {
-		return fmt.Errorf("change password: revoke sessions: %w", err)
+	//
+	// The new password is already committed here. If revocation fails we log
+	// and still report success: telling the caller the change failed would be
+	// wrong (it didn't) and would invite a confusing retry against
+	// already-changed state. The worst case is degraded security — old sessions
+	// linger — not a failed change.
+	if err := s.RevokeUserSessions(ctx, userID); err != nil {
+		slog.Error("audit: session revocation failed after password change",
+			"event", "session_revocation_failed",
+			"user_id", userID,
+			"error", err,
+		)
 	}
 	return nil
 }
 
 // ValidateSession returns the User associated with the session if it exists
-// and has not expired. Returns ErrNotFound if missing, expired, or the user
-// is locked — a locked account's sessions stop working immediately, mirroring
-// the bearer-token path.
+// and has not expired. Returns ErrNotFound if the session is missing or
+// expired, and ErrAccountLocked if the session is valid but the user has since
+// been locked — a locked account's sessions stop working immediately, mirroring
+// the bearer-token path. Distinguishing the two lets the middleware report the
+// reason rather than conflating a lock with an ordinary expired session.
 func (s *Service) ValidateSession(ctx context.Context, sessionID string) (*User, error) {
 	sess, err := s.sessions.Find(ctx, sessionID)
 	if err != nil {
@@ -265,7 +295,7 @@ func (s *Service) ValidateSession(ctx context.Context, sessionID string) (*User,
 		return nil, err
 	}
 	if u.LockedAt != nil {
-		return nil, ErrNotFound
+		return nil, ErrAccountLocked
 	}
 	return u, nil
 }

--- a/backend/internal/auth/service_test.go
+++ b/backend/internal/auth/service_test.go
@@ -387,8 +387,8 @@ func TestService_ValidateSession_LockedUser(t *testing.T) {
 		t.Fatalf("Lock: %v", err)
 	}
 
-	if _, err := svc.ValidateSession(ctx, sess.ID); err != auth.ErrNotFound {
-		t.Fatalf("expected ErrNotFound for locked user's session, got %v", err)
+	if _, err := svc.ValidateSession(ctx, sess.ID); err != auth.ErrAccountLocked {
+		t.Fatalf("expected ErrAccountLocked for locked user's session, got %v", err)
 	}
 }
 


### PR DESCRIPTION
Addresses the four code-review findings raised against the session-revocation changes on `fix/41-session-revocation`.

## Findings fixed

**1 — `ChangePassword` returned an error after the password was already committed** (High)
The post-commit `DeleteForUser` call now routes through `RevokeUserSessions` and, on failure, logs `slog.Error` and returns `nil`. The caller is no longer told a successful change failed (which would invite a retry against already-changed state). Now consistent with `CompleteSetup`.

**2 — `ValidateSession` masked locked accounts as `ErrNotFound`** (Medium)
Locked users with a live session now get `ErrAccountLocked`. The middleware maps it to **401 "account locked"** with an audit log (`session_rejected_locked`), distinguishing a lock from an ordinary expired session while preserving the SPA's existing 401-driven re-auth/redirect flow. (Kept at 401 rather than mirroring Login's 403 so the front-end redirect still fires; the distinct body + log provide the auditability signal the review asked for.)

**3 — `CompleteSetup` silently dropped the revocation error** (Medium)
Replaced the `//nolint:errcheck` with a captured error logged via `slog.Error`, then continues (the password is already set).

**4 — duplicated raw `*SessionRepo` access** (Low)
Added `Service.RevokeUserSessions(ctx, userID)` as the single choke-point for session revocation. `ChangePassword`, `CompleteSetup`, and the admin `LockUser`/`SetUserPassword` paths all route through it. `AdminHandler` no longer holds a raw `*SessionRepo` — both constructors keep their existing signatures (the no-invites one builds a minimal `Service` internally), and the invite-availability guard now checks `h.svc.invites == nil` so the "invite flow not configured" semantics are unchanged. Admin lock/reset revocation failures are now logged (`slog.Warn`) rather than swallowed.

## Out of scope
- No status-code change to the existing Login path (still 403 "account locked").
- No new `revoked_reason` column or rate limiting — `RevokeUserSessions` is the seam where those would later live.

## Test plan
- `make test` — full backend suite passes
- `make lint` — golangci-lint reports 0 issues
- `go vet -tags sqlite_fts5 ./internal/auth/...` — clean
- Updated `TestService_ValidateSession_LockedUser` to expect `ErrAccountLocked` (the only test exercising the locked-with-live-session branch; admin/auto-lockout tests delete the session first and still correctly expect `ErrNotFound`).

https://claude.ai/code/session_01XxWgSZnuXHBJL6Qehk6YyB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XxWgSZnuXHBJL6Qehk6YyB)_