### PR TITLE
[security] Fix all medium+ security issues: deploy credentials, offline data leak, link XSS, login timing, lockout DoS, dep CVEs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,21 +3,30 @@ BINARY := /tmp/crapnote-server
 # Env vars (override from the shell, e.g. ADMIN_PASSWORD=hunter2 make run)
 # PUBLIC_* vars are read by Vite at build time, so they're exported to all
 # child processes — including the frontend build invoked via backend/Makefile.
+# ADMIN_PASSWORD has no default on purpose: the initial admin is seeded into
+# the database on first run, so `make run` refuses to start without one rather
+# than silently creating a well-known admin/admin login.
 ADMIN_USERNAME          ?= admin
-ADMIN_PASSWORD          ?= admin
 PUBLIC_SYNC_INTERVAL_MS ?= 20000
 export PUBLIC_SYNC_INTERVAL_MS
 
-.PHONY: build run test-e2e test-backend test-frontend ci ci-full \
-        lint-backend lint-frontend check-frontend
+.PHONY: build run require-admin-password test-e2e test-backend test-frontend \
+        ci ci-full lint-backend lint-frontend check-frontend
 
 ## build: build frontend + backend (delegates to backend/Makefile)
 build:
 	$(MAKE) -C backend build-prod
 	cp backend/server $(BINARY)
 
+require-admin-password:
+	@test -n "$(ADMIN_PASSWORD)" || { \
+		echo "ERROR: ADMIN_PASSWORD is not set. The initial admin is seeded"; \
+		echo "into the database on first run — set a strong password, e.g.:"; \
+		echo "  ADMIN_PASSWORD='...' make run"; \
+		exit 1; }
+
 ## run: build then run the embedded binary (production path)
-run: build
+run: require-admin-password build
 	ADMIN_USERNAME=$(ADMIN_USERNAME) \
 	ADMIN_PASSWORD=$(ADMIN_PASSWORD) \
 	$(BINARY)

--- a/README.md
+++ b/README.md
@@ -95,8 +95,10 @@ npm run lint      # eslint
 | `PORT` | `8080` | HTTP listen port |
 | `DATABASE_PATH` | `notes.db` | Path to SQLite file |
 | `ADMIN_USERNAME` | — | Seeded on first run if no users exist |
-| `ADMIN_PASSWORD` | — | Seeded on first run if no users exist |
+| `ADMIN_PASSWORD` | — | Seeded on first run if no users exist. **Set a strong value before first run** — the seeded credential persists in the database, and the deploy tooling (`deploy/docker-compose.yml`, `make run`) refuses to start without it |
 | `SESSION_TTL_DAYS` | `7` | Session lifetime in days; refreshed on activity |
+| `MAX_FAILED_LOGIN_ATTEMPTS` | `5` | Consecutive failed passwords before a non-admin account is auto-locked |
+| `LOCKOUT_COOLDOWN_MINUTES` | `15` | How long an automatic lockout lasts before clearing itself; manual admin locks never expire |
 | `LOGIN_RATE_PER_MINUTE` | `5` | Per-IP rate limit on `POST /api/auth/login` |
 | `LOGIN_RATE_BURST` | `5` | Burst allowance for the login limiter |
 | `BEARER_RATE_PER_MINUTE` | `600` | Per-IP rate limit applied only to requests carrying an `Authorization` header |
@@ -255,15 +257,17 @@ Multi-stage build: Node (frontend) → Go/gcc (backend + CGO + go:embed) → `di
 docker build -t crapnote .
 docker run -p 8080:8080 \
   -e ADMIN_USERNAME=admin \
-  -e ADMIN_PASSWORD=changeme \
+  -e ADMIN_PASSWORD='<strong password — seeded into the DB on first run>' \
   -v $(pwd)/data:/data \
   crapnote
 ```
 
-For local dev with observability stack (Prometheus, Loki, Grafana):
+For local dev with observability stack (Prometheus, Loki, Grafana).
+`ADMIN_PASSWORD` (app admin) and `GRAFANA_PASSWORD` (Grafana admin) must be
+set — compose fails closed rather than shipping default credentials:
 
 ```bash
-cd deploy && docker compose up
+cd deploy && ADMIN_PASSWORD='...' GRAFANA_PASSWORD='...' docker compose up
 ```
 
 ---

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -51,6 +51,22 @@ func main() {
 		inviteRepo,
 		time.Duration(ttlDays)*24*time.Hour,
 	)
+	// Automatic-lockout policy: after MAX_FAILED_LOGIN_ATTEMPTS consecutive
+	// failures (default 5) a non-admin account is locked for
+	// LOCKOUT_COOLDOWN_MINUTES (default 15), then unlocks itself. This keeps
+	// brute-force protection without letting three bad requests per username
+	// create a standing, admin-only-recoverable outage. Manual admin locks
+	// remain indefinite.
+	lockoutAttempts := auth.DefaultMaxFailedLoginAttempts
+	lockoutCooldown := auth.DefaultLockoutCooldown
+	if v, err := strconv.Atoi(os.Getenv("MAX_FAILED_LOGIN_ATTEMPTS")); err == nil && v > 0 {
+		lockoutAttempts = v
+	}
+	if v, err := strconv.Atoi(os.Getenv("LOCKOUT_COOLDOWN_MINUTES")); err == nil && v > 0 {
+		lockoutCooldown = time.Duration(v) * time.Minute
+	}
+	authSvc.SetLockoutPolicy(lockoutAttempts, lockoutCooldown)
+
 	authHandler := auth.NewHandler(authSvc)
 	adminHandler := auth.NewAdminHandlerWithInvites(userRepo, sessRepo, authSvc)
 	setupHandler := auth.NewSetupHandler(authSvc)

--- a/backend/internal/auth/admin_handler.go
+++ b/backend/internal/auth/admin_handler.go
@@ -525,10 +525,10 @@ func toUserResponse(u *User) userResponse {
 		Username:         u.Username,
 		IsAdmin:          u.IsAdmin,
 		APITokensEnabled: u.APITokensEnabled,
-		Locked:           u.LockedAt != nil,
+		Locked:           u.Locked(time.Now()),
 		CreatedAt:        u.CreatedAt.Format("2006-01-02T15:04:05Z"),
 	}
-	if u.LockedAt != nil {
+	if u.Locked(time.Now()) {
 		resp.LockedAt = u.LockedAt.Format("2006-01-02T15:04:05Z")
 	}
 	return resp

--- a/backend/internal/auth/dummyhash_test.go
+++ b/backend/internal/auth/dummyhash_test.go
@@ -1,0 +1,29 @@
+package auth
+
+import (
+	"errors"
+	"testing"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+// The timing-equalisation placeholder must be a real cost-12 bcrypt hash. An
+// invalid literal (like the old "$2a$12$dummy") fails during hash parsing and
+// returns in microseconds instead of doing key-derivation work, which lets an
+// attacker enumerate usernames by response time (issue #55).
+func TestDummyPasswordHash_IsValidCost12(t *testing.T) {
+	cost, err := bcrypt.Cost(dummyPasswordHash)
+	if err != nil {
+		t.Fatalf("dummyPasswordHash does not parse as a bcrypt hash: %v", err)
+	}
+	if cost != bcryptCost {
+		t.Fatalf("dummyPasswordHash cost = %d, want %d", cost, bcryptCost)
+	}
+
+	// A comparison must reach the hashing step and report a mismatch — not a
+	// parse failure like ErrHashTooShort.
+	err = bcrypt.CompareHashAndPassword(dummyPasswordHash, []byte("any password"))
+	if !errors.Is(err, bcrypt.ErrMismatchedHashAndPassword) {
+		t.Fatalf("expected ErrMismatchedHashAndPassword, got %v", err)
+	}
+}

--- a/backend/internal/auth/handler_test.go
+++ b/backend/internal/auth/handler_test.go
@@ -188,8 +188,8 @@ func TestHandler_Login_LockedAccount_Returns403(t *testing.T) {
 	h, svc, users := newTestHandlerWithRepo(t)
 	createUser(t, users, "alice", "correctpass", false)
 
-	// Three failed attempts → locked.
-	for i := 0; i < 3; i++ {
+	// Enough failed attempts → locked.
+	for i := 0; i < auth.DefaultMaxFailedLoginAttempts; i++ {
 		svc.Login(t.Context(), "alice", "wrong") //nolint:errcheck
 	}
 

--- a/backend/internal/auth/model.go
+++ b/backend/internal/auth/model.go
@@ -11,7 +11,23 @@ type User struct {
 	APITokensEnabled    bool
 	FailedLoginAttempts int
 	LockedAt            *time.Time
+	LockedUntil         *time.Time
 	CreatedAt           time.Time
+}
+
+// Locked reports whether the account's lock is active at the given time.
+// Manual admin locks have no LockedUntil and are indefinite; automatic
+// failed-login locks carry a LockedUntil and lapse once it passes. Callers
+// that can write (e.g. Login) should also clear a lapsed lock via
+// UserRepo.Unlock so the stored state catches up.
+func (u *User) Locked(now time.Time) bool {
+	if u.LockedAt == nil {
+		return false
+	}
+	if u.LockedUntil != nil && !now.Before(*u.LockedUntil) {
+		return false
+	}
+	return true
 }
 
 // Session represents an authenticated session stored in the database.

--- a/backend/internal/auth/repository.go
+++ b/backend/internal/auth/repository.go
@@ -51,11 +51,11 @@ func (r *UserRepo) Create(ctx context.Context, username, passwordHash string, is
 func (r *UserRepo) FindByUsername(ctx context.Context, username string) (*User, error) {
 	u := &User{}
 	var isAdmin, apiTokensEnabled int
-	var lockedAt sql.NullTime
+	var lockedAt, lockedUntil sql.NullTime
 	err := r.db.QueryRowContext(ctx,
-		`SELECT id, username, password_hash, is_admin, api_tokens_enabled, failed_login_attempts, locked_at, created_at FROM users WHERE username=?`,
+		`SELECT id, username, password_hash, is_admin, api_tokens_enabled, failed_login_attempts, locked_at, locked_until, created_at FROM users WHERE username=?`,
 		username,
-	).Scan(&u.ID, &u.Username, &u.PasswordHash, &isAdmin, &apiTokensEnabled, &u.FailedLoginAttempts, &lockedAt, &u.CreatedAt)
+	).Scan(&u.ID, &u.Username, &u.PasswordHash, &isAdmin, &apiTokensEnabled, &u.FailedLoginAttempts, &lockedAt, &lockedUntil, &u.CreatedAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrNotFound
 	}
@@ -68,6 +68,10 @@ func (r *UserRepo) FindByUsername(ctx context.Context, username string) (*User, 
 		t := lockedAt.Time
 		u.LockedAt = &t
 	}
+	if lockedUntil.Valid {
+		t := lockedUntil.Time
+		u.LockedUntil = &t
+	}
 	return u, nil
 }
 
@@ -75,11 +79,11 @@ func (r *UserRepo) FindByUsername(ctx context.Context, username string) (*User, 
 func (r *UserRepo) FindByID(ctx context.Context, id int64) (*User, error) {
 	u := &User{}
 	var isAdmin, apiTokensEnabled int
-	var lockedAt sql.NullTime
+	var lockedAt, lockedUntil sql.NullTime
 	err := r.db.QueryRowContext(ctx,
-		`SELECT id, username, password_hash, is_admin, api_tokens_enabled, failed_login_attempts, locked_at, created_at FROM users WHERE id=?`,
+		`SELECT id, username, password_hash, is_admin, api_tokens_enabled, failed_login_attempts, locked_at, locked_until, created_at FROM users WHERE id=?`,
 		id,
-	).Scan(&u.ID, &u.Username, &u.PasswordHash, &isAdmin, &apiTokensEnabled, &u.FailedLoginAttempts, &lockedAt, &u.CreatedAt)
+	).Scan(&u.ID, &u.Username, &u.PasswordHash, &isAdmin, &apiTokensEnabled, &u.FailedLoginAttempts, &lockedAt, &lockedUntil, &u.CreatedAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrNotFound
 	}
@@ -91,6 +95,10 @@ func (r *UserRepo) FindByID(ctx context.Context, id int64) (*User, error) {
 	if lockedAt.Valid {
 		t := lockedAt.Time
 		u.LockedAt = &t
+	}
+	if lockedUntil.Valid {
+		t := lockedUntil.Time
+		u.LockedUntil = &t
 	}
 	return u, nil
 }
@@ -126,12 +134,28 @@ func (r *UserRepo) ResetFailedAttempts(ctx context.Context, id int64) error {
 	return nil
 }
 
-// Lock marks the account as locked (sets locked_at to now).
+// Lock marks the account as locked indefinitely (manual admin lock — sets
+// locked_at to now and clears any auto-lock expiry).
 func (r *UserRepo) Lock(ctx context.Context, id int64) error {
 	res, err := r.db.ExecContext(ctx,
-		`UPDATE users SET locked_at = CURRENT_TIMESTAMP WHERE id=?`, id)
+		`UPDATE users SET locked_at = CURRENT_TIMESTAMP, locked_until = NULL WHERE id=?`, id)
 	if err != nil {
 		return fmt.Errorf("lock user: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// LockUntil marks the account as locked with an automatic expiry (failed-login
+// cool-down). The lock lapses once `until` passes; see User.Locked.
+func (r *UserRepo) LockUntil(ctx context.Context, id int64, until time.Time) error {
+	res, err := r.db.ExecContext(ctx,
+		`UPDATE users SET locked_at = CURRENT_TIMESTAMP, locked_until = ? WHERE id=?`, until.UTC(), id)
+	if err != nil {
+		return fmt.Errorf("lock user until: %w", err)
 	}
 	n, _ := res.RowsAffected()
 	if n == 0 {
@@ -143,7 +167,7 @@ func (r *UserRepo) Lock(ctx context.Context, id int64) error {
 // Unlock clears the lock and resets the failed attempts counter.
 func (r *UserRepo) Unlock(ctx context.Context, id int64) error {
 	res, err := r.db.ExecContext(ctx,
-		`UPDATE users SET locked_at = NULL, failed_login_attempts = 0 WHERE id=?`, id)
+		`UPDATE users SET locked_at = NULL, locked_until = NULL, failed_login_attempts = 0 WHERE id=?`, id)
 	if err != nil {
 		return fmt.Errorf("unlock user: %w", err)
 	}
@@ -206,7 +230,7 @@ func (r *UserRepo) Delete(ctx context.Context, id int64) error {
 
 // List returns users ordered by created_at. limit <= 0 returns all users.
 func (r *UserRepo) List(ctx context.Context, limit, offset int) ([]*User, error) {
-	query := `SELECT id, username, password_hash, is_admin, api_tokens_enabled, failed_login_attempts, locked_at, created_at FROM users ORDER BY created_at`
+	query := `SELECT id, username, password_hash, is_admin, api_tokens_enabled, failed_login_attempts, locked_at, locked_until, created_at FROM users ORDER BY created_at`
 	var args []any
 	if limit > 0 {
 		query += ` LIMIT ? OFFSET ?`
@@ -222,8 +246,8 @@ func (r *UserRepo) List(ctx context.Context, limit, offset int) ([]*User, error)
 	for rows.Next() {
 		u := &User{}
 		var isAdmin, apiTokensEnabled int
-		var lockedAt sql.NullTime
-		if err := rows.Scan(&u.ID, &u.Username, &u.PasswordHash, &isAdmin, &apiTokensEnabled, &u.FailedLoginAttempts, &lockedAt, &u.CreatedAt); err != nil {
+		var lockedAt, lockedUntil sql.NullTime
+		if err := rows.Scan(&u.ID, &u.Username, &u.PasswordHash, &isAdmin, &apiTokensEnabled, &u.FailedLoginAttempts, &lockedAt, &lockedUntil, &u.CreatedAt); err != nil {
 			return nil, err
 		}
 		u.IsAdmin = isAdmin != 0
@@ -231,6 +255,10 @@ func (r *UserRepo) List(ctx context.Context, limit, offset int) ([]*User, error)
 		if lockedAt.Valid {
 			t := lockedAt.Time
 			u.LockedAt = &t
+		}
+		if lockedUntil.Valid {
+			t := lockedUntil.Time
+			u.LockedUntil = &t
 		}
 		users = append(users, u)
 	}

--- a/backend/internal/auth/service.go
+++ b/backend/internal/auth/service.go
@@ -15,9 +15,23 @@ import (
 
 const bcryptCost = 12
 
-// MaxFailedLoginAttempts is the number of consecutive failed password attempts
-// after which a non-admin account is locked.
-const MaxFailedLoginAttempts = 3
+// DefaultMaxFailedLoginAttempts is the default number of consecutive failed
+// password attempts after which a non-admin account is auto-locked. Tunable
+// via Service.SetLockoutPolicy (MAX_FAILED_LOGIN_ATTEMPTS env var in main).
+const DefaultMaxFailedLoginAttempts = 5
+
+// DefaultLockoutCooldown is how long an automatic failed-login lock lasts
+// before it lapses on its own. Manual admin locks never lapse. Tunable via
+// Service.SetLockoutPolicy (LOCKOUT_COOLDOWN_MINUTES env var in main).
+const DefaultLockoutCooldown = 15 * time.Minute
+
+// dummyPasswordHash is a syntactically valid, precomputed cost-12 bcrypt hash
+// of a throwaway placeholder string. Login compares against it on the
+// unknown-user and locked-user branches so those paths perform the same
+// key-derivation work as a real password check — an invalid hash literal
+// would fail during parsing and return in microseconds, letting an attacker
+// enumerate usernames by response time.
+var dummyPasswordHash = []byte("$2a$12$.6Huiifna4soSOzjPCMbPuaSQLzCYttSFwT5OAZXD6c1sVEdDv1IC")
 
 // ErrInvalidCredentials is returned when username/password don't match.
 var ErrInvalidCredentials = errors.New("invalid credentials")
@@ -32,22 +46,42 @@ var ErrInviteInvalid = errors.New("invite invalid or expired")
 
 // Service implements authentication business logic.
 type Service struct {
-	users    *UserRepo
-	sessions *SessionRepo
-	invites  *InviteRepo
-	ttl      time.Duration
+	users             *UserRepo
+	sessions          *SessionRepo
+	invites           *InviteRepo
+	ttl               time.Duration
+	maxFailedAttempts int
+	lockoutCooldown   time.Duration
 }
 
 // NewService creates a new auth Service without invite support (legacy
 // callers). CreateInvite and CompleteSetup will return an error if invoked.
 func NewService(users *UserRepo, sessions *SessionRepo, sessionTTL time.Duration) *Service {
-	return &Service{users: users, sessions: sessions, ttl: sessionTTL}
+	return &Service{
+		users: users, sessions: sessions, ttl: sessionTTL,
+		maxFailedAttempts: DefaultMaxFailedLoginAttempts,
+		lockoutCooldown:   DefaultLockoutCooldown,
+	}
 }
 
 // NewServiceWithInvites creates a new auth Service that supports the admin
 // invite / first-login password setup flow.
 func NewServiceWithInvites(users *UserRepo, sessions *SessionRepo, invites *InviteRepo, sessionTTL time.Duration) *Service {
-	return &Service{users: users, sessions: sessions, invites: invites, ttl: sessionTTL}
+	return &Service{
+		users: users, sessions: sessions, invites: invites, ttl: sessionTTL,
+		maxFailedAttempts: DefaultMaxFailedLoginAttempts,
+		lockoutCooldown:   DefaultLockoutCooldown,
+	}
+}
+
+// SetLockoutPolicy overrides the automatic-lockout tuning. maxAttempts < 1
+// keeps the current threshold; cooldown <= 0 makes automatic locks indefinite
+// (pre-cool-down behaviour, admin unlock required).
+func (s *Service) SetLockoutPolicy(maxAttempts int, cooldown time.Duration) {
+	if maxAttempts >= 1 {
+		s.maxFailedAttempts = maxAttempts
+	}
+	s.lockoutCooldown = cooldown
 }
 
 // SeedAdmin creates the initial admin user if no users exist yet.
@@ -74,13 +108,14 @@ func (s *Service) SeedAdmin(ctx context.Context, username, password string) erro
 
 // Login verifies credentials and returns a new Session on success.
 // Returns ErrInvalidCredentials for unknown users or wrong passwords, and
-// ErrAccountLocked for users whose accounts have been locked (either by an
-// admin or by exceeding MaxFailedLoginAttempts).
+// ErrAccountLocked for users whose accounts are locked (either by an admin,
+// or automatically after too many failed attempts — automatic locks lapse
+// after the configured cool-down).
 func (s *Service) Login(ctx context.Context, username, password string) (*Session, error) {
 	u, err := s.users.FindByUsername(ctx, username)
 	if errors.Is(err, ErrNotFound) {
 		// Perform a dummy comparison to avoid timing attacks.
-		bcrypt.CompareHashAndPassword([]byte("$2a$12$dummy"), []byte(password)) //nolint:errcheck
+		bcrypt.CompareHashAndPassword(dummyPasswordHash, []byte(password)) //nolint:errcheck
 		return nil, ErrInvalidCredentials
 	}
 	if err != nil {
@@ -88,9 +123,16 @@ func (s *Service) Login(ctx context.Context, username, password string) (*Sessio
 	}
 
 	if u.LockedAt != nil {
-		// Still perform a dummy comparison to keep timing uniform.
-		bcrypt.CompareHashAndPassword([]byte("$2a$12$dummy"), []byte(password)) //nolint:errcheck
-		return nil, ErrAccountLocked
+		if u.Locked(time.Now()) {
+			// Still perform a dummy comparison to keep timing uniform.
+			bcrypt.CompareHashAndPassword(dummyPasswordHash, []byte(password)) //nolint:errcheck
+			return nil, ErrAccountLocked
+		}
+		// Automatic lock whose cool-down has lapsed — clear it (also resets
+		// the failed-attempt counter) and let this attempt proceed normally.
+		if err := s.users.Unlock(ctx, u.ID); err != nil {
+			return nil, fmt.Errorf("login: clear lapsed lock: %w", err)
+		}
 	}
 
 	if err := bcrypt.CompareHashAndPassword([]byte(u.PasswordHash), []byte(password)); err != nil {
@@ -99,11 +141,16 @@ func (s *Service) Login(ctx context.Context, username, password string) (*Sessio
 		// able to unlock anyone.
 		if !u.IsAdmin {
 			n, incErr := s.users.IncrementFailedAttempts(ctx, u.ID)
-			if incErr == nil && n >= MaxFailedLoginAttempts {
-				s.users.Lock(ctx, u.ID) //nolint:errcheck
+			if incErr == nil && n >= s.maxFailedAttempts {
+				if s.lockoutCooldown > 0 {
+					s.users.LockUntil(ctx, u.ID, time.Now().Add(s.lockoutCooldown)) //nolint:errcheck
+				} else {
+					s.users.Lock(ctx, u.ID) //nolint:errcheck
+				}
 				// Lockout implies the account may be under attack — evict any
-				// established sessions rather than leaving them live.
-				s.sessions.DeleteForUser(ctx, u.ID) //nolint:errcheck
+				// established sessions rather than leaving them live, via the
+				// revocation choke-point so audit hooks cover this path too.
+				s.RevokeUserSessions(ctx, u.ID) //nolint:errcheck
 			}
 		}
 		return nil, ErrInvalidCredentials
@@ -294,7 +341,7 @@ func (s *Service) ValidateSession(ctx context.Context, sessionID string) (*User,
 	if err != nil {
 		return nil, err
 	}
-	if u.LockedAt != nil {
+	if u.Locked(time.Now()) {
 		return nil, ErrAccountLocked
 	}
 	return u, nil

--- a/backend/internal/auth/service_test.go
+++ b/backend/internal/auth/service_test.go
@@ -121,10 +121,11 @@ func TestService_Logout(t *testing.T) {
 	}
 }
 
-func TestService_Login_NonAdmin_LocksAfterThreeFailures(t *testing.T) {
+func TestService_Login_NonAdmin_LocksAfterMaxFailures(t *testing.T) {
 	svc, users := newTestServiceWithRepo(t)
 	ctx := context.Background()
 	createUser(t, users, "alice", "correctpass", false)
+	svc.SetLockoutPolicy(3, time.Hour)
 
 	for i := 0; i < 2; i++ {
 		if _, err := svc.Login(ctx, "alice", "wrong"); err != auth.ErrInvalidCredentials {
@@ -145,6 +146,54 @@ func TestService_Login_NonAdmin_LocksAfterThreeFailures(t *testing.T) {
 	got, _ := users.FindByID(ctx, 1)
 	if got.LockedAt == nil {
 		t.Fatal("expected account to be locked in storage")
+	}
+	if got.LockedUntil == nil {
+		t.Fatal("automatic lock must carry an expiry (locked_until)")
+	}
+}
+
+func TestService_Login_AutoLock_ExpiresAfterCooldown(t *testing.T) {
+	svc, users := newTestServiceWithRepo(t)
+	ctx := context.Background()
+	u := createUser(t, users, "alice", "correctpass", false)
+	svc.SetLockoutPolicy(3, 30*time.Millisecond)
+
+	for i := 0; i < 3; i++ {
+		svc.Login(ctx, "alice", "wrong") //nolint:errcheck
+	}
+	if _, err := svc.Login(ctx, "alice", "correctpass"); err != auth.ErrAccountLocked {
+		t.Fatalf("expected ErrAccountLocked during cool-down, got %v", err)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	// After the cool-down the correct password must work without admin action.
+	if _, err := svc.Login(ctx, "alice", "correctpass"); err != nil {
+		t.Fatalf("login after cool-down: %v", err)
+	}
+	got, _ := users.FindByID(ctx, u.ID)
+	if got.LockedAt != nil || got.LockedUntil != nil {
+		t.Fatal("expected lapsed auto-lock to be cleared in storage")
+	}
+	if got.FailedLoginAttempts != 0 {
+		t.Fatalf("expected failed-attempt counter reset, got %d", got.FailedLoginAttempts)
+	}
+}
+
+func TestService_Login_ManualLock_DoesNotExpire(t *testing.T) {
+	svc, users := newTestServiceWithRepo(t)
+	ctx := context.Background()
+	u := createUser(t, users, "alice", "correctpass", false)
+	svc.SetLockoutPolicy(3, 10*time.Millisecond)
+
+	// Manual admin lock (no expiry).
+	if err := users.Lock(ctx, u.ID); err != nil {
+		t.Fatalf("Lock: %v", err)
+	}
+	time.Sleep(30 * time.Millisecond)
+
+	if _, err := svc.Login(ctx, "alice", "correctpass"); err != auth.ErrAccountLocked {
+		t.Fatalf("manual lock must not auto-expire, got %v", err)
 	}
 }
 
@@ -402,7 +451,7 @@ func TestService_Login_AutoLockout_RevokesExistingSessions(t *testing.T) {
 		t.Fatalf("Login: %v", err)
 	}
 
-	for i := 0; i < auth.MaxFailedLoginAttempts; i++ {
+	for i := 0; i < auth.DefaultMaxFailedLoginAttempts; i++ {
 		svc.Login(ctx, "alice", "wrong") //nolint:errcheck
 	}
 	got, _ := users.FindByID(ctx, u.ID)

--- a/backend/internal/db/migrations/000011_lockout_expiry.down.sql
+++ b/backend/internal/db/migrations/000011_lockout_expiry.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users DROP COLUMN locked_until;

--- a/backend/internal/db/migrations/000011_lockout_expiry.up.sql
+++ b/backend/internal/db/migrations/000011_lockout_expiry.up.sql
@@ -1,0 +1,3 @@
+-- Automatic (failed-login) lockouts now expire: locked_until holds the moment
+-- the lock lapses. Manual admin locks leave it NULL, meaning indefinite.
+ALTER TABLE users ADD COLUMN locked_until DATETIME;

--- a/backend/internal/tokens/service.go
+++ b/backend/internal/tokens/service.go
@@ -150,8 +150,9 @@ func (s *Service) Verify(ctx context.Context, raw string) (*VerifiedToken, error
 		return nil, ErrInvalidToken
 	}
 
-	// A locked account's tokens stop working until the account is unlocked.
-	if user.LockedAt != nil {
+	// A locked account's tokens stop working while the lock is active (a
+	// lapsed automatic cool-down no longer counts as locked).
+	if user.Locked(time.Now()) {
 		return nil, ErrInvalidToken
 	}
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -9,7 +9,10 @@ services:
       - PORT=8080
       - DATABASE_PATH=/data/notes.db
       - ADMIN_USERNAME=${ADMIN_USERNAME:-admin}
-      - ADMIN_PASSWORD=${ADMIN_PASSWORD:-changeme}
+      # No default on purpose: the initial admin is seeded into the database
+      # on first run, so a weak fallback would persist even after the operator
+      # later sets a real password. Compose fails fast when it is unset.
+      - ADMIN_PASSWORD=${ADMIN_PASSWORD:?set a strong admin password (seeded into the app on first run)}
       - SESSION_TTL_DAYS=${SESSION_TTL_DAYS:-7}
       # Set TRUST_PROXY=1 only when a trusted reverse proxy (e.g. nginx,
       # Traefik) sits directly in front of the app; forwarded headers
@@ -85,7 +88,9 @@ services:
       - "3000:3000"
     environment:
       - GF_SECURITY_ADMIN_USER=${GRAFANA_USER:-admin}
-      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD:-admin}
+      # No admin/admin fallback: Grafana can read every Loki log line and
+      # Prometheus metric for the stack, so compose fails fast when unset.
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD:?set a Grafana admin password}
       - GF_AUTH_ANONYMOUS_ENABLED=false
     volumes:
       - grafana-data:/var/lib/grafana

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -6,17 +6,17 @@
     "": {
       "name": "crapnote-e2e",
       "devDependencies": {
-        "@playwright/test": "1.49.1"
+        "@playwright/test": "^1.61.1"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.49.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.1.tgz",
-      "integrity": "sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.49.1"
+        "playwright": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -41,13 +41,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.49.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.1.tgz",
-      "integrity": "sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.49.1"
+        "playwright-core": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -60,9 +60,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.49.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.1.tgz",
-      "integrity": "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -7,6 +7,6 @@
     "test:headed": "playwright test --headed"
   },
   "devDependencies": {
-    "@playwright/test": "1.49.1"
+    "@playwright/test": "^1.61.1"
   }
 }

--- a/e2e/tests/notes.spec.ts
+++ b/e2e/tests/notes.spec.ts
@@ -10,10 +10,22 @@ async function login(page: Page) {
 
 /** Create a note, set the title, and wait for autosave to persist it. */
 async function createNote(page: Page, title: string) {
-  await page.getByLabel('New note').click();
-  const titleInput = page.getByPlaceholder(/note title/i);
-  // Register the response listener BEFORE fill() so a fast autosave can't
+  // Register the response listener BEFORE clicking so a fast create can't
   // arrive before the listener is attached (race condition).
+  const created = page.waitForResponse(
+    (r) => r.url().includes('/api/notes') && r.request().method() === 'POST',
+  );
+  await page.getByLabel('New note').click();
+  await created;
+
+  const titleInput = page.getByPlaceholder(/note title/i);
+  // Wait for the editor to re-bind to the NEW note before typing. A fresh
+  // note's title defaults to a timestamp ("2026-07-04 …"); until that value
+  // appears, the visible title input still belongs to the previously
+  // selected note and fill() would rename that one instead (autosave
+  // captures the selected note id at input time).
+  await expect(titleInput).toHaveValue(/^\d{4}-\d{2}-\d{2}/);
+
   // fill() replaces any existing text atomically and fires Svelte's input
   // binding without needing keystroke delays or an explicit waitForTimeout.
   const saved = page.waitForResponse(

--- a/e2e/tests/offline-logout.spec.ts
+++ b/e2e/tests/offline-logout.spec.ts
@@ -1,0 +1,95 @@
+import { test, expect, type Page } from '@playwright/test';
+
+async function login(page: Page) {
+  await page.goto('/login');
+  await page.getByRole('textbox', { name: /username/i }).fill('admin');
+  await page.getByRole('textbox', { name: /password/i }).fill('admin123');
+  await page.getByRole('button', { name: /log in/i }).click();
+  await expect(page).toHaveURL('/');
+}
+
+/** Reads the local authenticated footprint: cached /api responses in Cache
+ * Storage and the number of notes in the offline IndexedDB store. */
+async function localFootprint(page: Page) {
+  return page.evaluate(async () => {
+    let cachedApiEntries = 0;
+    const cacheKeys = await caches.keys();
+    for (const key of cacheKeys) {
+      const cache = await caches.open(key);
+      const requests = await cache.keys();
+      cachedApiEntries += requests.filter((r) => new URL(r.url).pathname.startsWith('/api/')).length;
+    }
+
+    // Count notes in the offline DB, treating a missing DB/store as zero.
+    const offlineNotes = await new Promise<number>((resolve) => {
+      const dbs = indexedDB.databases ? indexedDB.databases() : Promise.resolve([]);
+      dbs
+        .then((list) => {
+          if (!list.some((d) => d.name === 'crapnote-notes-v2')) {
+            resolve(0);
+            return;
+          }
+          const req = indexedDB.open('crapnote-notes-v2');
+          req.onsuccess = () => {
+            const db = req.result;
+            if (!db.objectStoreNames.contains('notes')) {
+              db.close();
+              resolve(0);
+              return;
+            }
+            const count = db.transaction('notes', 'readonly').objectStore('notes').count();
+            count.onsuccess = () => {
+              db.close();
+              resolve(count.result);
+            };
+            count.onerror = () => {
+              db.close();
+              resolve(0);
+            };
+          };
+          req.onerror = () => resolve(0);
+        })
+        .catch(() => resolve(0));
+    });
+
+    return { cachedApiEntries, offlineNotes };
+  });
+}
+
+test.describe('Offline data is cleared at logout', () => {
+  test('cached API responses and the offline note store do not survive logout', async ({ page }) => {
+    await login(page);
+
+    // Create a note so there is something to cache offline.
+    await page.getByLabel('New note').click();
+    const titleInput = page.getByPlaceholder(/note title/i);
+    const saved = page.waitForResponse(
+      (r) => r.url().includes('/api/notes') && r.request().method() === 'PUT',
+    );
+    await titleInput.fill('Private note');
+    await saved;
+
+    // Wait for the service worker to control the page, then reload so the
+    // /api fetches flow through it and get cached, and the notes list load
+    // populates the offline IndexedDB store.
+    await page.evaluate(() => navigator.serviceWorker.ready);
+    await page.reload();
+    await expect(page.getByText('Private note').first()).toBeVisible();
+
+    await expect
+      .poll(async () => (await localFootprint(page)).offlineNotes, {
+        message: 'offline store should be populated while logged in',
+      })
+      .toBeGreaterThan(0);
+
+    // Log out and verify nothing authenticated is left behind.
+    await page.getByRole('button', { name: /log out/i }).click();
+    await expect(page).toHaveURL(/\/login/);
+
+    await expect
+      .poll(async () => localFootprint(page), {
+        message: 'cached /api responses and offline notes should be wiped at logout',
+      })
+      .toEqual({ cachedApiEntries: 0, offlineNotes: 0 });
+  });
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1735,9 +1735,9 @@
       "license": "MIT"
     },
     "node_modules/@sveltejs/acorn-typescript": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.9.tgz",
-      "integrity": "sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.10.tgz",
+      "integrity": "sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA==",
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^8.9.0"
@@ -1754,18 +1754,18 @@
       }
     },
     "node_modules/@sveltejs/kit": {
-      "version": "2.57.1",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.57.1.tgz",
-      "integrity": "sha512-VRdSbB96cI1EnRh09CqmnQqP/YJvET5buj8S6k7CxaJqBJD4bw4fRKDjcarAj/eX9k2eHifQfDH8NtOh+ZxxPw==",
+      "version": "2.69.1",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.69.1.tgz",
+      "integrity": "sha512-+nz8Fx/cElzb2ZPHC+6Ll3y3NEVIe4Na75PeplLlyTmd1dBXAjz2KR14y1ZgNjb2ThfAYzulu+PFy1UE3RCUzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
-        "@sveltejs/acorn-typescript": "^1.0.5",
+        "@sveltejs/acorn-typescript": "^1.0.9",
         "@types/cookie": "^0.6.0",
-        "acorn": "^8.14.1",
+        "acorn": "^8.16.0",
         "cookie": "^0.6.0",
-        "devalue": "^5.6.4",
+        "devalue": "^5.8.1",
         "esm-env": "^1.2.2",
         "kleur": "^4.1.5",
         "magic-string": "^0.30.5",
@@ -2178,6 +2178,7 @@
       "version": "8.58.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.1.tgz",
       "integrity": "sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2226,9 +2227,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2310,15 +2311,15 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
-      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
         "chai": "^5.2.0",
         "tinyrainbow": "^2.0.0"
       },
@@ -2327,13 +2328,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
-      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.2.4",
+        "@vitest/spy": "3.2.6",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.17"
       },
@@ -2354,9 +2355,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2367,13 +2368,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
-      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.2.4",
+        "@vitest/utils": "3.2.6",
         "pathe": "^2.0.3",
         "strip-literal": "^3.0.0"
       },
@@ -2382,13 +2383,13 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
-      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
+        "@vitest/pretty-format": "3.2.6",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
       },
@@ -2397,9 +2398,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
-      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2410,13 +2411,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
-      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
+        "@vitest/pretty-format": "3.2.6",
         "loupe": "^3.1.4",
         "tinyrainbow": "^2.0.0"
       },
@@ -2983,9 +2984,9 @@
       }
     },
     "node_modules/devalue": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.4.tgz",
-      "integrity": "sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
       "license": "MIT"
     },
     "node_modules/devlop": {
@@ -3009,9 +3010,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -3271,13 +3272,20 @@
       }
     },
     "node_modules/esrap": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.4.tgz",
-      "integrity": "sha512-suICpxAmZ9A8bzJjEl/+rLJiDKC0X4gYWUxT6URAWBLvlXmtbZd5ySMu/N2ZGEtMCAmflUDPSehrP9BQcsGcSg==",
+      "version": "2.2.13",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.13.tgz",
+      "integrity": "sha512-m8jH5hZgJE2RRUK/jjkGPcJEDAV+dYnZYFkosQaPTcE+Yw4xynXHOo6FUdwaWBtdR3b1MMa7wEDTSHeR2VWsGA==",
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.15",
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "peerDependencies": {
         "@typescript-eslint/types": "^8.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/types": {
+          "optional": true
+        }
       }
     },
     "node_modules/esrecurse": {
@@ -3657,10 +3665,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -4707,9 +4725,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "funding": [
         {
           "type": "github",
@@ -4877,9 +4895,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
       "funding": [
         {
           "type": "opencollective",
@@ -4896,7 +4914,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -5588,23 +5606,23 @@
       }
     },
     "node_modules/svelte": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.1.tgz",
-      "integrity": "sha512-QjvU7EFemf6mRzdMGlAFttMWtAAVXrax61SZYHdkD6yoVGQ89VeyKfZD4H1JrV1WLmJBxWhFch9H6ig/87VGjw==",
+      "version": "5.56.4",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.4.tgz",
+      "integrity": "sha512-/d0QHehmRuJW8gVz395MTkPcPozxzdjBMBE8oEYGz8O3b9KTMzzQ9ZHJQLuFKOHOPQbU6kx/X4iid/EBBzH7iw==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
-        "@sveltejs/acorn-typescript": "^1.0.5",
+        "@sveltejs/acorn-typescript": "^1.0.10",
         "@types/estree": "^1.0.5",
         "@types/trusted-types": "^2.0.7",
         "acorn": "^8.12.1",
         "aria-query": "5.3.1",
         "axobject-query": "^4.1.0",
         "clsx": "^2.1.1",
-        "devalue": "^5.6.4",
+        "devalue": "^5.8.1",
         "esm-env": "^1.2.1",
-        "esrap": "^2.2.4",
+        "esrap": "^2.2.12",
         "is-reference": "^3.0.3",
         "locate-character": "^3.0.0",
         "magic-string": "^0.30.11",
@@ -6041,9 +6059,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6159,20 +6177,20 @@
       }
     },
     "node_modules/vitest": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
-      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.4",
-        "@vitest/mocker": "3.2.4",
-        "@vitest/pretty-format": "^3.2.4",
-        "@vitest/runner": "3.2.4",
-        "@vitest/snapshot": "3.2.4",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
+        "@vitest/expect": "3.2.6",
+        "@vitest/mocker": "3.2.6",
+        "@vitest/pretty-format": "^3.2.6",
+        "@vitest/runner": "3.2.6",
+        "@vitest/snapshot": "3.2.6",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
         "chai": "^5.2.0",
         "debug": "^4.4.1",
         "expect-type": "^1.2.1",
@@ -6202,8 +6220,8 @@
         "@edge-runtime/vm": "*",
         "@types/debug": "^4.1.12",
         "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.4",
-        "@vitest/ui": "3.2.4",
+        "@vitest/browser": "3.2.6",
+        "@vitest/ui": "3.2.6",
         "happy-dom": "*",
         "jsdom": "*"
       },
@@ -6363,9 +6381,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/frontend/src/lib/localData.test.ts
+++ b/frontend/src/lib/localData.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import 'fake-indexeddb/auto';
+import { clearLocalData, ensureOfflineOwner } from './localData';
+import { openOfflineDB, upsertNote, getAllNotes, getOfflineOwner, setOfflineOwner, deleteOfflineDB } from './offlineDB';
+
+const makeNote = (id: number) => ({
+	id,
+	title: 'Secret',
+	body: 'Body',
+	starred: false,
+	pinned: false,
+	tags: [],
+	server_updated_at: '2024-01-01T00:00:00Z',
+	local_updated_at: '2024-01-01T00:00:00Z',
+	is_dirty: true,
+	is_new: false,
+});
+
+function stubCaches(keys: string[]) {
+	const deleted: string[] = [];
+	const cachesStub = {
+		keys: vi.fn().mockResolvedValue(keys),
+		delete: vi.fn(async (k: string) => {
+			deleted.push(k);
+			return true;
+		}),
+	};
+	vi.stubGlobal('caches', cachesStub);
+	return { cachesStub, deleted };
+}
+
+beforeEach(async () => {
+	vi.unstubAllGlobals();
+	await deleteOfflineDB();
+});
+
+describe('clearLocalData', () => {
+	it('deletes crapnote-* Cache Storage entries and leaves others alone', async () => {
+		const { deleted } = stubCaches(['crapnote-abc123', 'other-app-cache']);
+
+		await clearLocalData();
+
+		expect(deleted).toEqual(['crapnote-abc123']);
+	});
+
+	it('deletes the offline IndexedDB store', async () => {
+		stubCaches([]);
+		let db = await openOfflineDB();
+		await upsertNote(db, makeNote(1));
+		await setOfflineOwner(db, 42);
+		db.close();
+
+		await clearLocalData();
+
+		// Re-opening creates a fresh, empty database.
+		db = await openOfflineDB();
+		expect(await getAllNotes(db)).toEqual([]);
+		expect(await getOfflineOwner(db)).toBeNull();
+		db.close();
+	});
+
+	it('does not throw when Cache Storage is unavailable', async () => {
+		vi.stubGlobal('caches', undefined);
+		await expect(clearLocalData()).resolves.toBeUndefined();
+	});
+});
+
+describe('ensureOfflineOwner', () => {
+	it('stamps the owner on a fresh store', async () => {
+		stubCaches([]);
+		await ensureOfflineOwner(7);
+
+		const db = await openOfflineDB();
+		expect(await getOfflineOwner(db)).toBe(7);
+		db.close();
+	});
+
+	it('keeps cached notes when the same user returns', async () => {
+		stubCaches([]);
+		let db = await openOfflineDB();
+		await setOfflineOwner(db, 7);
+		await upsertNote(db, makeNote(1));
+		db.close();
+
+		await ensureOfflineOwner(7);
+
+		db = await openOfflineDB();
+		expect((await getAllNotes(db)).length).toBe(1);
+		db.close();
+	});
+
+	it('wipes the previous user\'s notes and caches when a different user logs in', async () => {
+		const { deleted } = stubCaches(['crapnote-v1']);
+		let db = await openOfflineDB();
+		await setOfflineOwner(db, 7);
+		await upsertNote(db, makeNote(1));
+		db.close();
+
+		await ensureOfflineOwner(8);
+
+		db = await openOfflineDB();
+		expect(await getAllNotes(db)).toEqual([]);
+		expect(await getOfflineOwner(db)).toBe(8);
+		expect(deleted).toEqual(['crapnote-v1']);
+		db.close();
+	});
+});

--- a/frontend/src/lib/localData.ts
+++ b/frontend/src/lib/localData.ts
@@ -1,0 +1,59 @@
+import { openOfflineDB, deleteOfflineDB, getOfflineOwner, setOfflineOwner, clearAllNotes } from '$lib/offlineDB';
+
+/**
+ * Wipes every locally persisted trace of the authenticated user: the
+ * service-worker Cache Storage entries (cached /api responses and app shell)
+ * and the offline notes IndexedDB. Called at logout so the next person on a
+ * shared browser cannot read the previous user's notes. Best-effort — a
+ * failure to clear must never block the logout itself.
+ */
+export async function clearLocalData(): Promise<void> {
+	try {
+		if (typeof caches !== 'undefined') {
+			const keys = await caches.keys();
+			await Promise.all(keys.filter((k) => k.startsWith('crapnote-')).map((k) => caches.delete(k)));
+		}
+	} catch {
+		// Cache Storage unavailable (old browser, private mode) — nothing cached.
+	}
+	try {
+		if (typeof indexedDB !== 'undefined') {
+			await deleteOfflineDB();
+		}
+	} catch {
+		// Same: if IDB is unavailable there is nothing to clear.
+	}
+}
+
+/**
+ * Binds the offline store to the given user. If the store currently belongs
+ * to a different user (shared browser, previous session not logged out
+ * cleanly), the cached notes and cached /api responses are wiped first so
+ * nothing leaks across accounts. Called after login and after session
+ * restore, before any sync can run.
+ */
+export async function ensureOfflineOwner(userId: number): Promise<void> {
+	try {
+		const db = await openOfflineDB();
+		try {
+			const owner = await getOfflineOwner(db);
+			if (owner !== null && owner !== userId) {
+				await clearAllNotes(db);
+				try {
+					if (typeof caches !== 'undefined') {
+						const keys = await caches.keys();
+						await Promise.all(keys.filter((k) => k.startsWith('crapnote-')).map((k) => caches.delete(k)));
+					}
+				} catch {
+					// best-effort, as above
+				}
+			}
+			await setOfflineOwner(db, userId);
+		} finally {
+			db.close();
+		}
+	} catch {
+		// If the store can't be opened, there's nothing to rebind — the sync
+		// guard in offlineSync refuses to push without a matching owner anyway.
+	}
+}

--- a/frontend/src/lib/milkdown/link.test.ts
+++ b/frontend/src/lib/milkdown/link.test.ts
@@ -10,8 +10,14 @@ vi.mock('@milkdown/kit/prose/inputrules', () => ({ InputRule: vi.fn() }));
 vi.mock('@milkdown/kit/prose/state', () => ({ Plugin: vi.fn(), PluginKey: vi.fn() }));
 vi.mock('@milkdown/kit/prose/model', () => ({ Fragment: { from: vi.fn() }, Slice: vi.fn() }));
 vi.mock('@milkdown/kit/prose/view', () => ({}));
+vi.mock('@milkdown/kit/preset/commonmark', () => ({
+	linkSchema: {
+		// Capture the extension handler so tests can exercise the wrapped spec.
+		extendSchema: vi.fn((handler: unknown) => ({ __handler: handler })),
+	},
+}));
 
-import { isUrl, normalizeUrl } from './link';
+import { isUrl, normalizeUrl, isSafeHref, sanitizeHref, safeLinkMarkSchema } from './link';
 
 describe('isUrl', () => {
 	it('accepts https URLs', () => {
@@ -74,5 +80,82 @@ describe('normalizeUrl', () => {
 
 	it('preserves paths and query strings', () => {
 		expect(normalizeUrl('https://example.com/a?b=c')).toBe('https://example.com/a?b=c');
+	});
+});
+
+describe('isSafeHref / sanitizeHref', () => {
+	it.each([
+		'javascript:alert(1)',
+		'JaVaScRiPt:alert(document.cookie)',
+		'java\nscript:alert(1)', // control chars are stripped by browsers before scheme parsing
+		' \tjavascript:alert(1)',
+		'data:text/html,<script>alert(1)</script>',
+		'vbscript:msgbox(1)',
+		'file:///etc/passwd',
+	])('neutralises %s', (href) => {
+		expect(isSafeHref(href)).toBe(false);
+		expect(sanitizeHref(href)).toBe('');
+	});
+
+	it.each([
+		'https://example.com',
+		'http://example.com/a?b=c',
+		'mailto:someone@example.com',
+		'/relative/path',
+		'relative.html',
+		'#fragment',
+		'?query=1',
+	])('preserves %s', (href) => {
+		expect(isSafeHref(href)).toBe(true);
+		expect(sanitizeHref(href)).toBe(href);
+	});
+
+	it('neutralises non-string hrefs', () => {
+		expect(sanitizeHref(null)).toBe('');
+		expect(sanitizeHref(undefined)).toBe('');
+	});
+});
+
+describe('safeLinkMarkSchema', () => {
+	type MarkLike = { attrs: Record<string, unknown> };
+	type SpecLike = {
+		parseDOM: Array<{ tag: string; getAttrs: (dom: unknown) => Record<string, unknown> | false }>;
+		toDOM: (mark: MarkLike) => unknown[];
+	};
+
+	const baseSpec = {
+		attrs: { href: {}, title: { default: null } },
+		parseDOM: [],
+		toDOM: (mark: MarkLike) => ['a', { class: 'link', ...mark.attrs }],
+	};
+	const handler = (safeLinkMarkSchema as unknown as { __handler: (prev: unknown) => (ctx: unknown) => SpecLike }).__handler;
+	const spec = handler(() => baseSpec)({});
+
+	it('toDOM drops an unsafe href but keeps the rest of the mark', () => {
+		const [tag, attrs] = spec.toDOM({ attrs: { href: 'javascript:alert(1)', title: null } }) as [string, Record<string, unknown>];
+		expect(tag).toBe('a');
+		expect('href' in attrs).toBe(false);
+		expect(attrs.class).toBe('link');
+	});
+
+	it('toDOM keeps a safe href', () => {
+		const [, attrs] = spec.toDOM({ attrs: { href: 'https://example.com', title: null } }) as [string, Record<string, unknown>];
+		expect(attrs.href).toBe('https://example.com');
+	});
+
+	it('parseDOM sanitises pasted anchors with unsafe schemes', () => {
+		const a = document.createElement('a');
+		a.setAttribute('href', 'data:text/html,<script>alert(1)</script>');
+		const attrs = spec.parseDOM[0].getAttrs(a);
+		expect(attrs && attrs.href).toBe('');
+	});
+
+	it('parseDOM keeps safe pasted hrefs', () => {
+		const a = document.createElement('a');
+		a.setAttribute('href', 'https://example.com/x');
+		a.setAttribute('title', 't');
+		const attrs = spec.parseDOM[0].getAttrs(a);
+		expect(attrs && attrs.href).toBe('https://example.com/x');
+		expect(attrs && attrs.title).toBe('t');
 	});
 });

--- a/frontend/src/lib/milkdown/link.test.ts
+++ b/frontend/src/lib/milkdown/link.test.ts
@@ -92,6 +92,11 @@ describe('isSafeHref / sanitizeHref', () => {
 		'data:text/html,<script>alert(1)</script>',
 		'vbscript:msgbox(1)',
 		'file:///etc/passwd',
+		'//evil.example.com/phish', // protocol-relative resolves off-origin
+		'/\\evil.example.com', // backslash variants browsers normalise to //
+		'\\\\evil.example.com',
+		'\\/evil.example.com',
+		' //evil.example.com', // leading whitespace stripped before checking
 	])('neutralises %s', (href) => {
 		expect(isSafeHref(href)).toBe(false);
 		expect(sanitizeHref(href)).toBe('');

--- a/frontend/src/lib/milkdown/link.ts
+++ b/frontend/src/lib/milkdown/link.ts
@@ -19,6 +19,7 @@
  */
 
 import { $prose, $pasteRule, $inputRule } from '@milkdown/kit/utils';
+import { linkSchema } from '@milkdown/kit/preset/commonmark';
 import { InputRule } from '@milkdown/kit/prose/inputrules';
 import { Plugin, PluginKey } from '@milkdown/kit/prose/state';
 import { Fragment, Slice } from '@milkdown/kit/prose/model';
@@ -35,6 +36,30 @@ export function normalizeUrl(url: string): string {
 	return t.startsWith('http://') || t.startsWith('https://') ? t : `https://${t}`;
 }
 
+// Schemes a stored note is allowed to link to. Anything else — javascript:,
+// data:, vbscript:, file:, … — is a stored-XSS / drive-by vector when the
+// note body comes from another user or a leaked API token.
+const SAFE_LINK_SCHEMES = new Set(['http', 'https', 'mailto']);
+
+/**
+ * True when the href is a relative URL or uses an allowlisted scheme.
+ * Whitespace and control characters are removed before the scheme is read,
+ * because browsers strip them when resolving URLs (`java\nscript:` runs).
+ */
+export function isSafeHref(href: string): boolean {
+	// eslint-disable-next-line no-control-regex
+	const cleaned = href.replace(/[\u0000-\u0020]/g, '');
+	const match = /^([a-zA-Z][a-zA-Z0-9+.-]*):/.exec(cleaned);
+	if (!match) return true; // relative URL — resolves against our own origin
+	return SAFE_LINK_SCHEMES.has(match[1].toLowerCase());
+}
+
+/** Returns the href unchanged when safe, or '' when it must be neutralised. */
+export function sanitizeHref(href: unknown): string {
+	if (typeof href !== 'string' || !isSafeHref(href)) return '';
+	return href;
+}
+
 // ─── 1. Ctrl/Cmd+K keymap ────────────────────────────────────────────────────
 
 export const linkKeymapPlugin = $prose(() =>
@@ -45,8 +70,13 @@ export const linkKeymapPlugin = $prose(() =>
 			handleDOMEvents: {
 				click(_view: EditorView, event: MouseEvent): boolean {
 					const anchor = (event.target as HTMLElement).closest('a');
-					if (!anchor?.href) return false;
+					const href = anchor?.getAttribute('href');
+					if (!anchor || !href) return false;
 					event.preventDefault();
+					// safeLinkMarkSchema keeps unsafe hrefs out of the DOM, but
+					// refuse to navigate to one here too in case an <a> arrives
+					// through a path the schema doesn't own.
+					if (!isSafeHref(href)) return true;
 					window.open(anchor.href, '_blank', 'noopener,noreferrer');
 					return true;
 				},
@@ -156,6 +186,45 @@ export const linkInputRule = $inputRule(
 		})
 );
 
+// ─── 4. Scheme-filtered link mark schema ─────────────────────────────────────
+//
+// Re-registers the commonmark `link` mark with a sanitising wrapper. Because
+// this is .use()d after the commonmark preset, it wins the schema slot, so it
+// covers every path that puts a link into the DOM: markdown loaded from the
+// server (defaultValueCtx), rich-content paste (parseDOM), and typing/paste
+// rules. Unsafe hrefs are dropped from the rendered <a>; the stored markdown
+// is left untouched so a save doesn't rewrite note content.
+
+export const safeLinkMarkSchema = linkSchema.extendSchema((prev) => (ctx) => {
+	const base = prev(ctx);
+	return {
+		...base,
+		parseDOM: [
+			{
+				tag: 'a[href]',
+				getAttrs: (dom) => {
+					if (!(dom instanceof HTMLElement)) return false;
+					return {
+						href: sanitizeHref(dom.getAttribute('href')),
+						title: dom.getAttribute('title'),
+					};
+				},
+			},
+		],
+		toDOM: (mark, inline) => {
+			const spec = base.toDOM?.(mark, inline);
+			if (Array.isArray(spec) && spec[1] && typeof spec[1] === 'object' && !Array.isArray(spec[1])) {
+				const attrs = { ...(spec[1] as Record<string, unknown>) };
+				if (typeof attrs['href'] !== 'string' || !isSafeHref(attrs['href'])) {
+					delete attrs['href'];
+				}
+				return [spec[0], attrs, ...spec.slice(2)] as typeof spec;
+			}
+			return spec ?? ['a', mark.attrs];
+		},
+	};
+});
+
 // ─── Composed export ──────────────────────────────────────────────────────────
 
-export const linkPlugin = [linkKeymapPlugin, linkPasteRule, linkInputRule].flat();
+export const linkPlugin = [linkKeymapPlugin, linkPasteRule, linkInputRule, safeLinkMarkSchema].flat();

--- a/frontend/src/lib/milkdown/link.ts
+++ b/frontend/src/lib/milkdown/link.ts
@@ -49,6 +49,10 @@ const SAFE_LINK_SCHEMES = new Set(['http', 'https', 'mailto']);
 export function isSafeHref(href: string): boolean {
 	// eslint-disable-next-line no-control-regex
 	const cleaned = href.replace(/[\u0000-\u0020]/g, '');
+	// Protocol-relative URLs ("//host/…", plus the backslash variants browsers
+	// normalise to slashes) carry no scheme token but resolve OFF-origin, so
+	// they must not pass as relative links.
+	if (/^[/\\]{2}/.test(cleaned)) return false;
 	const match = /^([a-zA-Z][a-zA-Z0-9+.-]*):/.exec(cleaned);
 	if (!match) return true; // relative URL — resolves against our own origin
 	return SAFE_LINK_SCHEMES.has(match[1].toLowerCase());

--- a/frontend/src/lib/offlineDB.ts
+++ b/frontend/src/lib/offlineDB.ts
@@ -12,8 +12,14 @@ export interface CachedNote {
 }
 
 const DB_NAME = 'crapnote-notes-v2';
-const DB_VERSION = 1;
+const DB_VERSION = 2;
 const STORE = 'notes';
+// Key/value store holding the id of the user the cached notes belong to.
+// The store is shared per-browser, so every read-for-display and every sync
+// push must be checked against it — otherwise user A's offline edits would
+// sync into user B's account on a shared machine.
+const META_STORE = 'meta';
+const OWNER_KEY = 'owner';
 
 export function openOfflineDB(): Promise<IDBDatabase> {
 	return new Promise((resolve, reject) => {
@@ -23,9 +29,57 @@ export function openOfflineDB(): Promise<IDBDatabase> {
 			if (!db.objectStoreNames.contains(STORE)) {
 				db.createObjectStore(STORE, { keyPath: 'id' });
 			}
+			if (!db.objectStoreNames.contains(META_STORE)) {
+				db.createObjectStore(META_STORE, { keyPath: 'key' });
+			}
 		};
 		req.onsuccess = () => resolve(req.result);
 		req.onerror = () => reject(req.error);
+	});
+}
+
+/** Deletes the entire offline database (used at logout). */
+export function deleteOfflineDB(): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const req = indexedDB.deleteDatabase(DB_NAME);
+		req.onsuccess = () => resolve();
+		// Blocked means another open connection delays the delete — it still
+		// completes once that connection closes, so don't fail the logout.
+		req.onblocked = () => resolve();
+		req.onerror = () => reject(req.error);
+	});
+}
+
+/** Returns the user id the offline store belongs to, or null if unset. */
+export function getOfflineOwner(db: IDBDatabase): Promise<number | null> {
+	return new Promise((resolve, reject) => {
+		const tx = db.transaction(META_STORE, 'readonly');
+		const req = tx.objectStore(META_STORE).get(OWNER_KEY);
+		req.onsuccess = () => {
+			const row = req.result as { key: string; userId: number } | undefined;
+			resolve(typeof row?.userId === 'number' ? row.userId : null);
+		};
+		req.onerror = () => reject(req.error);
+	});
+}
+
+/** Records which user the offline store belongs to. */
+export function setOfflineOwner(db: IDBDatabase, userId: number): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const tx = db.transaction(META_STORE, 'readwrite');
+		tx.objectStore(META_STORE).put({ key: OWNER_KEY, userId });
+		tx.oncomplete = () => resolve();
+		tx.onerror = () => reject(tx.error);
+	});
+}
+
+/** Removes every cached note (owner metadata is left as-is). */
+export function clearAllNotes(db: IDBDatabase): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const tx = db.transaction(STORE, 'readwrite');
+		tx.objectStore(STORE).clear();
+		tx.oncomplete = () => resolve();
+		tx.onerror = () => reject(tx.error);
 	});
 }
 

--- a/frontend/src/lib/offlineSync.test.ts
+++ b/frontend/src/lib/offlineSync.test.ts
@@ -19,6 +19,8 @@ vi.mock('$lib/offlineDB', () => ({
 	deleteNote: vi.fn(),
 	getNote: vi.fn(),
 	getAllNotes: vi.fn(),
+	getOfflineOwner: vi.fn(),
+	setOfflineOwner: vi.fn(),
 }));
 
 vi.mock('$app/navigation', () => ({ goto: vi.fn() }));
@@ -62,6 +64,8 @@ beforeEach(() => {
 	vi.mocked(offlineDB.getDirtyNotes).mockResolvedValue([]);
 	vi.mocked(offlineDB.upsertNote).mockResolvedValue(undefined);
 	vi.mocked(offlineDB.deleteNote).mockResolvedValue(undefined);
+	vi.mocked(offlineDB.getOfflineOwner).mockResolvedValue(1);
+	vi.mocked(offlineDB.setOfflineOwner).mockResolvedValue(undefined);
 });
 
 describe('syncOfflineChanges — new notes', () => {
@@ -70,7 +74,7 @@ describe('syncOfflineChanges — new notes', () => {
 		vi.mocked(offlineDB.getDirtyNotes).mockResolvedValue([note]);
 		vi.mocked(api.notes.create).mockResolvedValue(fakeServerNote({ id: 99, title: 'New', body: 'Hello', updated_at: '2024-01-03T00:00:00Z' }));
 
-		await syncOfflineChanges();
+		await syncOfflineChanges('heartbeat', 1);
 
 		expect(api.notes.create).toHaveBeenCalledWith('New', 'Hello');
 	});
@@ -80,7 +84,7 @@ describe('syncOfflineChanges — new notes', () => {
 		vi.mocked(offlineDB.getDirtyNotes).mockResolvedValue([note]);
 		vi.mocked(api.notes.create).mockResolvedValue(fakeServerNote({ id: 99, updated_at: '2024-01-03T00:00:00Z' }));
 
-		await syncOfflineChanges();
+		await syncOfflineChanges('heartbeat', 1);
 
 		expect(offlineDB.deleteNote).toHaveBeenCalledWith(fakeDB, -1000);
 		expect(offlineDB.upsertNote).toHaveBeenCalledWith(fakeDB, expect.objectContaining({
@@ -99,7 +103,7 @@ describe('syncOfflineChanges — modified notes, no conflict', () => {
 		vi.mocked(api.notes.get).mockResolvedValue(fakeServerNote({ id: 5, updated_at: '2024-01-01T00:00:00Z' }));
 		vi.mocked(api.notes.update).mockResolvedValue(fakeServerNote({ id: 5, updated_at: '2024-01-05T00:00:00Z' }));
 
-		await syncOfflineChanges();
+		await syncOfflineChanges('heartbeat', 1);
 
 		expect(api.notes.get).toHaveBeenCalledWith(5);
 	});
@@ -110,7 +114,7 @@ describe('syncOfflineChanges — modified notes, no conflict', () => {
 		vi.mocked(api.notes.get).mockResolvedValue(fakeServerNote({ id: 5, updated_at: '2024-01-01T00:00:00Z' }));
 		vi.mocked(api.notes.update).mockResolvedValue(fakeServerNote({ id: 5, updated_at: '2024-01-05T00:00:00Z' }));
 
-		await syncOfflineChanges();
+		await syncOfflineChanges('heartbeat', 1);
 
 		expect(api.notes.update).toHaveBeenCalledWith(5, { title: 'Local', body: 'Local body' });
 	});
@@ -121,7 +125,7 @@ describe('syncOfflineChanges — modified notes, no conflict', () => {
 		vi.mocked(api.notes.get).mockResolvedValue(fakeServerNote({ id: 5, updated_at: '2024-01-01T00:00:00Z' }));
 		vi.mocked(api.notes.update).mockResolvedValue(fakeServerNote({ id: 5, updated_at: '2024-01-05T00:00:00Z' }));
 
-		await syncOfflineChanges();
+		await syncOfflineChanges('heartbeat', 1);
 
 		expect(offlineDB.upsertNote).toHaveBeenCalledWith(fakeDB, expect.objectContaining({
 			id: 5,
@@ -139,7 +143,7 @@ describe('syncOfflineChanges — conflict', () => {
 		vi.mocked(api.notes.get).mockResolvedValue(fakeServerNote({ id: 7, updated_at: '2024-01-02T00:00:00Z' }));
 		vi.mocked(api.notes.create).mockResolvedValue(fakeServerNote({ id: 999 }));
 
-		await syncOfflineChanges();
+		await syncOfflineChanges('heartbeat', 1);
 
 		expect(api.notes.create).toHaveBeenCalledWith('[sync conflict] My Edit', 'My body');
 	});
@@ -150,7 +154,7 @@ describe('syncOfflineChanges — conflict', () => {
 		vi.mocked(api.notes.get).mockResolvedValue(fakeServerNote({ id: 7, updated_at: '2024-01-02T00:00:00Z' }));
 		vi.mocked(api.notes.create).mockResolvedValue(fakeServerNote({ id: 999 }));
 
-		await syncOfflineChanges();
+		await syncOfflineChanges('heartbeat', 1);
 
 		expect(api.notes.update).not.toHaveBeenCalled();
 	});
@@ -162,7 +166,7 @@ describe('syncOfflineChanges — conflict', () => {
 		vi.mocked(api.notes.get).mockResolvedValue(serverNote);
 		vi.mocked(api.notes.create).mockResolvedValue(fakeServerNote({ id: 999 }));
 
-		await syncOfflineChanges();
+		await syncOfflineChanges('heartbeat', 1);
 
 		expect(offlineDB.upsertNote).toHaveBeenCalledWith(fakeDB, expect.objectContaining({
 			id: 7,
@@ -190,7 +194,7 @@ describe('syncOfflineChanges — conflict', () => {
 		vi.mocked(api.notes.update).mockResolvedValue(fakeServerNote({ id: 7, updated_at: '2024-01-05T00:00:00Z' }));
 		vi.mocked(api.notes.create).mockResolvedValue(fakeServerNote({ id: 999 }));
 
-		await syncOfflineChanges();
+		await syncOfflineChanges('heartbeat', 1);
 
 		// Local wins: local edit is PUT to server
 		expect(api.notes.update).toHaveBeenCalledWith(7, { title: 'Local Newer', body: 'Local body' });
@@ -213,7 +217,7 @@ describe('syncOfflineChanges — conflict', () => {
 		}));
 		vi.mocked(api.notes.create).mockResolvedValue(fakeServerNote({ id: 999 }));
 
-		await syncOfflineChanges();
+		await syncOfflineChanges('heartbeat', 1);
 
 		// Server wins: NO update call (server version stays as-is)
 		expect(api.notes.update).not.toHaveBeenCalled();
@@ -232,7 +236,7 @@ describe('syncOfflineChanges — result and logging', () => {
 		vi.mocked(api.notes.get).mockResolvedValue(fakeServerNote({ id: 5, updated_at: '2024-01-01T00:00:00Z' }));
 		vi.mocked(api.notes.update).mockResolvedValue(fakeServerNote({ id: 5, updated_at: '2024-01-05T00:00:00Z' }));
 
-		const result = await syncOfflineChanges();
+		const result = await syncOfflineChanges('heartbeat', 1);
 
 		expect(result.pushed.created).toBe(1);
 		expect(result.pushed.updated).toBe(1);
@@ -250,7 +254,7 @@ describe('syncOfflineChanges — result and logging', () => {
 		vi.mocked(api.notes.get).mockResolvedValue(fakeServerNote({ id: 7, updated_at: '2024-01-05T00:00:00Z' }));
 		vi.mocked(api.notes.create).mockResolvedValue(fakeServerNote({ id: 999 }));
 
-		const result = await syncOfflineChanges();
+		const result = await syncOfflineChanges('heartbeat', 1);
 
 		expect(result.conflicts).toBe(1);
 	});
@@ -260,7 +264,7 @@ describe('syncOfflineChanges — result and logging', () => {
 		vi.mocked(offlineDB.getDirtyNotes).mockResolvedValue([note]);
 		vi.mocked(api.notes.create).mockRejectedValue(new Error('Network down'));
 
-		const result = await syncOfflineChanges();
+		const result = await syncOfflineChanges('heartbeat', 1);
 
 		expect(result.errors).toBe(1);
 	});
@@ -268,7 +272,7 @@ describe('syncOfflineChanges — result and logging', () => {
 	it('accepts a trigger parameter and echoes it in the result', async () => {
 		vi.mocked(offlineDB.getDirtyNotes).mockResolvedValue([]);
 
-		const result = await syncOfflineChanges('manual');
+		const result = await syncOfflineChanges('manual', 1);
 
 		expect(result.trigger).toBe('manual');
 	});
@@ -277,7 +281,7 @@ describe('syncOfflineChanges — result and logging', () => {
 		const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
 		vi.mocked(offlineDB.getDirtyNotes).mockResolvedValue([]);
 
-		await syncOfflineChanges('heartbeat');
+		await syncOfflineChanges('heartbeat', 1);
 
 		// Must be a single structured log call that includes "sync" and the trigger
 		expect(spy).toHaveBeenCalled();
@@ -299,7 +303,7 @@ describe('syncOfflineChanges — resilience', () => {
 			.mockRejectedValueOnce(new Error('Network error'))
 			.mockResolvedValueOnce(fakeServerNote({ id: 99, updated_at: '2024-01-03T00:00:00Z' }));
 
-		await syncOfflineChanges();
+		await syncOfflineChanges('heartbeat', 1);
 
 		// Should have attempted both
 		expect(api.notes.create).toHaveBeenCalledTimes(2);
@@ -310,7 +314,7 @@ describe('syncOfflineChanges — resilience', () => {
 		vi.mocked(offlineDB.getDirtyNotes).mockResolvedValue([note]);
 		vi.mocked(api.notes.create).mockResolvedValue(fakeServerNote({ id: 99, updated_at: '2024-01-03T00:00:00Z' }));
 
-		const result = await syncOfflineChanges();
+		const result = await syncOfflineChanges('heartbeat', 1);
 
 		expect(result.mappings).toEqual([{ tempId: -1000, serverId: 99 }]);
 	});
@@ -321,11 +325,64 @@ describe('syncOfflineChanges — resilience', () => {
 		vi.mocked(api.notes.get).mockResolvedValue(fakeServerNote({ id: 5, updated_at: '2024-01-01T00:00:00Z' }));
 		vi.mocked(api.notes.update).mockResolvedValue(fakeServerNote({ id: 5, updated_at: '2024-01-05T00:00:00Z' }));
 
-		const [, r2] = await Promise.all([syncOfflineChanges(), syncOfflineChanges()]);
+		const [, r2] = await Promise.all([syncOfflineChanges('heartbeat', 1), syncOfflineChanges('heartbeat', 1)]);
 
 		// Second call skipped entirely; note was only synced once
 		expect(api.notes.get).toHaveBeenCalledTimes(1);
 		expect(r2.skipped).toBe(true);
 		expect(r2.mappings).toEqual([]);
+	});
+});
+
+describe('syncOfflineChanges — ownership guard', () => {
+	it('refuses to push when the offline store belongs to a different user', async () => {
+		const note = fakeCachedNote({ id: 5 });
+		vi.mocked(offlineDB.getDirtyNotes).mockResolvedValue([note]);
+		vi.mocked(offlineDB.getOfflineOwner).mockResolvedValue(2); // store owned by user 2
+
+		const result = await syncOfflineChanges('heartbeat', 1); // session is user 1
+
+		expect(result.skipped).toBe(true);
+		expect(result.reason).toBe('owner-mismatch');
+		expect(api.notes.create).not.toHaveBeenCalled();
+		expect(api.notes.update).not.toHaveBeenCalled();
+		expect(api.notes.get).not.toHaveBeenCalled();
+	});
+
+	it('refuses to push when there is no authenticated user', async () => {
+		const note = fakeCachedNote({ id: 5 });
+		vi.mocked(offlineDB.getDirtyNotes).mockResolvedValue([note]);
+
+		const result = await syncOfflineChanges('heartbeat', null);
+
+		expect(result.skipped).toBe(true);
+		expect(result.reason).toBe('no-user');
+		expect(api.notes.create).not.toHaveBeenCalled();
+		expect(api.notes.update).not.toHaveBeenCalled();
+	});
+
+	it('adopts a legacy store with no recorded owner and proceeds', async () => {
+		const note = fakeCachedNote({ id: -1000, is_new: true });
+		vi.mocked(offlineDB.getDirtyNotes).mockResolvedValue([note]);
+		vi.mocked(offlineDB.getOfflineOwner).mockResolvedValue(null);
+		vi.mocked(api.notes.create).mockResolvedValue(fakeServerNote({ id: 9 }));
+
+		const result = await syncOfflineChanges('heartbeat', 7);
+
+		expect(offlineDB.setOfflineOwner).toHaveBeenCalledWith(fakeDB, 7);
+		expect(result.skipped).toBe(false);
+		expect(api.notes.create).toHaveBeenCalled();
+	});
+
+	it('pushes normally when the owner matches the current user', async () => {
+		const note = fakeCachedNote({ id: -1000, is_new: true });
+		vi.mocked(offlineDB.getDirtyNotes).mockResolvedValue([note]);
+		vi.mocked(offlineDB.getOfflineOwner).mockResolvedValue(1);
+		vi.mocked(api.notes.create).mockResolvedValue(fakeServerNote({ id: 9 }));
+
+		const result = await syncOfflineChanges('heartbeat', 1);
+
+		expect(result.skipped).toBe(false);
+		expect(api.notes.create).toHaveBeenCalled();
 	});
 });

--- a/frontend/src/lib/offlineSync.ts
+++ b/frontend/src/lib/offlineSync.ts
@@ -1,5 +1,5 @@
 import { api } from '$lib/api';
-import { openOfflineDB, getDirtyNotes, upsertNote, deleteNote } from '$lib/offlineDB';
+import { openOfflineDB, getDirtyNotes, upsertNote, deleteNote, getOfflineOwner, setOfflineOwner } from '$lib/offlineDB';
 import type { CachedNote } from '$lib/offlineDB';
 
 export interface IdMapping {
@@ -20,8 +20,12 @@ export interface SyncResult {
 	conflicts: number;
 	/** Notes whose push attempt threw (network error, server error). */
 	errors: number;
-	/** True if this call was a no-op because another sync was already running. */
+	/** True if this call was a no-op because another sync was already running,
+	 * or because the offline store belongs to a different user than the
+	 * current session (see `reason`). */
 	skipped: boolean;
+	/** Why the run was skipped, when it was. */
+	reason?: 'in-progress' | 'no-user' | 'owner-mismatch';
 }
 
 // Module-level mutex: prevents two concurrent sync runs from racing each other.
@@ -38,8 +42,16 @@ let syncInProgress = false;
  * The caller is expected to trigger a list-reload after this returns so
  * server-side changes made elsewhere become visible locally (see
  * `heartbeatSync` in `+page.svelte`).
+ *
+ * `currentUserId` is the id of the user the active session belongs to. Dirty
+ * notes are only pushed when the offline store's recorded owner matches it —
+ * on a shared browser, user A's offline edits must never be created inside
+ * user B's account just because B logged in next.
  */
-export async function syncOfflineChanges(trigger: SyncTrigger = 'heartbeat'): Promise<SyncResult> {
+export async function syncOfflineChanges(
+	trigger: SyncTrigger = 'heartbeat',
+	currentUserId: number | null = null
+): Promise<SyncResult> {
 	const startedAt = new Date().toISOString();
 	const start = typeof performance !== 'undefined' ? performance.now() : Date.now();
 	const result: SyncResult = {
@@ -55,6 +67,14 @@ export async function syncOfflineChanges(trigger: SyncTrigger = 'heartbeat'): Pr
 
 	if (syncInProgress) {
 		result.skipped = true;
+		result.reason = 'in-progress';
+		result.durationMs = Math.round((typeof performance !== 'undefined' ? performance.now() : Date.now()) - start);
+		logSyncResult(result);
+		return result;
+	}
+	if (currentUserId === null) {
+		result.skipped = true;
+		result.reason = 'no-user';
 		result.durationMs = Math.round((typeof performance !== 'undefined' ? performance.now() : Date.now()) - start);
 		logSyncResult(result);
 		return result;
@@ -63,6 +83,20 @@ export async function syncOfflineChanges(trigger: SyncTrigger = 'heartbeat'): Pr
 
 	const db = await openOfflineDB();
 	try {
+		const owner = (await getOfflineOwner(db)) ?? null;
+		if (owner === null) {
+			// Legacy store from before owner tracking — adopt it for the
+			// current user rather than stranding pre-upgrade offline edits.
+			await setOfflineOwner(db, currentUserId);
+		} else if (owner !== currentUserId) {
+			// The cached notes belong to someone else. Refuse to push: doing
+			// so would disclose their note bodies into this user's account.
+			result.skipped = true;
+			result.reason = 'owner-mismatch';
+			result.durationMs = Math.round((typeof performance !== 'undefined' ? performance.now() : Date.now()) - start);
+			logSyncResult(result);
+			return result;
+		}
 		const dirty = await getDirtyNotes(db);
 		for (const note of dirty) {
 			try {
@@ -98,6 +132,7 @@ function logSyncResult(r: SyncResult): void {
 		conflicts: r.conflicts,
 		errors: r.errors,
 		skipped: r.skipped,
+		reason: r.reason,
 		mappings: r.mappings.length,
 	});
 }

--- a/frontend/src/lib/stores/auth.svelte.test.ts
+++ b/frontend/src/lib/stores/auth.svelte.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('$lib/api', () => ({
+	api: {
+		auth: {
+			me: vi.fn(),
+			login: vi.fn(),
+			logout: vi.fn(),
+		},
+	},
+}));
+
+vi.mock('$lib/localData', () => ({
+	clearLocalData: vi.fn().mockResolvedValue(undefined),
+	ensureOfflineOwner: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { api } from '$lib/api';
+import { clearLocalData, ensureOfflineOwner } from '$lib/localData';
+import { auth } from './auth.svelte';
+
+const fakeUser = { id: 3, username: 'alice', is_admin: false, created_at: '' };
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	auth.setUser(null);
+});
+
+describe('auth.logout', () => {
+	it('clears the local authenticated footprint (caches + offline store)', async () => {
+		auth.setUser(fakeUser);
+		vi.mocked(api.auth.logout).mockResolvedValue(undefined);
+
+		await auth.logout();
+
+		expect(clearLocalData).toHaveBeenCalledTimes(1);
+		expect(auth.user).toBeNull();
+	});
+
+	it('still clears local data when the server logout call fails', async () => {
+		auth.setUser(fakeUser);
+		vi.mocked(api.auth.logout).mockRejectedValue(new Error('network down'));
+
+		await expect(auth.logout()).rejects.toThrow('network down');
+
+		expect(clearLocalData).toHaveBeenCalledTimes(1);
+		expect(auth.user).toBeNull();
+	});
+});
+
+describe('offline store ownership stamping', () => {
+	it('login binds the offline store to the logged-in user', async () => {
+		vi.mocked(api.auth.login).mockResolvedValue(fakeUser);
+
+		await auth.login('alice', 'pw');
+
+		expect(ensureOfflineOwner).toHaveBeenCalledWith(3);
+	});
+
+	it('init binds the offline store to the restored session user', async () => {
+		vi.mocked(api.auth.me).mockResolvedValue(fakeUser);
+
+		await auth.init();
+
+		expect(ensureOfflineOwner).toHaveBeenCalledWith(3);
+	});
+
+	it('init does not touch ownership when there is no session', async () => {
+		vi.mocked(api.auth.me).mockRejectedValue(new Error('401'));
+
+		await auth.init();
+
+		expect(ensureOfflineOwner).not.toHaveBeenCalled();
+	});
+});

--- a/frontend/src/lib/stores/auth.svelte.ts
+++ b/frontend/src/lib/stores/auth.svelte.ts
@@ -1,4 +1,5 @@
 import { api, type User } from '$lib/api';
+import { clearLocalData, ensureOfflineOwner } from '$lib/localData';
 
 let user = $state<User | null>(null);
 let loading = $state(true);
@@ -14,6 +15,7 @@ export const auth = {
 		loading = true;
 		try {
 			user = await api.auth.me();
+			await ensureOfflineOwner(user.id);
 		} catch {
 			user = null;
 		} finally {
@@ -22,10 +24,18 @@ export const auth = {
 	},
 	async login(username: string, password: string) {
 		user = await api.auth.login(username, password);
+		await ensureOfflineOwner(user.id);
 	},
 	async logout() {
-		await api.auth.logout();
-		user = null;
+		try {
+			await api.auth.logout();
+		} finally {
+			// Even if the server call fails, this browser must forget the
+			// user: cached /api responses and the offline note store would
+			// otherwise be readable by (and sync under) the next account.
+			user = null;
+			await clearLocalData();
+		}
 	},
 	setUser(u: User | null) {
 		user = u;

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -385,10 +385,22 @@
 		});
 	}
 
+	// Monotonic token guarding the notes list against stale writes. Every new
+	// load and every local list mutation (create/delete/archive) bumps it; a
+	// loadNotes() call only applies its result if no newer load or mutation
+	// happened while its response was in flight. Without this, a slow list
+	// response issued before a delete can land after it and resurrect the
+	// deleted note in the UI (the mount load and the sync heartbeat both fetch
+	// the list concurrently with user actions).
+	let listVersion = 0;
+
 	async function loadNotes() {
+		const version = ++listVersion;
 		if (!navigator.onLine) {
 			isOnline = false;
-			notes = await loadFromCache();
+			const cached = await loadFromCache();
+			if (version !== listVersion) return;
+			notes = cached;
 			return;
 		}
 		const params: { search?: string; tag?: number; starred?: boolean } = {};
@@ -398,7 +410,9 @@
 		try {
 			const fetched = await api.notes.list(params);
 			isOnline = true;
-			notes = await mergeServerWithCache(fetched);
+			const merged = await mergeServerWithCache(fetched);
+			if (version !== listVersion) return; // stale — newer load/mutation won
+			notes = merged;
 			// Cache top-N when no filter is active (we want the canonical recent list)
 			if (!search && activeTagId === null && !starredOnly) {
 				cacheNotesForOffline(fetched); // fire-and-forget
@@ -406,7 +420,9 @@
 		} catch {
 			// Network failed despite navigator.onLine — server is unreachable.
 			isOnline = false;
-			notes = await loadFromCache();
+			const cached = await loadFromCache();
+			if (version !== listVersion) return;
+			notes = cached;
 		}
 	}
 
@@ -669,6 +685,7 @@
 			starred: false, pinned: false, archived: false,
 			created_at: now, updated_at: now,
 		};
+		listVersion++; // invalidate in-flight list loads that predate the note
 		notes = [offlineNote, ...notes];
 		selectedId = tempId;
 		noteTags = [];
@@ -683,6 +700,7 @@
 		}
 		try {
 			const note = await api.notes.create(defaultNoteTitle());
+			listVersion++; // invalidate in-flight list loads that predate the note
 			const firstUnpinned = notes.findIndex((n) => !n.pinned);
 			if (firstUnpinned === -1) {
 				notes = [...notes, note];
@@ -896,11 +914,13 @@
 
 	async function toggleStar(id: number) {
 		const updated = await api.notes.toggleStar(id);
+		listVersion++; // invalidate in-flight list loads carrying the old state
 		notes = notes.map((n) => (n.id === updated.id ? updated : n));
 	}
 
 	async function togglePin(id: number) {
 		const updated = await api.notes.togglePin(id);
+		listVersion++; // invalidate in-flight list loads carrying the old state
 		const rest = notes.filter((n) => n.id !== updated.id);
 		const full = [updated, ...rest];
 		notes = [...full.filter((n) => n.pinned), ...full.filter((n) => !n.pinned)];
@@ -908,6 +928,7 @@
 
 	async function archiveNote(id: number) {
 		await api.notes.archive(id);
+		listVersion++; // invalidate any in-flight list load fetched pre-archive
 		notes = notes.filter((n) => n.id !== id);
 		if (selectedId === id) {
 			selectedId = notes.length > 0 ? notes[0].id : null;
@@ -916,6 +937,7 @@
 
 	async function deleteNote(id: number) {
 		await api.notes.delete(id);
+		listVersion++; // invalidate any in-flight list load fetched pre-delete
 		notes = notes.filter((n) => n.id !== id);
 		if (selectedId === id) {
 			selectedId = notes.length > 0 ? notes[0].id : null;

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -435,7 +435,7 @@
 		}
 		syncStatus = 'syncing';
 
-		const result = await syncOfflineChanges(trigger);
+		const result = await syncOfflineChanges(trigger, auth.user?.id ?? null);
 
 		// If the note we had open was a temp-ID that just got a real server ID, update selection
 		if (selectedId !== null) {

--- a/frontend/src/routes/page.test.ts
+++ b/frontend/src/routes/page.test.ts
@@ -711,7 +711,7 @@ describe('Offline mode', () => {
 
 		window.dispatchEvent(new Event('online'));
 
-		await waitFor(() => expect(syncOfflineChanges).toHaveBeenCalledWith('online'));
+		await waitFor(() => expect(syncOfflineChanges).toHaveBeenCalledWith('online', 1));
 		await waitFor(() => expect(api.notes.list).toHaveBeenCalled());
 	});
 
@@ -730,6 +730,6 @@ describe('Offline mode', () => {
 		);
 		await fireEvent.click(syncBtn);
 
-		await waitFor(() => expect(syncOfflineChanges).toHaveBeenCalledWith('manual'));
+		await waitFor(() => expect(syncOfflineChanges).toHaveBeenCalledWith('manual', 1));
 	});
 });


### PR DESCRIPTION
## What & why

Fixes every open security issue rated Medium or above (severity review in the session): fail-closed deploy credentials, cross-account offline data leak, latent stored-XSS via link schemes, username enumeration via login timing, account-lockout DoS, and known-vulnerable frontend dependencies.

Closes #44, closes #51, closes #55, closes #56, closes #57, closes #58, closes #59.

## How

One commit per issue, in dependency order:

- **#55 (timing enumeration)** — replaced the invalid `$2a$12$dummy` literal (which fails at hash *parsing* in ~1 ms) with a real precomputed cost-12 bcrypt hash, so the unknown-user and locked-user branches do the same key-derivation work as a real compare.
- **#44 (lockout DoS)** — new `locked_until` column (migration `000011`): automatic failed-login locks now expire after a cool-down (default 15 min) and clear themselves on the next login attempt; manual admin locks leave it NULL and stay indefinite. Threshold raised to 5; both knobs tunable via `MAX_FAILED_LOGIN_ATTEMPTS` / `LOCKOUT_COOLDOWN_MINUTES`. Storing the expiry in the row (rather than an `auto_locked` flag) lets the bearer-token and session paths evaluate lock state without knowing the cool-down config. **#51** is fixed as part of this: the lockout branch now revokes sessions via the `RevokeUserSessions` choke-point.
- **#58 (default credentials)** — `deploy/docker-compose.yml` uses `${ADMIN_PASSWORD:?…}` / `${GRAFANA_PASSWORD:?…}` so compose errors clearly instead of shipping `admin`/`changeme` and `admin`/`admin`; `make run` refuses to start without `ADMIN_PASSWORD` (checked before the build); README updated. Alternative rejected: keeping a default but warning — the seeded credential persists in the DB, so a warning arrives too late.
- **#57 (link schemes)** — re-registered the commonmark `link` mark via `linkSchema.extendSchema` with an allowlist (`http`, `https`, `mailto`, relative); unsafe hrefs are dropped from the rendered `<a>` on markdown load and rich paste, and the click handler independently refuses non-allowlisted schemes. Control characters are stripped before scheme parsing (`java\nscript:`). Stored markdown is untouched, so a save never rewrites note content.
- **#56 (offline data leak)** — `logout()` wipes all `crapnote-*` Cache Storage entries and deletes the offline IndexedDB even when the server call fails; the offline store records its owning user id (new meta store, DB v2), login/session-restore rebind it and wipe foreign data first; `syncOfflineChanges()` now takes the current user id and refuses to push when the store owner doesn't match (ownerless legacy stores are adopted rather than stranded).
- **#59 (dep CVEs)** — `npm audit fix` in `frontend/` (svelte 5.56.4, dompurify 3.4.11, postcss 8.5.16); `@playwright/test` 1.61.1 in `e2e/`. Accepted leftover: low-severity `cookie <0.7.0` via `@sveltejs/kit` — build/dev-time only under adapter-static, and the only automated fix is a breaking kit downgrade.

No CI changes were needed: the e2e job supplies its own credentials and never uses `make run` or docker-compose, and the Playwright browser cache is keyed on `e2e/package-lock.json`.

## Test plan

- **Go (`backend/internal/`)**: new service tests — auto-lock expires after cool-down and login succeeds without admin action, manual lock never expires, lockout revokes sessions; `dummyhash_test.go` asserts the placeholder parses at cost 12 and reaches key derivation (`ErrMismatchedHashAndPassword`, not `ErrHashTooShort`). Full `go test -race ./...`, `go vet`, and `golangci-lint` (0 issues) pass.
- **Vitest (`frontend/src/`)**: new suites for `localData` (cache + IDB clearing, owner rebinding wipes a different user's notes), the auth store (logout clears even when the server call fails; login/init stamp ownership), the sync ownership guard (owner mismatch / no user → no API pushes), and link sanitisation (`javascript:`, `data:`, `vbscript:`, `file:` neutralised; `https`, `http`, `mailto`, relative preserved, on both `toDOM` and `parseDOM`). 256/256 pass; `svelte-check` and build clean.
- **Playwright (`e2e/tests/`)**: new `offline-logout.spec.ts` — logs in, creates a note, waits for the service worker to populate cache + IDB, logs out, asserts zero cached `/api` responses and zero offline notes. Full suite run against the built binary: 20/21 passed; the one failure (`notes.spec.ts` list-refresh timing) was reproduced identically on a pre-change build of `main`, i.e. pre-existing flake, not a regression.
- **Deploy config**: `docker compose config` verified to fail with a clear message when `ADMIN_PASSWORD`/`GRAFANA_PASSWORD` are unset and validate when set; `make run` verified to refuse without `ADMIN_PASSWORD`.
- `npm audit --omit=dev` in `frontend/`: 0 advisories.

## Risk & rollback

- **Lockout**: `locked_until` is nullable; existing manual locks keep working unchanged. Rolling back is the down migration plus reverting the commit — no data backfill needed.
- **Deploy**: `docker compose up` / `make run` now *require* `ADMIN_PASSWORD` (and compose requires `GRAFANA_PASSWORD`) — existing operators relying on the old defaults will get an explicit error with instructions on first redeploy. This is the intended fail-closed behaviour.
- **Offline store**: the DB version bump (1→2) upgrades in place; ownerless stores are adopted by the next logged-in user, so pre-upgrade offline edits still sync. If clearing fails (private mode, old browser), logout still completes — clearing is best-effort by design.
- **Editor links**: unsafe hrefs are neutralised only in the rendered DOM; stored markdown is untouched, so reverting restores prior behaviour with no content changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YDdRKpJMaDez4QZ5rAGoBR